### PR TITLE
test: Add coverage for SourceManager::default

### DIFF
--- a/src/tests/source_manager.rs
+++ b/src/tests/source_manager.rs
@@ -475,3 +475,10 @@ fn test_source_manager_get_file_id() {
     let not_found = sm.get_file_id("non_existent.c");
     assert_eq!(not_found, None);
 }
+
+#[test]
+fn test_source_manager_default() {
+    let mut sm = SourceManager::default();
+    let file_id = sm.add_buffer(b"content".to_vec(), "test.c", None);
+    assert!(sm.get_file_info(file_id).is_some());
+}


### PR DESCRIPTION
Added `test_source_manager_default` to `src/tests/source_manager.rs` to cover `SourceManager::default()`.
Verified coverage increase using `cargo llvm-cov`.
Restored unrelated snapshot files to avoid noise.


---
*PR created automatically by Jules for task [673482915041897559](https://jules.google.com/task/673482915041897559) started by @bungcip*