### PR TITLE
Refactor lexer tests to use snapshots and increase coverage

### DIFF
--- a/src/tests/lexer.rs
+++ b/src/tests/lexer.rs
@@ -1,7 +1,7 @@
 use crate::driver::artifact::CompilePhase;
-use crate::intern::StringId;
 use crate::lexer::*;
 use crate::tests::test_utils;
+use std::collections::BTreeMap;
 
 /// Helper function to test lexing from string to TokenKind
 /// This tests the full pipeline: string -> PPToken -> TokenKind
@@ -48,174 +48,128 @@ mod tests {
             "_Noreturn", "_Static_assert", "_Thread_local",
         ];
 
-        for keyword in keywords {
-            let symbol = StringId::new(keyword);
-            let expected_kind =
-                crate::lexer::is_keyword(symbol).unwrap_or_else(|| panic!("{} should be a keyword", keyword));
+        let results: BTreeMap<_, _> = keywords
+            .iter()
+            .map(|keyword| (*keyword, setup_lexer(keyword)))
+            .collect();
 
-            let token_kinds = setup_lexer(keyword);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for keyword: {}", keyword);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for keyword: {}", keyword);
-        }
+        insta::assert_yaml_snapshot!(results);
     }
 
     #[test]
     fn test_operators_and_punctuation() {
         let operators = vec![
-            ("+", TokenKind::Plus),
-            ("-", TokenKind::Minus),
-            ("*", TokenKind::Star),
-            ("/", TokenKind::Slash),
-            ("%", TokenKind::Percent),
-            ("&", TokenKind::And),
-            ("|", TokenKind::Or),
-            ("^", TokenKind::Xor),
-            ("!", TokenKind::Not),
-            ("~", TokenKind::Tilde),
-            ("<", TokenKind::Less),
-            (">", TokenKind::Greater),
-            ("<=", TokenKind::LessEqual),
-            (">=", TokenKind::GreaterEqual),
-            ("==", TokenKind::Equal),
-            ("!=", TokenKind::NotEqual),
-            ("<<", TokenKind::LeftShift),
-            (">>", TokenKind::RightShift),
-            ("=", TokenKind::Assign),
-            ("+=", TokenKind::PlusAssign),
-            ("-=", TokenKind::MinusAssign),
-            ("*=", TokenKind::StarAssign),
-            ("/=", TokenKind::DivAssign),
-            ("%=", TokenKind::ModAssign),
-            ("&=", TokenKind::AndAssign),
-            ("|=", TokenKind::OrAssign),
-            ("^=", TokenKind::XorAssign),
-            ("<<=", TokenKind::LeftShiftAssign),
-            (">>=", TokenKind::RightShiftAssign),
-            ("++", TokenKind::Increment),
-            ("--", TokenKind::Decrement),
-            ("->", TokenKind::Arrow),
-            (".", TokenKind::Dot),
-            ("?", TokenKind::Question),
-            (":", TokenKind::Colon),
-            (",", TokenKind::Comma),
-            (";", TokenKind::Semicolon),
-            ("(", TokenKind::LeftParen),
-            (")", TokenKind::RightParen),
-            ("[", TokenKind::LeftBracket),
-            ("]", TokenKind::RightBracket),
-            ("{", TokenKind::LeftBrace),
-            ("}", TokenKind::RightBrace),
-            ("...", TokenKind::Ellipsis),
-            ("&&", TokenKind::LogicAnd),
-            ("||", TokenKind::LogicOr),
+            "+", "-", "*", "/", "%", "&", "|", "^", "!", "~", "<", ">", "<=", ">=", "==", "!=",
+            "<<", ">>", "=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=", "++",
+            "--", "->", ".", "?", ":", ",", ";", "(", ")", "[", "]", "{", "}", "...", "&&", "||",
         ];
 
-        for (text, expected_kind) in operators {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for operator: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for operator: {}", text);
-        }
+        // Map to just text for the snapshot key to keep it clean
+        let results: BTreeMap<_, _> = operators
+            .iter()
+            .map(|op| (*op, setup_lexer(op)))
+            .collect();
+
+        insta::assert_yaml_snapshot!(results);
     }
 
     #[test]
     fn test_literals() {
-        use crate::ast::literal::IntegerSuffix;
         // Integer constants
         let int_literals = vec![
-            ("42", TokenKind::IntegerConstant(42, None)),
-            ("0x1A", TokenKind::IntegerConstant(26, None)),
-            ("077", TokenKind::IntegerConstant(63, None)),
+            "42",
+            "0x1A",
+            "077",
             // C11 integer suffixes - decimal
-            ("1ll", TokenKind::IntegerConstant(1, Some(IntegerSuffix::LL))),
-            ("42u", TokenKind::IntegerConstant(42, Some(IntegerSuffix::U))),
-            ("123l", TokenKind::IntegerConstant(123, Some(IntegerSuffix::L))),
-            ("456ul", TokenKind::IntegerConstant(456, Some(IntegerSuffix::UL))),
-            ("789lu", TokenKind::IntegerConstant(789, Some(IntegerSuffix::UL))),
-            ("1000ull", TokenKind::IntegerConstant(1000, Some(IntegerSuffix::ULL))),
-            ("2000llu", TokenKind::IntegerConstant(2000, Some(IntegerSuffix::ULL))),
+            "1ll",
+            "42u",
+            "123l",
+            "456ul",
+            "789lu",
+            "1000ull",
+            "2000llu",
             // C11 integer suffixes - hexadecimal
-            ("0x1Au", TokenKind::IntegerConstant(26, Some(IntegerSuffix::U))),
-            ("0xFFll", TokenKind::IntegerConstant(255, Some(IntegerSuffix::LL))),
-            ("0x10UL", TokenKind::IntegerConstant(16, Some(IntegerSuffix::UL))),
-            ("0x20LU", TokenKind::IntegerConstant(32, Some(IntegerSuffix::UL))),
-            ("0x40ULL", TokenKind::IntegerConstant(64, Some(IntegerSuffix::ULL))),
-            ("0x80LLU", TokenKind::IntegerConstant(128, Some(IntegerSuffix::ULL))),
+            "0x1Au",
+            "0xFFll",
+            "0x10UL",
+            "0x20LU",
+            "0x40ULL",
+            "0x80LLU",
             // C11 integer suffixes - octal
-            ("077u", TokenKind::IntegerConstant(63, Some(IntegerSuffix::U))),
-            ("0123l", TokenKind::IntegerConstant(83, Some(IntegerSuffix::L))),
-            ("0777ul", TokenKind::IntegerConstant(511, Some(IntegerSuffix::UL))),
-            ("0123lu", TokenKind::IntegerConstant(83, Some(IntegerSuffix::UL))),
-            ("0777ull", TokenKind::IntegerConstant(511, Some(IntegerSuffix::ULL))),
-            ("0123llu", TokenKind::IntegerConstant(83, Some(IntegerSuffix::ULL))),
+            "077u",
+            "0123l",
+            "0777ul",
+            "0123lu",
+            "0777ull",
+            "0123llu",
             // Case insensitive suffixes
-            ("1LL", TokenKind::IntegerConstant(1, Some(IntegerSuffix::LL))),
-            ("42U", TokenKind::IntegerConstant(42, Some(IntegerSuffix::U))),
-            ("123L", TokenKind::IntegerConstant(123, Some(IntegerSuffix::L))),
-            ("456UL", TokenKind::IntegerConstant(456, Some(IntegerSuffix::UL))),
-            ("789LU", TokenKind::IntegerConstant(789, Some(IntegerSuffix::UL))),
-            ("1000ULL", TokenKind::IntegerConstant(1000, Some(IntegerSuffix::ULL))),
-            ("2000LLU", TokenKind::IntegerConstant(2000, Some(IntegerSuffix::ULL))),
+            "1LL",
+            "42U",
+            "123L",
+            "456UL",
+            "789LU",
+            "1000ULL",
+            "2000LLU",
         ];
 
-        for (text, expected_kind) in int_literals {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for integer literal: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for integer literal: {}", text);
-        }
+        let results: BTreeMap<_, _> = int_literals
+            .iter()
+            .map(|lit| (*lit, setup_lexer(lit)))
+            .collect();
+
+        insta::assert_yaml_snapshot!("integer_literals", results);
 
         // Float constants
         let float_literals = vec![
-            ("1.5", TokenKind::FloatConstant(1.5)),
-            ("1.23e-4", TokenKind::FloatConstant(1.23e-4)),
-            ("0x1.2p3", TokenKind::FloatConstant(9.0)),
+            "1.5",
+            "1.23e-4",
+            "0x1.2p3",
         ];
 
-        for (text, expected_kind) in float_literals {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for float literal: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for float literal: {}", text);
-        }
+        let results: BTreeMap<_, _> = float_literals
+            .iter()
+            .map(|lit| (*lit, setup_lexer(lit)))
+            .collect();
+
+        insta::assert_yaml_snapshot!("float_literals", results);
 
         // Character constants
         let char_literals = vec![
-            ("'a'", TokenKind::CharacterConstant(97)),   // 'a' = 97
-            ("'\\n'", TokenKind::CharacterConstant(10)), // '\n' = 10
+            "'a'",
+            "'\\n'",
         ];
 
-        for (text, expected_kind) in char_literals {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for character literal: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for character literal: {}", text);
-        }
+        let results: BTreeMap<_, _> = char_literals
+            .iter()
+            .map(|lit| (*lit, setup_lexer(lit)))
+            .collect();
+
+        insta::assert_yaml_snapshot!("char_literals", results);
 
         // String literals
         let string_literals = vec![
-            ("\"hello\"", TokenKind::StringLiteral(StringId::new("hello"))),
-            ("\"world\\n\"", TokenKind::StringLiteral(StringId::new("world\n"))),
+            "\"hello\"",
+            "\"world\\n\"",
         ];
 
-        for (text, expected_kind) in string_literals {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for string literal: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for string literal: {}", text);
-        }
+        let results: BTreeMap<_, _> = string_literals
+            .iter()
+            .map(|lit| (*lit, setup_lexer(lit)))
+            .collect();
+
+        insta::assert_yaml_snapshot!("string_literals", results);
     }
 
     #[test]
     fn test_identifiers() {
         let identifiers = vec!["variable", "my_var", "_private", "var123", "a", "_"];
 
-        for ident in identifiers {
-            let symbol = StringId::new(ident);
-            let token_kinds = setup_lexer(ident);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for identifier: {}", ident);
-            assert_eq!(
-                token_kinds[0],
-                TokenKind::Identifier(symbol),
-                "Failed for identifier: {}",
-                ident
-            );
-        }
+        let results: BTreeMap<_, _> = identifiers
+            .iter()
+            .map(|ident| (*ident, setup_lexer(ident)))
+            .collect();
+
+        insta::assert_yaml_snapshot!(results);
     }
 
     #[test]
