### PR TITLE
pp: Prevent redefinition and undefinition of built-in macros

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,6 +13,7 @@ pub mod parser_declarations;
 pub mod parser_function_params_regression;
 pub mod parser_utils;
 pub mod pointer_arithmetic_regression;
+pub mod pp_builtins;
 pub mod pp_comma_separator;
 pub mod pp_common;
 pub mod pp_computed_include;

--- a/src/tests/pp_builtins.rs
+++ b/src/tests/pp_builtins.rs
@@ -1,0 +1,29 @@
+use crate::tests::pp_common::setup_pp_snapshot_with_diags;
+
+#[test]
+fn test_redefine_builtin_macro_should_fail() {
+    let src = r#"
+#define __DATE__ "123"
+const char* s = __DATE__;
+"#;
+    let (tokens, diags) = setup_pp_snapshot_with_diags(src);
+
+    // Currently, this probably succeeds and changes __DATE__.
+    // We expect it to FAIL or warn and NOT change __DATE__.
+    // For now, let's just snapshot what happens.
+    insta::assert_yaml_snapshot!((tokens, diags));
+}
+
+#[test]
+fn test_undef_builtin_macro_should_fail() {
+    let src = r#"
+#undef __DATE__
+#ifdef __DATE__
+int x = 1;
+#else
+int x = 0;
+#endif
+"#;
+    let (tokens, diags) = setup_pp_snapshot_with_diags(src);
+    insta::assert_yaml_snapshot!((tokens, diags));
+}

--- a/src/tests/snapshots/cendol__tests__pp_builtins__redefine_builtin_macro_should_fail.snap
+++ b/src/tests/snapshots/cendol__tests__pp_builtins__redefine_builtin_macro_should_fail.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/pp_builtins.rs
+expression: "(tokens, diags)"
+---
+- - kind: Identifier
+    text: const
+  - kind: Identifier
+    text: char
+  - kind: Star
+    text: "*"
+  - kind: Identifier
+    text: s
+  - kind: Assign
+    text: "="
+  - kind: StringLiteral
+    text: "\"Jan 27 2026\""
+  - kind: Semicolon
+    text: ;
+- - "Warning: Redefinition of built-in macro '__DATE__'"

--- a/src/tests/snapshots/cendol__tests__pp_builtins__undef_builtin_macro_should_fail.snap
+++ b/src/tests/snapshots/cendol__tests__pp_builtins__undef_builtin_macro_should_fail.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/pp_builtins.rs
+expression: "(tokens, diags)"
+---
+- - kind: Identifier
+    text: int
+  - kind: Identifier
+    text: x
+  - kind: Assign
+    text: "="
+  - kind: Number
+    text: "1"
+  - kind: Semicolon
+    text: ;
+- - "Warning: Undefining built-in macro '__DATE__'"


### PR DESCRIPTION
- Modified `src/pp/preprocessor.rs`:
  - `handle_define`: Check for `MacroFlags::BUILTIN` and return early with warning.
  - `handle_undef`: Check for `MacroFlags::BUILTIN` and return early with warning (after consuming EOD).
- Added `src/tests/pp_builtins.rs`:
  - `test_redefine_builtin_macro_should_fail`: Verifies warning and value preservation.
  - `test_undef_builtin_macro_should_fail`: Verifies warning and existence preservation.
- Registered new test module in `src/tests.rs`.

---
*PR created automatically by Jules for task [7755761169601786693](https://jules.google.com/task/7755761169601786693) started by @fajarkudaile*