### PR TITLE
feat: Add --dump-untyped-ast flag

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -39,9 +39,14 @@ pub struct Cli {
     /// Verbose output
     #[arg(short, long)]
     pub verbose: bool,
+
+    /// Dump untyped AST
+    #[arg(long)]
+    pub dump_untyped_ast: bool,
 }
 
 use crate::codegen::CodeGen;
+use crate::dumper::Dumper;
 use crate::logger::Logger;
 use crate::parser::Parser;
 use crate::parser::error::ParserError;
@@ -192,6 +197,12 @@ impl Compiler {
                 return Err(CompilerError::new(vec![report]));
             }
         };
+
+        if self.cli.dump_untyped_ast {
+            let mut dumper = Dumper::new();
+            dumper.dump(&ast);
+            return Ok(());
+        }
 
         // Perform semantic analysis
         let semantic_analyzer = SemanticAnalyzer::with_builtins();

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -1,0 +1,346 @@
+use crate::parser::ast::{
+    Decl, Declarator, Expr, ForInit, FuncDecl, Initializer, Stmt, TranslationUnit, BinOp, AssignOp
+};
+use crate::parser::string_interner::StringId;
+use crate::types::{TypeSpec, TypeSpecKind, TypeQualifiers};
+use std::fmt::Write;
+
+pub struct Dumper {
+    indent: String,
+}
+
+impl Dumper {
+    pub fn new() -> Self {
+        Self {
+            indent: String::new(),
+        }
+    }
+
+    pub fn dump(&mut self, tu: &TranslationUnit) {
+        println!("TranslationUnit");
+        let mut globals_iter = tu.globals.iter().peekable();
+        while let Some(decl) = globals_iter.next() {
+            let is_last = globals_iter.peek().is_none();
+            self.dump_decl(decl, is_last);
+        }
+    }
+
+    fn dump_decl(&mut self, decl: &Decl, is_last: bool) {
+        let prefix = if is_last { "└─ " } else { "├─ " };
+        let child_indent = if is_last { "   " } else { "│  " };
+
+        print!("{}{}", self.indent, prefix);
+
+        match decl {
+            Decl::Func(func) => self.dump_func_decl(func, child_indent),
+            Decl::VarGroup(type_spec, declarators) => {
+                println!("VarGroup '{}'", type_spec_to_string(type_spec));
+                self.indent.push_str(child_indent);
+                let mut decls_iter = declarators.iter().peekable();
+                while let Some(declarator) = decls_iter.next() {
+                    let is_last_decl = decls_iter.peek().is_none();
+                    self.dump_declarator(declarator, is_last_decl);
+                }
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Decl::Struct(s) => {
+                let name = s.name.map_or("".to_string(), |id| id.as_str().to_string());
+                println!("StructDecl '{}'", name);
+            }
+            Decl::Union(u) => {
+                let name = u.name.map_or("".to_string(), |id| id.as_str().to_string());
+                println!("UnionDecl '{}'", name);
+            }
+            Decl::Enum(e) => {
+                let name = e.name.map_or("".to_string(), |id| id.as_str().to_string());
+                println!("EnumDecl '{}'", name);
+            }
+            Decl::Typedef(name, type_spec) => {
+                println!("Typedef '{}' '{}'", name.as_str(), type_spec_to_string(type_spec));
+            }
+            Decl::StaticAssert(expr, message) => {
+                 println!("StaticAssert '{}'", message.as_str());
+                 self.indent.push_str(child_indent);
+                 self.dump_expr(expr, true);
+                 self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+        }
+    }
+
+    fn dump_declarator(&mut self, declarator: &Declarator, is_last: bool) {
+        let prefix = if is_last { "└─ " } else { "├─ " };
+        let child_indent = if is_last { "   " } else { "│  " };
+
+        print!("{}{}", self.indent, prefix);
+        let name = declarator.name.map_or("<unnamed>".to_string(), |id| id.as_str().to_string());
+        println!("Declarator '{}'", name);
+
+        if let Some(init) = &declarator.init {
+            self.indent.push_str(child_indent);
+            self.dump_expr(init, true);
+            self.indent.truncate(self.indent.len() - child_indent.len());
+        }
+    }
+
+
+    fn dump_func_decl(&mut self, func: &FuncDecl, child_indent: &str) {
+        let name = func.name.as_str();
+        let return_type = type_spec_to_string(&func.return_type);
+        println!("FunctionDecl {} '{}'", name, return_type);
+
+        self.indent.push_str(child_indent);
+        if let Some(body) = &func.body {
+            let mut stmts_iter = body.iter().peekable();
+            while let Some(stmt) = stmts_iter.next() {
+                let is_last = stmts_iter.peek().is_none();
+                self.dump_stmt(stmt, is_last);
+            }
+        }
+        self.indent.truncate(self.indent.len() - child_indent.len());
+    }
+
+    fn dump_stmt(&mut self, stmt: &Stmt, is_last: bool) {
+        let prefix = if is_last { "└─ " } else { "├─ " };
+        let child_indent = if is_last { "   " } else { "│  " };
+
+        print!("{}{}", self.indent, prefix);
+
+        match stmt {
+            Stmt::Return(expr) => {
+                println!("Return");
+                self.indent.push_str(child_indent);
+                self.dump_expr(expr, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::If(cond, then_stmt, else_stmt) => {
+                println!("If");
+                self.indent.push_str(child_indent);
+                self.dump_expr(cond, false);
+                self.dump_stmt(then_stmt, else_stmt.is_none());
+                if let Some(else_s) = else_stmt {
+                    self.dump_stmt(else_s, true);
+                }
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::While(cond, body) => {
+                println!("While");
+                self.indent.push_str(child_indent);
+                self.dump_expr(cond, false);
+                self.dump_stmt(body, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+             Stmt::For(init, cond, inc, body) => {
+                println!("For");
+                self.indent.push_str(child_indent);
+                let has_cond = cond.is_some();
+                let has_inc = inc.is_some();
+
+                if let Some(init_expr) = init {
+                    let is_last_child = !has_cond && !has_inc;
+                    let prefix = if is_last_child { "└─ " } else { "├─ " };
+                    print!("{}{}", self.indent, prefix);
+                    match &**init_expr {
+                        ForInit::Declaration(ts, id, init) => {
+                            println!("ForInit Declaration '{} {}'", type_spec_to_string(ts), id.as_str());
+                            if let Some(init_val) = init {
+                                self.indent.push_str("│     ");
+                                match init_val {
+                                    Initializer::Expr(e) => self.dump_expr(e, true),
+                                    Initializer::List(_) => println!("InitializerList"),
+                                }
+                                self.indent.truncate(self.indent.len() - 6);
+                            }
+                        },
+                        ForInit::Expr(e) => {
+                            println!("ForInit Expr");
+                            self.dump_expr(e, true);
+                        }
+                    }
+                }
+                if let Some(cond_expr) = cond {
+                    let is_last_child = !has_inc;
+                    self.dump_expr(cond_expr, is_last_child);
+                }
+                if let Some(inc_expr) = inc {
+                    self.dump_expr(inc_expr, true);
+                }
+                self.dump_stmt(body, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::Block(stmts) => {
+                println!("Block");
+                self.indent.push_str(child_indent);
+                let mut stmts_iter = stmts.iter().peekable();
+                while let Some(s) = stmts_iter.next() {
+                    let is_last_stmt = stmts_iter.peek().is_none();
+                    self.dump_stmt(s, is_last_stmt);
+                }
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::Expr(expr) => {
+                println!("ExprStmt");
+                self.indent.push_str(child_indent);
+                self.dump_expr(expr, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::Declaration(decl) => {
+                 self.dump_decl(decl, is_last);
+            }
+            Stmt::Empty => {
+                println!("Empty");
+            }
+            Stmt::Break => println!("Break"),
+            Stmt::Continue => println!("Continue"),
+            Stmt::Switch(expr, body) => {
+                println!("Switch");
+                self.indent.push_str(child_indent);
+                self.dump_expr(expr, false);
+                self.dump_stmt(body, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::Case(expr, body) => {
+                println!("Case");
+                self.indent.push_str(child_indent);
+                self.dump_expr(expr, false);
+                self.dump_stmt(body, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::Default(body) => {
+                println!("Default");
+                self.indent.push_str(child_indent);
+                self.dump_stmt(body, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::DoWhile(body, cond) => {
+                println!("DoWhile");
+                self.indent.push_str(child_indent);
+                self.dump_stmt(body, false);
+                self.dump_expr(cond, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+             Stmt::Label(name, body, _) => {
+                println!("Label '{}'", name.as_str());
+                self.indent.push_str(child_indent);
+                self.dump_stmt(body, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Stmt::Goto(name, _) => {
+                println!("Goto '{}'", name.as_str());
+            }
+        }
+    }
+
+    fn dump_expr(&mut self, expr: &Expr, is_last: bool) {
+        let prefix = if is_last { "└─ " } else { "├─ " };
+        let child_indent = if is_last { "   " } else { "│  " };
+
+        print!("{}{}", self.indent, prefix);
+
+        match expr {
+            Expr::Variable(name, _) => {
+                println!("Variable '{}'", name.as_str());
+            }
+            Expr::Number(val, _) => {
+                println!("Number '{}'", val);
+            }
+            Expr::FloatNumber(val, _) => {
+                println!("FloatNumber '{}'", val);
+            }
+            Expr::String(id, _) => {
+                println!("String '{}'", id.as_str());
+            }
+            Expr::Char(id, _) => {
+                println!("Char '{}'", id.as_str());
+            }
+            Expr::Call(name, args, _) => {
+                println!("Call '{}'", name.as_str());
+                self.indent.push_str(child_indent);
+                let mut args_iter = args.iter().peekable();
+                while let Some(arg) = args_iter.next() {
+                    let is_last_arg = args_iter.peek().is_none();
+                    self.dump_expr(arg, is_last_arg);
+                }
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Expr::PostIncrement(e) | Expr::PostDecrement(e) | Expr::PreIncrement(e) | Expr::PreDecrement(e) | Expr::Deref(e) | Expr::AddressOf(e) | Expr::Sizeof(e) | Expr::Neg(e) | Expr::BitwiseNot(e) | Expr::LogicalNot(e) => {
+                let op_name = match expr {
+                    Expr::PostIncrement(_) => "PostIncrement",
+                    Expr::PostDecrement(_) => "PostDecrement",
+                    Expr::PreIncrement(_) => "PreIncrement",
+                    Expr::PreDecrement(_) => "PreDecrement",
+                    Expr::Deref(_) => "Deref",
+                    Expr::AddressOf(_) => "AddressOf",
+                    Expr::Sizeof(_) => "Sizeof",
+                    Expr::Neg(_) => "Neg",
+                    Expr::BitwiseNot(_) => "BitwiseNot",
+                    Expr::LogicalNot(_) => "LogicalNot",
+                    _ => unreachable!(),
+                };
+                println!("{}", op_name);
+                self.indent.push_str(child_indent);
+                self.dump_expr(e, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+            Expr::SizeofType(type_spec) => {
+                println!("SizeofType '{}'", type_spec_to_string(type_spec));
+            }
+            Expr::ExplicitCast(ts, e) => {
+                 println!("ExplicitCast to '{}'", type_spec_to_string(ts));
+                self.indent.push_str(child_indent);
+                self.dump_expr(e, true);
+                self.indent.truncate(self.indent.len() - child_indent.len());
+            }
+             _ => {
+                if let Some((op, lhs, rhs)) = expr.get_binary_expr() {
+                    self.dump_binary_op(op, lhs, rhs, child_indent);
+                } else if let Some((op, lhs, rhs)) = expr.get_assign_expr() {
+                    self.dump_assign_op(op, lhs, rhs, child_indent);
+                } else {
+                     println!("Other Expr");
+                }
+            }
+        }
+    }
+
+    fn dump_binary_op(&mut self, op: BinOp, lhs: &Expr, rhs: &Expr, child_indent: &str) {
+        println!("{:?}", op);
+        self.indent.push_str(child_indent);
+        self.dump_expr(lhs, false);
+        self.dump_expr(rhs, true);
+        self.indent.truncate(self.indent.len() - child_indent.len());
+    }
+
+    fn dump_assign_op(&mut self, op: AssignOp, lhs: &Expr, rhs: &Expr, child_indent: &str) {
+        println!("Assign {:?}", op);
+        self.indent.push_str(child_indent);
+        self.dump_expr(lhs, false);
+        self.dump_expr(rhs, true);
+        self.indent.truncate(self.indent.len() - child_indent.len());
+    }
+}
+
+fn type_spec_to_string(ts: &TypeSpec) -> String {
+    let mut s = String::new();
+    if ts.qualifiers.contains(TypeQualifiers::CONST) {
+        s.push_str("const ");
+    }
+    if ts.qualifiers.contains(TypeQualifiers::VOLATILE) {
+        s.push_str("volatile ");
+    }
+    match &ts.kind {
+        TypeSpecKind::Builtin(mask) => write!(s, "Builtin({:?})", mask).unwrap(),
+        TypeSpecKind::Struct(id) => write!(s, "struct {}", id.as_str()).unwrap(),
+        TypeSpecKind::Union(id) => write!(s, "union {}", id.as_str()).unwrap(),
+        TypeSpecKind::Enum(id) => write!(s, "enum {}", id.as_str()).unwrap(),
+        TypeSpecKind::Typedef(id) => write!(s, "{}", id.as_str()).unwrap(),
+    }
+
+    for _ in 0..ts.pointer_depth {
+        s.push('*');
+    }
+
+    for size in &ts.array_sizes {
+        write!(s, "[{:?}]", size).unwrap();
+    }
+    s
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports)]
 //! A C compiler implemented in Rust.
 pub mod file;
+pub mod dumper;
 pub mod source;
 
 /// Contains the code generation components.


### PR DESCRIPTION
This commit introduces a new command-line flag, `--dump-untyped-ast`, to the compiler. When this flag is used, the compiler will parse the input file and print a pretty, tree-like representation of the untyped Abstract Syntax Tree (AST) to standard output.

After dumping the AST, the compiler will exit immediately, skipping semantic analysis and code generation.

A new `dumper` module has been created to handle the AST traversal and pretty-printing logic.