@@ -223,71 +177,105 @@ mod tests {
         // Test adjacent string literal concatenation (C11 6.4.5)
         let test_cases = vec![
             // Basic concatenation
-            ("\"hello\" \"world\"", "helloworld"),
+            "\"hello\" \"world\"",
             // With whitespace between
-            ("\"hello\"   \"world\"", "helloworld"),
+            "\"hello\"   \"world\"",
             // Multiple concatenations
-            ("\"a\" \"b\" \"c\"", "abc"),
+            "\"a\" \"b\" \"c\"",
             // With escape sequences
-            ("\"hello\\n\" \"world\"", "hello\nworld"),
+            "\"hello\\n\" \"world\"",
             // Mixed quotes and content
-            ("\"start\" \" middle \" \"end\"", "start middle end"),
+            "\"start\" \" middle \" \"end\"",
         ];
 
-        for (input, expected_content) in test_cases {
-            let token_kinds = setup_lexer(input);
-            assert_eq!(
-                token_kinds.len(),
-                1,
-                "Expected 1 token for concatenated string: {}",
-                input
-            );
+        let results: BTreeMap<_, _> = test_cases
+            .iter()
+            .map(|input| (*input, setup_lexer(input)))
+            .collect();
 
-            match &token_kinds[0] {
-                TokenKind::StringLiteral(symbol) => {
-                    let actual_content = symbol.as_str();
-                    assert_eq!(
-                        actual_content, expected_content,
-                        "String concatenation failed for input: {}",
-                        input
-                    );
-                }
-                _ => panic!("Expected StringLiteral token for input: {}", input),
-            }
-        }
+        insta::assert_yaml_snapshot!(results);
+    }
 
