### PR TITLE
fix(codegen): Pass built-in function info to codegen

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -225,7 +225,8 @@ impl Compiler {
 
         let mut codegen = CodeGen::new();
         codegen.enum_constants = semantic_analyzer.enum_constants;
-        let object_bytes = match codegen.compile(typed_ast) {
+        codegen.used_builtins = semantic_analyzer.used_builtins;
+        let object_bytes = match codegen.compile(typed_ast, &semantic_analyzer.symbol_table) {
             Ok(bytes) => bytes,
             Err(err) => {
                 let report = Report::err(err.to_string(), None);

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -20,8 +20,8 @@ use crate::semantic::typed_ast::{TypedExpr, TypedLValue, TypedStmt, TypedInitial
 /// Represents a symbol in the symbol table.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-struct Symbol {
-    ty: TypeId,
+pub struct Symbol {
+    pub ty: TypeId,
     is_function: bool,
     span: SourceSpan,
     is_builtin: bool,
@@ -61,7 +61,7 @@ impl SymbolTable {
     }
 
     /// Looks up a symbol starting from the current scope and moving outwards.
-    fn lookup(&self, name: &StringId) -> Option<&Symbol> {
+    pub fn lookup(&self, name: &StringId) -> Option<&Symbol> {
         for scope in self.scopes.iter().rev() {
             if let Some(symbol) = scope.get(name) {
                 return Some(symbol);
@@ -86,7 +86,7 @@ pub struct SemaOutput(
 
 /// A semantic analyzer that checks for semantic errors in the AST.
 pub struct SemanticAnalyzer {
-    symbol_table: SymbolTable,
+    pub symbol_table: SymbolTable,
     pub enum_constants: HashMap<StringId, i64>,
     struct_definitions: HashMap<StringId, TypeId>,
     union_definitions: HashMap<StringId, TypeId>,
@@ -94,7 +94,7 @@ pub struct SemanticAnalyzer {
     labels: HashMap<StringId, SourceSpan>,
     errors: Vec<(SemanticError, SourceSpan)>, // (error, file, span)
     warnings: Vec<(SemanticError, SourceSpan)>, // (warning, file, span)
-    used_builtins: HashSet<StringId>,
+    pub used_builtins: HashSet<StringId>,
     used_variables: HashSet<StringId>,
     in_loop: bool,
     in_switch: bool,


### PR DESCRIPTION
The codegen module was failing on calls to built-in functions like 'printf' because it was unaware of them. The semantic analyzer correctly identified these functions, but this information was not being passed to the code generator.

This commit fixes the issue by:
1.  Passing the semantic analyzer's symbol table and the set of used built-in functions to the code generator.
2.  Declaring the used built-in functions as imported functions in the Cranelift module at the start of code generation.
3.  This ensures that the code generator is aware of the built-in functions and their signatures, resolving the "Undefined function" panic.