### PR TITLE
Implement sizeof support in constant evaluator

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -1320,6 +1320,7 @@ impl<'a> SemanticAnalyzer<'a> {
                     let ctx = crate::semantic::const_eval::ConstEvalCtx {
                         ast: self.ast,
                         symbol_table: self.symbol_table,
+                        registry: self.registry,
                     };
                     if let Some(val) = crate::semantic::const_eval::eval_const_expr(&ctx, *expr) {
                         let is_duplicate = if let Some(cases) = self.switch_cases.last_mut() {
@@ -1349,6 +1350,7 @@ impl<'a> SemanticAnalyzer<'a> {
                     let ctx = crate::semantic::const_eval::ConstEvalCtx {
                         ast: self.ast,
                         symbol_table: self.symbol_table,
+                        registry: self.registry,
                     };
                     if let (Some(start_val), Some(end_val)) = (
                         crate::semantic::const_eval::eval_const_expr(&ctx, *start),
@@ -1954,6 +1956,7 @@ impl<'a> SemanticAnalyzer<'a> {
             let ctx = crate::semantic::const_eval::ConstEvalCtx {
                 ast: self.ast,
                 symbol_table: self.symbol_table,
+                registry: self.registry,
             };
             let msg_kind = self.ast.get_kind(msg_ref);
             let message = if let NodeKind::Literal(literal::Literal::String(s)) = msg_kind {

--- a/src/semantic/lower_expression.rs
+++ b/src/semantic/lower_expression.rs
@@ -35,6 +35,7 @@ impl<'a> AstToMirLowerer<'a> {
             let ctx = ConstEvalCtx {
                 ast: self.ast,
                 symbol_table: self.symbol_table,
+                registry: self.registry,
             };
             if let Some(val) = eval_const_expr(&ctx, expr_ref) {
                 let ty_id = self.lower_qual_type(ty);

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -160,6 +160,7 @@ fn resolve_array_size(size: Option<ParsedNodeRef>, ctx: &mut LowerCtx) -> ArrayS
         let const_ctx = ConstEvalCtx {
             ast: ctx.ast,
             symbol_table: ctx.symbol_table,
+            registry: ctx.registry,
         };
         if let Some(val) = const_eval::eval_const_expr(&const_ctx, expr_ref) {
             if val < 0 {
@@ -711,6 +712,7 @@ fn resolve_type_specifier(
                             let const_ctx = ConstEvalCtx {
                                 ast: ctx.ast,
                                 symbol_table: ctx.symbol_table,
+                                registry: ctx.registry,
                             };
                             if let Some(val) = const_eval::eval_const_expr(&const_ctx, expr_ref) {
                                 (val, Some(expr_ref))
@@ -1007,6 +1009,7 @@ fn lower_decl_specifiers(specs: &[ParsedDeclSpecifier], ctx: &mut LowerCtx, span
                         let const_ctx = ConstEvalCtx {
                             ast: ctx.ast,
                             symbol_table: ctx.symbol_table,
+                            registry: ctx.registry,
                         };
                         if let Some(val) = const_eval::eval_const_expr(&const_ctx, lowered_expr) {
                             if val > 0 && (val as u64).is_power_of_two() {
@@ -2537,6 +2540,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                                     let const_ctx = ConstEvalCtx {
                                         ast: self.ast,
                                         symbol_table: self.symbol_table,
+                                        registry: self.registry,
                                     };
                                     if let Some(val) = const_eval::eval_const_expr(&const_ctx, *expr_ref) {
                                         current_index = val;
@@ -2548,6 +2552,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                                     let const_ctx = ConstEvalCtx {
                                         ast: self.ast,
                                         symbol_table: self.symbol_table,
+                                        registry: self.registry,
                                     };
                                     if let (Some(start_val), Some(end_val)) = (
                                         const_eval::eval_const_expr(&const_ctx, *start),

--- a/src/tests/semantic_static_assert.rs
+++ b/src/tests/semantic_static_assert.rs
@@ -1,7 +1,15 @@
 use crate::driver::artifact::CompilePhase;
-use crate::tests::semantic_common::run_fail;
+use crate::tests::semantic_common::{run_fail, run_pass};
 
 #[test]
 fn test_static_assert_fail() {
     run_fail("void main() { _Static_assert(0, \"message\"); }", CompilePhase::Mir);
+}
+
+#[test]
+fn test_static_assert_sizeof() {
+    run_pass(
+        "void main() { _Static_assert(sizeof(int) == 4, \"size of int is not 4\"); }",
+        CompilePhase::Mir,
+    );
 }


### PR DESCRIPTION
This change implements support for `sizeof` expressions in the constant evaluator, allowing their use in `_Static_assert` and other constant-expression contexts. The implementation adds `SizeOfExpr` and `SizeOfType` handlers to the `eval_const_expr` function, which now has access to the `TypeRegistry` to resolve type sizes. A new test case has been added to verify the functionality.

---
*PR created automatically by Jules for task [9534712037510406214](https://jules.google.com/task/9534712037510406214) started by @bungcip*