### PR TITLE
🛡️ Guardian: allow function parameter to shadow typedef

### DIFF
--- a/src/tests/semantic_typedef_variable_conflict.rs
+++ b/src/tests/semantic_typedef_variable_conflict.rs
@@ -1,5 +1,16 @@
 use crate::driver::artifact::CompilePhase;
-use crate::tests::semantic_common::run_fail_with_diagnostic;
+use crate::tests::semantic_common::{run_fail_with_diagnostic, run_pass};
+
+#[test]
+fn allows_function_parameter_to_shadow_typedef() {
+    run_pass(
+        r#"
+typedef int T;
+void foo(T T) {}
+        "#,
+        CompilePhase::Mir,
+    );
+}
 
 #[test]
 fn rejects_variable_declaration_conflicting_with_typedef() {


### PR DESCRIPTION
🧪 What: C code snippet + scenario
typedef int T;
void foo(T T) {}

🎯 Why: What bug or ambiguity this prevents
This test ensures the compiler correctly handles a valid C11 scoping rule where a function parameter's name is allowed to shadow a typedef from an outer scope. This prevents a potential regression where the compiler might incorrectly flag this as a redefinition error.

🛠️ Phase: Semantic
🔬 Verify: cargo test semantic_typedef_variable_conflict

---
*PR created automatically by Jules for task [12516532425202966137](https://jules.google.com/task/12516532425202966137) started by @bungcip*