### PR TITLE
fix(semantic): Correctly determine bitwise shift result type

### DIFF
--- a/.jules/reno.md
+++ b/.jules/reno.md
@@ -32,3 +32,4 @@ c-testsuite/tests/single-exec/00022.c
 c-testsuite/tests/single-exec/00025.c
 c-testsuite/tests/single-exec/00219.c
 c-testsuite/tests/single-exec/00125.c
+c-testsuite/tests/single-exec/00200.c

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -484,6 +484,12 @@ impl<'a> SemanticAnalyzer<'a> {
                 Some((QualType::unqualified(self.registry.type_int), lhs_promoted))
             }
 
+            // Shift operations
+            BinaryOp::LShift | BinaryOp::RShift => {
+                // C11 6.5.7: result is type of promoted left operand
+                Some((lhs_promoted, lhs_promoted))
+            }
+
             // For other operations, use usual arithmetic conversions
             _ => {
                 let ty = usual_arithmetic_conversions(self.registry, lhs_promoted, rhs_promoted)?;


### PR DESCRIPTION
This commit corrects a bug in the semantic analyzer where the result type of bitwise shift operations was being determined incorrectly. The fix aligns the compiler with the C11 standard by ensuring the result type is that of the promoted left operand, and it has been verified against the relevant `c-testsuite` test case.

---
*PR created automatically by Jules for task [56787225949773557](https://jules.google.com/task/56787225949773557) started by @bungcip*