### PR TITLE
Fix parsing of escape sequences in character literals

### DIFF
--- a/src/tests/pp_lexer.rs
+++ b/src/tests/pp_lexer.rs
@@ -491,3 +491,29 @@ fn test_hex_float_literal() {
         ("0x1P+1", PPTokenKind::Number(_)),
     );
 }
+
+/// Test character literals with escape sequences
+#[test]
+fn test_char_literal_escapes() {
+    let source = r"'\1' '\10' '\100' '\x01' '\x0e' '\x10' '\x40'";
+    let mut lexer = create_test_pp_lexer(source);
+
+    // '\1' is octal 1 -> 1
+    // '\10' is octal 10 -> 8
+    // '\100' is octal 100 -> 64
+    // '\x01' is hex 1 -> 1
+    // '\x0e' is hex E -> 14
+    // '\x10' is hex 10 -> 16
+    // '\x40' is hex 40 -> 64
+
+    test_tokens!(
+        lexer,
+        (r"'\1'", PPTokenKind::CharLiteral(1, _)),
+        (r"'\10'", PPTokenKind::CharLiteral(8, _)),
+        (r"'\100'", PPTokenKind::CharLiteral(64, _)),
+        (r"'\x01'", PPTokenKind::CharLiteral(1, _)),
+        (r"'\x0e'", PPTokenKind::CharLiteral(14, _)),
+        (r"'\x10'", PPTokenKind::CharLiteral(16, _)),
+        (r"'\x40'", PPTokenKind::CharLiteral(64, _)),
+    );
+}


### PR DESCRIPTION
This PR fixes a miscompilation issue where character literals containing octal or hexadecimal escape sequences were not parsed correctly by the preprocessor lexer.

Previously, `lex_char_literal` only supported simple single-character escapes like `\n` or `\\`. Complex escapes like `\1` (octal) or `\x40` (hex) fell through to a default case that often resulted in incorrect values (e.g. `\1` becoming '1' (49) or `\10` becoming 0).

The fix implements robust parsing for:
- Octal escapes: `\0` through `\777` (max 3 digits).
- Hex escapes: `\x` followed by hex digits.
- Standard escapes: `\n`, `\t`, `\r`, `\b`, `\f`, `\v`, `\a`, `\?`, `\'`, `\"`, `\\`.

A new unit test `test_char_literal_escapes` has been added to `src/tests/pp_lexer.rs` covering these cases.
Verified with the user-provided reproduction C code.

---
*PR created automatically by Jules for task [8750382161103898715](https://jules.google.com/task/8750382161103898715) started by @bungcip*