-        // Test that non-adjacent strings are not concatenated
-        let token_kinds = setup_lexer("\"hello\" ; \"world\"");
-        assert_eq!(token_kinds.len(), 3, "Expected 3 tokens for non-adjacent strings");
-        assert!(
-            matches!(token_kinds[0], TokenKind::StringLiteral(_)),
-            "First token should be string literal"
-        );
-        assert_eq!(token_kinds[1], TokenKind::Semicolon, "Second token should be semicolon");
-        assert!(
-            matches!(token_kinds[2], TokenKind::StringLiteral(_)),
-            "Third token should be string literal"
-        );
+    #[test]
+    fn test_non_adjacent_string_literals() {
+         let input = "\"hello\" ; \"world\"";
+         let tokens = setup_lexer(input);
+         insta::assert_yaml_snapshot!(tokens);
     }
 
     #[test]
     fn test_special_tokens() {
         // EndOfFile - empty string should produce EndOfFile when included
-        let token_kinds = setup_lexer_with_eof("", true);
-        assert_eq!(token_kinds.len(), 1, "Expected 1 token for empty string");
-        assert_eq!(
-            token_kinds[0],
-            TokenKind::EndOfFile,
-            "Empty string should produce EndOfFile"
-        );
+        let eof_tokens = setup_lexer_with_eof("", true);
+        insta::assert_yaml_snapshot!("eof_token", eof_tokens);
 
         // Unknown - unrecognized character should produce Unknown
-        let token_kinds = setup_lexer("@");
-        assert_eq!(token_kinds.len(), 1, "Expected 1 token for unknown character");
-        assert_eq!(
-            token_kinds[0],
-            TokenKind::Unknown,
-            "Unrecognized character should produce Unknown"
-        );
+        let unknown_tokens = setup_lexer("@");
+        insta::assert_yaml_snapshot!("unknown_token", unknown_tokens);
+    }
+
+    #[test]
+    fn test_complex_float_literals() {
+        let cases = vec![
+            "0x1.fp-2",
+            "0x.p0",     // Invalid hex float (must have digits) - wait, C11 says hex float must have digits
+                         // actually 0x.p0 is invalid because hex-float requires hex digits either before or after dot.
+                         // But `.` alone is not a valid hex float prefix.
+            "0x.8p0",    // Valid
+            "0x1p+5",    // Valid
+            "1.f",       // Valid float with suffix
+            ".5f",       // Valid
+            "1e5f",      // Valid
+            "0x1P-1L",   // Valid hex float with long double suffix
+        ];
+
+        let results: BTreeMap<_, _> = cases
+            .iter()
+            .map(|lit| (*lit, setup_lexer(lit)))
+            .collect();
+
+        insta::assert_yaml_snapshot!(results);
+    }
+
+    #[test]
+    fn test_complex_integer_suffixes() {
+        let cases = vec![
+            "1uLl", // Valid: unsigned long long (mixed case)
+            "1UlL", // Valid: unsigned long long
+            "1LLu", // Valid: long long unsigned
+            "1llU", // Valid
+            "1Lu",  // Valid: long unsigned
+            "1uL",  // Valid
+            // Invalid ones are usually handled by parser or lexer error, here we check what token we get.
+            // If lexer is robust, it might consume valid prefix.
+        ];
+
+        let results: BTreeMap<_, _> = cases
+            .iter()
+            .map(|lit| (*lit, setup_lexer(lit)))
+            .collect();
+
+        insta::assert_yaml_snapshot!(results);
+    }
+
+    #[test]
+    fn test_string_escapes() {
+        let cases = vec![
+            r#""\x41""#,      // Hex 'A'
+            r#""\101""#,      // Octal 'A'
+            r#""\?""#,        // Question mark
+            r#""\"""#,        // Double quote
+            r#""\'""#,        // Single quote
+            r#""\a\b\f\n\r\t\v""#, // Common escapes
+            r#""\x""#,        // Empty hex escape (invalid but interesting to see lexer behavior)
+            r#""\777""#,      // Octal overflow (char is u8, so it wraps or errors?)
+        ];
+
+        let results: BTreeMap<_, _> = cases
+            .iter()
+            .map(|lit| (*lit, setup_lexer(lit)))
+            .collect();
+
+        insta::assert_yaml_snapshot!(results);
     }
 }

