### PR TITLE
Refactor: Reduce Visibility of Internal Lexer Function

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -811,7 +811,7 @@ impl<'src> Lexer<'src> {
     }
 
     /// Unescape C11 string literal content
-    pub fn unescape_string(s: &str) -> String {
+    pub(crate) fn unescape_string(s: &str) -> String {
         // ⚡ Bolt: Fast path for strings with no escape sequences.
         // This avoids allocating a new string and iterating over it when no
         // unescaping is necessary. It makes the common case of simple strings


### PR DESCRIPTION
This change reduces the visibility of the internal lexer helper function `Lexer::unescape_string` from `pub` to `pub(crate)`, aligning with the goal of minimizing the public API surface.

---
*PR created automatically by Jules for task [16753911536616490435](https://jules.google.com/task/16753911536616490435) started by @bungcip*