### PR TITLE
Refactor semantic lowering helpers and type mapping

### DIFF
--- a/src/semantic/lower_expression.rs
+++ b/src/semantic/lower_expression.rs
@@ -313,7 +313,7 @@ impl<'a> AstToMirLowerer<'a> {
         let target_mir_ty = self.lower_qual_type(operand_ty);
         let operand_converted = self.apply_conversions(operand, operand_ref, target_mir_ty);
 
-        let place = Place::Deref(Box::new(operand_converted));
+        let place = self.deref_operand(operand_converted);
         Operand::Copy(Box::new(place))
     }
 
@@ -790,8 +790,7 @@ impl<'a> AstToMirLowerer<'a> {
 
             if is_arrow {
                 // Dereference: *ptr
-                let deref_op = Operand::Copy(Box::new(current_place));
-                current_place = Place::Deref(Box::new(deref_op));
+                current_place = self.deref_place(current_place);
             }
 
             for field_idx in path {

--- a/src/semantic/type_registry.rs
+++ b/src/semantic/type_registry.rs
@@ -183,6 +183,29 @@ impl TypeRegistry {
         self.alloc(ty)
     }
 
+    pub(crate) fn get_builtin_type(&self, b: BuiltinType) -> TypeRef {
+        match b {
+            BuiltinType::Void => self.type_void,
+            BuiltinType::Bool => self.type_bool,
+            BuiltinType::Char => self.type_char,
+            BuiltinType::SChar => self.type_schar,
+            BuiltinType::UChar => self.type_char_unsigned,
+            BuiltinType::Short => self.type_short,
+            BuiltinType::UShort => self.type_short_unsigned,
+            BuiltinType::Int => self.type_int,
+            BuiltinType::UInt => self.type_int_unsigned,
+            BuiltinType::Long => self.type_long,
+            BuiltinType::ULong => self.type_long_unsigned,
+            BuiltinType::LongLong => self.type_long_long,
+            BuiltinType::ULongLong => self.type_long_long_unsigned,
+            BuiltinType::Float => self.type_float,
+            BuiltinType::Double => self.type_double,
+            BuiltinType::LongDouble => self.type_long_double,
+            BuiltinType::Signed => self.type_signed,
+            BuiltinType::VaList => self.type_valist,
+        }
+    }
+
     /// Allocate a new canonical type and return its TypeRef.
     fn alloc(&mut self, ty: Type) -> TypeRef {
         let idx = self.types.len() as u32;


### PR DESCRIPTION
This PR refactors the semantic analysis lowering phase to reduce code duplication and improve maintainability, following the directives of the "Maul" persona.

Key changes:
1.  **Centralized Type Mapping:** Added `get_builtin_type` to `TypeRegistry` to handle `BuiltinType` to `TypeRef` conversion, eliminating a manual match statement in `lower_initializer.rs`.
2.  **Shared Utility:** Moved `evaluate_constant_usize` from `lower_initializer.rs` to the main `AstToMirLowerer` implementation in `ast_to_mir.rs`, making it available for other lowering contexts.
3.  **Simplified Dereferences:** Introduced `deref_place` and `deref_operand` helpers in `AstToMirLowerer` and applied them in `lower_expression.rs` to clean up verbose `Place::Deref(Box::new(...))` construction.

These changes are structural refactorings and do not affect the compiler's behavior or output. Verified with `cargo test semantic`.

---
*PR created automatically by Jules for task [1451813790699933990](https://jules.google.com/task/1451813790699933990) started by @fajarkudaile*