--- a/src/tests/snapshots/cendol__tests__lexer__tests__c11_keywords.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__c11_keywords.snap
@@ -1,0 +1,91 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 57
+expression: results
+---
+_Alignas:
+  - Alignas
+_Alignof:
+  - Alignof
+_Atomic:
+  - Atomic
+_Bool:
+  - Bool
+_Complex:
+  - Complex
+_Generic:
+  - Generic
+_Noreturn:
+  - Noreturn
+_Static_assert:
+  - StaticAssert
+_Thread_local:
+  - ThreadLocal
+auto:
+  - Auto
+break:
+  - Break
+case:
+  - Case
+char:
+  - Char
+const:
+  - Const
+continue:
+  - Continue
+default:
+  - Default
+do:
+  - Do
+double:
+  - Double
+else:
+  - Else
+enum:
+  - Enum
+extern:
+  - Extern
+float:
+  - Float
+for:
+  - For
+goto:
+  - Goto
+if:
+  - If
+inline:
+  - Inline
+int:
+  - Int
+long:
+  - Long
+register:
+  - Register
+restrict:
+  - Restrict
+return:
+  - Return
+short:
+  - Short
+signed:
+  - Signed
+sizeof:
+  - Sizeof
+static:
+  - Static
+struct:
+  - Struct
+switch:
+  - Switch
+typedef:
+  - Typedef
+union:
+  - Union
+unsigned:
+  - Unsigned
+void:
+  - Void
+volatile:
+  - Volatile
+while:
+  - While

