### PR TITLE
🛡️ Guardian: Corrects typedef shadowing test

### DIFF
--- a/src/tests/semantic_shadowing.rs
+++ b/src/tests/semantic_shadowing.rs
@@ -21,3 +21,20 @@ fn test_nested_scope_shadowing() {
         "#,
     );
 }
+
+#[test]
+fn allows_parameter_to_shadow_typedef() {
+    run_full_pass(
+        r#"
+typedef int T;
+void f(int T) {
+    T = 1;
+}
+
+int main() {
+    f(0);
+    return 0;
+}
+        "#,
+    );
+}


### PR DESCRIPTION
🧪 **What:** Corrected the test suite to properly handle C11 scoping rules for `typedef` shadowing. Removed a failing negative test that asserted valid code was an error and added a positive test to confirm the compiler's correct behavior.

🎯 **Why:** The original test `rejects_typedef_as_function_parameter_name` was based on a misunderstanding of C11 scoping. A function parameter can legally shadow a `typedef` from an outer scope. This change ensures the test suite accurately reflects the language standard and validates correct compiler behavior instead of a false positive.

🛠️ **Phase:** Semantic Analysis

🔬 **Verify:** Run `cargo test semantic_shadowing`.

---
*PR created automatically by Jules for task [3035833763041143633](https://jules.google.com/task/3035833763041143633) started by @bungcip*