### PR TITLE
🛡️ Guardian: rejects_typedef_conflicting_with_variable

### DIFF
--- a/src/tests/semantic_typedef_variable_conflict.rs
+++ b/src/tests/semantic_typedef_variable_conflict.rs
@@ -16,6 +16,20 @@ int T;
 }
 
 #[test]
+fn rejects_typedef_declaration_conflicting_with_variable() {
+    run_fail_with_diagnostic(
+        r#"
+int T;
+typedef int T;
+        "#,
+        CompilePhase::Mir,
+        "redefinition of 'T'",
+        3,
+        1,
+    );
+}
+
+#[test]
 fn rejects_extern_variable_declaration_conflicting_with_typedef() {
     run_fail_with_diagnostic(
         r#"


### PR DESCRIPTION
Adds a negative test case to verify that the compiler correctly rejects a typedef declaration that conflicts with an existing variable name, enforcing C11's namespace rules.

---
*PR created automatically by Jules for task [4985532552043217753](https://jules.google.com/task/4985532552043217753) started by @bungcip*