--- a/src/tests/snapshots/cendol__tests__lexer__tests__char_literals.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__char_literals.snap
@@ -1,0 +1,9 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 147
+expression: results
+---
+"'\\n'":
+  - CharacterConstant: 10
+"'a'":
+  - CharacterConstant: 97

--- a/src/tests/snapshots/cendol__tests__lexer__tests__complex_float_literals.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__complex_float_literals.snap
@@ -1,0 +1,21 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 280
+expression: results
+---
+".5f":
+  - FloatConstant: 0.5
+"0x.8p0":
+  - FloatConstant: 0.5
+"0x.p0":
+  - FloatConstant: 0
+"0x1.fp-2":
+  - FloatConstant: 0.484375
+"0x1P-1L":
+  - FloatConstant: 0.5
+"0x1p+5":
+  - FloatConstant: 32
+1.f:
+  - FloatConstant: 1
+1e5f:
+  - FloatConstant: 100000

--- a/src/tests/snapshots/cendol__tests__lexer__tests__complex_integer_suffixes.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__complex_integer_suffixes.snap
@@ -1,0 +1,29 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 301
+expression: results
+---
+1LLu:
+  - IntegerConstant:
+      - 1
+      - ULL
+1Lu:
+  - IntegerConstant:
+      - 1
+      - UL
+1UlL:
+  - IntegerConstant:
+      - 1
+      - ULL
+1llU:
+  - IntegerConstant:
+      - 1
+      - ULL
+1uL:
+  - IntegerConstant:
+      - 1
+      - UL
+1uLl:
+  - IntegerConstant:
+      - 1
+      - ULL

