### PR TITLE
refactor: cleanup redundant code and fix clippy warning

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -955,7 +955,6 @@ impl<'a> SemanticAnalyzer<'a> {
                 let first_des_ref = init.designator_start;
                 if let NodeKind::Designator(Designator::FieldName(name)) = self.ast.get_kind(first_des_ref) {
                     // Check if member exists
-                    // TODO: recursive search for anonymous members if not found directly
                     let found = members.iter().any(|m| m.name == Some(*name));
 
                     if !found {

--- a/src/source_manager.rs
+++ b/src/source_manager.rs
@@ -22,7 +22,7 @@ impl SourceId {
         SourceId(NonZeroU32::new(id).expect("SourceId must be non-zero"))
     }
 
-    pub(crate) fn to_u32(&self) -> u32 {
+    pub(crate) fn to_u32(self) -> u32 {
         self.0.get()
     }
 }


### PR DESCRIPTION
This PR addresses redundant code and clippy warnings:
1.  **`src/source_manager.rs`**: Changed `SourceId::to_u32(&self)` to `SourceId::to_u32(self)`. `SourceId` is a `Copy` type (wrapper around `NonZeroU32`), so passing by value is more idiomatic and satisfies `clippy::wrong_self_convention`.
2.  **`src/semantic/analyzer.rs`**: Removed a TODO comment suggesting recursive search for anonymous members is missing. Verified that `check_initializer_item_record` receives a flattened list of members (via `flatten_members` in `src/semantic/types.rs`), which already includes members from anonymous structs/unions recursively. Thus, the local search `members.iter().any(...)` is sufficient and correct.

---
*PR created automatically by Jules for task [394251595823312699](https://jules.google.com/task/394251595823312699) started by @bungcip*