### PR TITLE
Fix long double miscompilation on x86_64 by aliasing to double

### DIFF
--- a/src/semantic/ast_to_mir.rs
+++ b/src/semantic/ast_to_mir.rs
@@ -20,6 +20,7 @@ use crate::semantic::{DefinitionState, TypeRef, TypeRegistry};
 use crate::semantic::{ImplicitConversion, Namespace, ScopeId};
 use hashbrown::{HashMap, HashSet};
 use log::debug;
+use target_lexicon::Architecture;
 
 use crate::mir::GlobalId;
 
@@ -874,7 +875,13 @@ impl<'a> AstToMirLowerer<'a> {
             BuiltinType::ULong | BuiltinType::ULongLong => MirType::U64,
             BuiltinType::Float => MirType::F32,
             BuiltinType::Double => MirType::F64,
-            BuiltinType::LongDouble => MirType::F128,
+            BuiltinType::LongDouble => {
+                if self.registry.target_triple.architecture == Architecture::X86_64 {
+                    MirType::F64
+                } else {
+                    MirType::F128
+                }
+            }
             BuiltinType::Signed => MirType::I32,
             BuiltinType::VaList => MirType::U64, // Opaque handle
         }

--- a/src/semantic/type_registry.rs
+++ b/src/semantic/type_registry.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use crate::source_manager::SourceSpan;
 use crate::{ast::NameId, diagnostic::SemanticError, semantic::QualType};
 use hashbrown::{HashMap, HashSet};
-use target_lexicon::{PointerWidth, Triple};
+use target_lexicon::{Architecture, PointerWidth, Triple};
 
 use super::types::TypeClass;
 use super::types::{FieldLayout, LayoutKind};
@@ -559,11 +559,18 @@ impl TypeRegistry {
                     alignment: 8,
                     kind: LayoutKind::Scalar,
                 },
-                BuiltinType::LongDouble => TypeLayout {
-                    size: 16,
-                    alignment: 16,
-                    kind: LayoutKind::Scalar,
-                },
+                BuiltinType::LongDouble => {
+                    let size = if self.target_triple.architecture == Architecture::X86_64 {
+                        8
+                    } else {
+                        16
+                    };
+                    TypeLayout {
+                        size,
+                        alignment: size,
+                        kind: LayoutKind::Scalar,
+                    }
+                }
                 BuiltinType::Signed => TypeLayout {
                     size: 4,
                     alignment: 4,

--- a/src/tests/regression_movi.rs
+++ b/src/tests/regression_movi.rs
@@ -25,7 +25,7 @@ fn test_movi_unsigned_constant_codegen() {
 
 #[test]
 fn test_long_double_size() {
-    // Check that long double is treated as 16 bytes (size of F128)
+    // Check that long double size matches architecture (8 on x86_64, 16 otherwise)
     let source = r#"
         int main() {
             long double ld;
@@ -33,10 +33,17 @@ fn test_long_double_size() {
         }
     "#;
     let clif_dump = setup_cranelift(source);
-    // We expect a stack slot of size 16
+
+    let expected_size = if target_lexicon::Triple::host().architecture == target_lexicon::Architecture::X86_64 {
+        8
+    } else {
+        16
+    };
+
     assert!(
-        clif_dump.contains("explicit_slot 16"),
-        "Expected explicit_slot 16 for long double, found:\n{}",
+        clif_dump.contains(&format!("explicit_slot {}", expected_size)),
+        "Expected explicit_slot {} for long double, found:\n{}",
+        expected_size,
         clif_dump
     );
 }


### PR DESCRIPTION
This change addresses a miscompilation issue where `long double` values were producing `nan` or garbage output on x86_64 systems. The issue stemmed from an ABI mismatch: the compiler was generating 128-bit floats (`F128`) for `long double`, while the system libc `printf` on x86_64 expects 80-bit extended precision floats (typically padded to 16 bytes).

Since Cranelift does not natively support 80-bit floats (`f80`), `long double` support on x86_64 is problematic. This patch pragmatically changes `long double` to be an alias for `double` (`f64`, 8 bytes) specifically on x86_64 targets. This ensures valid floating-point arithmetic is performed using standard `f64` instructions. While `printf` with `%Lf` will still likely produce incorrect output (garbage) due to the ABI mismatch (reading 16 bytes from stack vs 8 bytes pushed), this prevents invalid instruction usage and `nan` generation from `f128` bit patterns, and allows arithmetic to be correct.

On other architectures like AArch64, `long double` remains 128-bit (`F128`), preserving correctness where support exists.

Verification:
- Added conditional logic to `regression_movi.rs` to verify correct stack slot allocation size (8 bytes on x86_64, 16 bytes elsewhere).
- Verified `repro_long_double.c` (locally) confirms output is no longer `nan` (though printf value is 0.000000 due to ABI limitation, internal value is preserved as double).
- Ran existing tests.

---
*PR created automatically by Jules for task [8839071259345493175](https://jules.google.com/task/8839071259345493175) started by @bungcip*