--- a/src/tests/snapshots/cendol__tests__lexer__tests__eof_token.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__eof_token.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 210
+expression: eof_tokens
+---
+- EndOfFile

--- a/src/tests/snapshots/cendol__tests__lexer__tests__float_literals.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__float_literals.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 134
+expression: results
+---
+"0x1.2p3":
+  - FloatConstant: 9
+"1.23e-4":
+  - FloatConstant: 0.000123
+"1.5":
+  - FloatConstant: 1.5

--- a/src/tests/snapshots/cendol__tests__lexer__tests__identifiers.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__identifiers.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 172
+expression: results
+---
+_:
+  - Identifier: _
+_private:
+  - Identifier: _private
+a:
+  - Identifier: a
+my_var:
+  - Identifier: my_var
+var123:
+  - Identifier: var123
+variable:
+  - Identifier: variable

--- a/src/tests/snapshots/cendol__tests__lexer__tests__integer_literals.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__integer_literals.snap
@@ -1,0 +1,121 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 120
+expression: results
+---
+0123l:
+  - IntegerConstant:
+      - 83
+      - L
+0123llu:
+  - IntegerConstant:
+      - 83
+      - ULL
+0123lu:
+  - IntegerConstant:
+      - 83
+      - UL
+"077":
+  - IntegerConstant:
+      - 63
+      - ~
+0777ul:
+  - IntegerConstant:
+      - 511
+      - UL
+0777ull:
+  - IntegerConstant:
+      - 511
+      - ULL
+077u:
+  - IntegerConstant:
+      - 63
+      - U
+"0x10UL":
+  - IntegerConstant:
+      - 16
+      - UL
+"0x1A":
+  - IntegerConstant:
+      - 26
+      - ~
+"0x1Au":
+  - IntegerConstant:
+      - 26
+      - U
+"0x20LU":
+  - IntegerConstant:
+      - 32
+      - UL
+"0x40ULL":
+  - IntegerConstant:
+      - 64
+      - ULL
+"0x80LLU":
+  - IntegerConstant:
+      - 128
+      - ULL
+"0xFFll":
+  - IntegerConstant:
+      - 255
+      - LL
+1000ULL:
+  - IntegerConstant:
+      - 1000
+      - ULL
+1000ull:
+  - IntegerConstant:
+      - 1000
+      - ULL
+123L:
+  - IntegerConstant:
+      - 123
+      - L
+123l:
+  - IntegerConstant:
+      - 123
+      - L
+1LL:
+  - IntegerConstant:
+      - 1
+      - LL
+1ll:
+  - IntegerConstant:
+      - 1
+      - LL
+2000LLU:
+  - IntegerConstant:
+      - 2000
+      - ULL
+2000llu:
+  - IntegerConstant:
+      - 2000
+      - ULL
+"42":
+  - IntegerConstant:
+      - 42
+      - ~
+42U:
+  - IntegerConstant:
+      - 42
+      - U
+42u:
+  - IntegerConstant:
+      - 42
+      - U
+456UL:
+  - IntegerConstant:
+      - 456
+      - UL
+456ul:
+  - IntegerConstant:
+      - 456
+      - UL
+789LU:
+  - IntegerConstant:
+      - 789
+      - UL
+789lu:
+  - IntegerConstant:
+      - 789
+      - UL

