### PR TITLE
🛡️ Guardian: Protect against typedef/tag namespace collision

### DIFF
--- a/src/tests/semantic_namespace_collision.rs
+++ b/src/tests/semantic_namespace_collision.rs
@@ -1,0 +1,19 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::semantic_common::run_pass;
+
+#[test]
+fn allows_typedef_and_struct_tag_with_same_name() {
+    run_pass(
+        r#"
+typedef int T;
+struct T { int i; };
+int main() {
+    struct T var;
+    var.i = 0;
+    T other_var = 1;
+    return 0;
+}
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
🧪 **What:** Adds a new semantic test case in `src/tests/semantic_namespace_collision.rs`. The test compiles a C snippet where a `typedef` named `T` and a `struct T` are defined and used in the same scope.

🎯 **Why:** This test prevents a potential regression where the compiler might incorrectly flag a redefinition error due to confusion between the 'ordinary' and 'tag' namespaces. It explicitly safeguards the correct implementation of C11's namespace rules.

🛠️ **Phase:** Semantic Analysis

🔬 **Verify:** The test can be run using `cargo test allows_typedef_and_struct_tag_with_same_name`. The test passes, confirming the compiler behaves as expected. The full test suite was also run (skipping an unrelated failing test) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [6168544646067205434](https://jules.google.com/task/6168544646067205434) started by @bungcip*