--- a/src/tests/snapshots/cendol__tests__lexer__tests__non_adjacent_string_literals.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__non_adjacent_string_literals.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 203
+expression: tokens
+---
+- StringLiteral: hello
+- Semicolon
+- StringLiteral: world

--- a/src/tests/snapshots/cendol__tests__lexer__tests__operators_and_punctuation.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__operators_and_punctuation.snap
@@ -1,0 +1,97 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 73
+expression: results
+---
+"!":
+  - Not
+"!=":
+  - NotEqual
+"%":
+  - Percent
+"%=":
+  - ModAssign
+"&":
+  - And
+"&&":
+  - LogicAnd
+"&=":
+  - AndAssign
+(:
+  - LeftParen
+):
+  - RightParen
+"*":
+  - Star
+"*=":
+  - StarAssign
++:
+  - Plus
+++:
+  - Increment
++=:
+  - PlusAssign
+",":
+  - Comma
+"-":
+  - Minus
+"--":
+  - Decrement
+"-=":
+  - MinusAssign
+"->":
+  - Arrow
+".":
+  - Dot
+"...":
+  - Ellipsis
+/:
+  - Slash
+/=:
+  - DivAssign
+":":
+  - Colon
+;:
+  - Semicolon
+"<":
+  - Less
+"<<":
+  - LeftShift
+"<<=":
+  - LeftShiftAssign
+"<=":
+  - LessEqual
+"=":
+  - Assign
+"==":
+  - Equal
+">":
+  - Greater
+">=":
+  - GreaterEqual
+">>":
+  - RightShift
+">>=":
+  - RightShiftAssign
+"?":
+  - Question
+"[":
+  - LeftBracket
+"]":
+  - RightBracket
+^:
+  - Xor
+^=:
+  - XorAssign
+"{":
+  - LeftBrace
+"|":
+  - Or
+"|=":
+  - OrAssign
+"||":
+  - LogicOr
+"}":
+  - RightBrace
+"~":
+  - Tilde

--- a/src/tests/snapshots/cendol__tests__lexer__tests__string_escapes.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__string_escapes.snap
@@ -1,0 +1,21 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 322
+expression: results
+---
+"\"\\\"\"":
+  - StringLiteral: "\""
+"\"\\'\"":
+  - StringLiteral: "'"
+"\"\\101\"":
+  - StringLiteral: A
+"\"\\777\"":
+  - StringLiteral: ǿ
+"\"\\?\"":
+  - StringLiteral: "?"
+"\"\\a\\b\\f\\n\\r\\t\\v\"":
+  - StringLiteral: "\u0007\b\f\n\r\t\u000b"
+"\"\\x\"":
+  - StringLiteral: x
+"\"\\x41\"":
+  - StringLiteral: A

--- a/src/tests/snapshots/cendol__tests__lexer__tests__string_literal_concatenation.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__string_literal_concatenation.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 196
+expression: results
+---
+"\"a\" \"b\" \"c\"":
+  - StringLiteral: abc
+"\"hello\"   \"world\"":
+  - StringLiteral: helloworld
+"\"hello\" \"world\"":
+  - StringLiteral: helloworld
+"\"hello\\n\" \"world\"":
+  - StringLiteral: "hello\nworld"
+"\"start\" \" middle \" \"end\"":
+  - StringLiteral: start middle end

--- a/src/tests/snapshots/cendol__tests__lexer__tests__string_literals.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__string_literals.snap
@@ -1,0 +1,9 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 160
+expression: results
+---
+"\"hello\"":
+  - StringLiteral: hello
+"\"world\\n\"":
+  - StringLiteral: "world\n"

--- a/src/tests/snapshots/cendol__tests__lexer__tests__unknown_token.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__unknown_token.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 214
+expression: unknown_tokens
+---
+- Unknown


### PR DESCRIPTION
Refactored lexer tests to use snapshots and added new test cases for edge cases.

---
*PR created automatically by Jules for task [4124955189292417722](https://jules.google.com/task/4124955189292417722) started by @fajarkudaile*