### PR TITLE
Refactor Lexer Tests to Snapshots

### DIFF
--- a/src/tests/lexer.rs
+++ b/src/tests/lexer.rs
@@ -1,5 +1,4 @@
 use crate::driver::artifact::CompilePhase;
-use crate::intern::StringId;
 use crate::lexer::*;
 use crate::tests::test_utils;
 
@@ -29,6 +28,14 @@ fn setup_lexer_with_eof(source: &str, include_eof: bool) -> Vec<TokenKind> {
     }
 }
 
+/// Helper function to batch process lexer inputs for snapshot testing
+fn setup_lexer_snapshot(inputs: Vec<&str>) -> Vec<(&str, Vec<TokenKind>)> {
+    inputs
+        .into_iter()
+        .map(|input| (input, setup_lexer(input)))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,174 +55,61 @@ mod tests {
             "_Noreturn", "_Static_assert", "_Thread_local",
         ];
 
-        for keyword in keywords {
-            let symbol = StringId::new(keyword);
-            let expected_kind =
-                crate::lexer::is_keyword(symbol).unwrap_or_else(|| panic!("{} should be a keyword", keyword));
-
-            let token_kinds = setup_lexer(keyword);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for keyword: {}", keyword);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for keyword: {}", keyword);
-        }
+        let results = setup_lexer_snapshot(keywords);
+        insta::assert_yaml_snapshot!(results);
     }
 
     #[test]
     fn test_operators_and_punctuation() {
         let operators = vec![
-            ("+", TokenKind::Plus),
-            ("-", TokenKind::Minus),
-            ("*", TokenKind::Star),
-            ("/", TokenKind::Slash),
-            ("%", TokenKind::Percent),
-            ("&", TokenKind::And),
-            ("|", TokenKind::Or),
-            ("^", TokenKind::Xor),
-            ("!", TokenKind::Not),
-            ("~", TokenKind::Tilde),
-            ("<", TokenKind::Less),
-            (">", TokenKind::Greater),
-            ("<=", TokenKind::LessEqual),
-            (">=", TokenKind::GreaterEqual),
-            ("==", TokenKind::Equal),
-            ("!=", TokenKind::NotEqual),
-            ("<<", TokenKind::LeftShift),
-            (">>", TokenKind::RightShift),
-            ("=", TokenKind::Assign),
-            ("+=", TokenKind::PlusAssign),
-            ("-=", TokenKind::MinusAssign),
-            ("*=", TokenKind::StarAssign),
-            ("/=", TokenKind::DivAssign),
-            ("%=", TokenKind::ModAssign),
-            ("&=", TokenKind::AndAssign),
-            ("|=", TokenKind::OrAssign),
-            ("^=", TokenKind::XorAssign),
-            ("<<=", TokenKind::LeftShiftAssign),
-            (">>=", TokenKind::RightShiftAssign),
-            ("++", TokenKind::Increment),
-            ("--", TokenKind::Decrement),
-            ("->", TokenKind::Arrow),
-            (".", TokenKind::Dot),
-            ("?", TokenKind::Question),
-            (":", TokenKind::Colon),
-            (",", TokenKind::Comma),
-            (";", TokenKind::Semicolon),
-            ("(", TokenKind::LeftParen),
-            (")", TokenKind::RightParen),
-            ("[", TokenKind::LeftBracket),
-            ("]", TokenKind::RightBracket),
-            ("{", TokenKind::LeftBrace),
-            ("}", TokenKind::RightBrace),
-            ("...", TokenKind::Ellipsis),
-            ("&&", TokenKind::LogicAnd),
-            ("||", TokenKind::LogicOr),
+            "+", "-", "*", "/", "%", "&", "|", "^", "!", "~", "<", ">", "<=", ">=", "==", "!=",
+            "<<", ">>", "=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=",
+            "++", "--", "->", ".", "?", ":", ",", ";", "(", ")", "[", "]", "{", "}", "...",
+            "&&", "||",
         ];
 
-        for (text, expected_kind) in operators {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for operator: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for operator: {}", text);
-        }
+        let results = setup_lexer_snapshot(operators);
+        insta::assert_yaml_snapshot!(results);
     }
 
     #[test]
     fn test_literals() {
-        use crate::ast::literal::IntegerSuffix;
         // Integer constants
         let int_literals = vec![
-            ("42", TokenKind::IntegerConstant(42, None)),
-            ("0x1A", TokenKind::IntegerConstant(26, None)),
-            ("077", TokenKind::IntegerConstant(63, None)),
+            "42", "0x1A", "077",
             // C11 integer suffixes - decimal
-            ("1ll", TokenKind::IntegerConstant(1, Some(IntegerSuffix::LL))),
-            ("42u", TokenKind::IntegerConstant(42, Some(IntegerSuffix::U))),
-            ("123l", TokenKind::IntegerConstant(123, Some(IntegerSuffix::L))),
-            ("456ul", TokenKind::IntegerConstant(456, Some(IntegerSuffix::UL))),
-            ("789lu", TokenKind::IntegerConstant(789, Some(IntegerSuffix::UL))),
-            ("1000ull", TokenKind::IntegerConstant(1000, Some(IntegerSuffix::ULL))),
-            ("2000llu", TokenKind::IntegerConstant(2000, Some(IntegerSuffix::ULL))),
+            "1ll", "42u", "123l", "456ul", "789lu", "1000ull", "2000llu",
             // C11 integer suffixes - hexadecimal
-            ("0x1Au", TokenKind::IntegerConstant(26, Some(IntegerSuffix::U))),
-            ("0xFFll", TokenKind::IntegerConstant(255, Some(IntegerSuffix::LL))),
-            ("0x10UL", TokenKind::IntegerConstant(16, Some(IntegerSuffix::UL))),
-            ("0x20LU", TokenKind::IntegerConstant(32, Some(IntegerSuffix::UL))),
-            ("0x40ULL", TokenKind::IntegerConstant(64, Some(IntegerSuffix::ULL))),
-            ("0x80LLU", TokenKind::IntegerConstant(128, Some(IntegerSuffix::ULL))),
+            "0x1Au", "0xFFll", "0x10UL", "0x20LU", "0x40ULL", "0x80LLU",
             // C11 integer suffixes - octal
-            ("077u", TokenKind::IntegerConstant(63, Some(IntegerSuffix::U))),
-            ("0123l", TokenKind::IntegerConstant(83, Some(IntegerSuffix::L))),
-            ("0777ul", TokenKind::IntegerConstant(511, Some(IntegerSuffix::UL))),
-            ("0123lu", TokenKind::IntegerConstant(83, Some(IntegerSuffix::UL))),
-            ("0777ull", TokenKind::IntegerConstant(511, Some(IntegerSuffix::ULL))),
-            ("0123llu", TokenKind::IntegerConstant(83, Some(IntegerSuffix::ULL))),
+            "077u", "0123l", "0777ul", "0123lu", "0777ull", "0123llu",
             // Case insensitive suffixes
-            ("1LL", TokenKind::IntegerConstant(1, Some(IntegerSuffix::LL))),
-            ("42U", TokenKind::IntegerConstant(42, Some(IntegerSuffix::U))),
-            ("123L", TokenKind::IntegerConstant(123, Some(IntegerSuffix::L))),
-            ("456UL", TokenKind::IntegerConstant(456, Some(IntegerSuffix::UL))),
-            ("789LU", TokenKind::IntegerConstant(789, Some(IntegerSuffix::UL))),
-            ("1000ULL", TokenKind::IntegerConstant(1000, Some(IntegerSuffix::ULL))),
-            ("2000LLU", TokenKind::IntegerConstant(2000, Some(IntegerSuffix::ULL))),
+            "1LL", "42U", "123L", "456UL", "789LU", "1000ULL", "2000LLU",
         ];
-
-        for (text, expected_kind) in int_literals {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for integer literal: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for integer literal: {}", text);
-        }
 
         // Float constants
-        let float_literals = vec![
-            ("1.5", TokenKind::FloatConstant(1.5, None)),
-            ("1.23e-4", TokenKind::FloatConstant(1.23e-4, None)),
-            ("0x1.2p3", TokenKind::FloatConstant(9.0, None)),
-        ];
-
-        for (text, expected_kind) in float_literals {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for float literal: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for float literal: {}", text);
-        }
+        let float_literals = vec!["1.5", "1.23e-4", "0x1.2p3"];
 
         // Character constants
-        let char_literals = vec![
-            ("'a'", TokenKind::CharacterConstant(97)),   // 'a' = 97
-            ("'\\n'", TokenKind::CharacterConstant(10)), // '\n' = 10
-        ];
-
-        for (text, expected_kind) in char_literals {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for character literal: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for character literal: {}", text);
-        }
+        let char_literals = vec!["'a'", "'\\n'"];
 
         // String literals
-        let string_literals = vec![
-            ("\"hello\"", TokenKind::StringLiteral(StringId::new("hello"))),
-            ("\"world\\n\"", TokenKind::StringLiteral(StringId::new("world\n"))),
-        ];
+        let string_literals = vec!["\"hello\"", "\"world\\n\""];
 
-        for (text, expected_kind) in string_literals {
-            let token_kinds = setup_lexer(text);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for string literal: {}", text);
-            assert_eq!(token_kinds[0], expected_kind, "Failed for string literal: {}", text);
-        }
+        let mut results = Vec::new();
+        results.push(("Integers", setup_lexer_snapshot(int_literals)));
+        results.push(("Floats", setup_lexer_snapshot(float_literals)));
+        results.push(("Chars", setup_lexer_snapshot(char_literals)));
+        results.push(("Strings", setup_lexer_snapshot(string_literals)));
+
+        insta::assert_yaml_snapshot!(results);
     }
 
     #[test]
     fn test_identifiers() {
         let identifiers = vec!["variable", "my_var", "_private", "var123", "a", "_"];
-
-        for ident in identifiers {
-            let symbol = StringId::new(ident);
-            let token_kinds = setup_lexer(ident);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for identifier: {}", ident);
-            assert_eq!(
-                token_kinds[0],
-                TokenKind::Identifier(symbol),
-                "Failed for identifier: {}",
-                ident
-            );
-        }
+        let results = setup_lexer_snapshot(identifiers);
+        insta::assert_yaml_snapshot!(results);
     }
 
     #[test]
@@ -223,72 +117,34 @@ mod tests {
         // Test adjacent string literal concatenation (C11 6.4.5)
         let test_cases = vec![
             // Basic concatenation
-            ("\"hello\" \"world\"", "helloworld"),
+            "\"hello\" \"world\"",
             // With whitespace between
-            ("\"hello\"   \"world\"", "helloworld"),
+            "\"hello\"   \"world\"",
             // Multiple concatenations
-            ("\"a\" \"b\" \"c\"", "abc"),
+            "\"a\" \"b\" \"c\"",
             // With escape sequences
-            ("\"hello\\n\" \"world\"", "hello\nworld"),
+            "\"hello\\n\" \"world\"",
             // Mixed quotes and content
-            ("\"start\" \" middle \" \"end\"", "start middle end"),
+            "\"start\" \" middle \" \"end\"",
         ];
 
-        for (input, expected_content) in test_cases {
-            let token_kinds = setup_lexer(input);
-            assert_eq!(
-                token_kinds.len(),
-                1,
-                "Expected 1 token for concatenated string: {}",
-                input
-            );
-
-            match &token_kinds[0] {
-                TokenKind::StringLiteral(symbol) => {
-                    let actual_content = symbol.as_str();
-                    assert_eq!(
-                        actual_content, expected_content,
-                        "String concatenation failed for input: {}",
-                        input
-                    );
-                }
-                _ => panic!("Expected StringLiteral token for input: {}", input),
-            }
-        }
+        let results = setup_lexer_snapshot(test_cases);
+        insta::assert_yaml_snapshot!(results);
 
         // Test that non-adjacent strings are not concatenated
-        let token_kinds = setup_lexer("\"hello\" ; \"world\"");
-        assert_eq!(token_kinds.len(), 3, "Expected 3 tokens for non-adjacent strings");
-        assert!(
-            matches!(token_kinds[0], TokenKind::StringLiteral(_)),
-            "First token should be string literal"
-        );
-        assert_eq!(token_kinds[1], TokenKind::Semicolon, "Second token should be semicolon");
-        assert!(
-            matches!(token_kinds[2], TokenKind::StringLiteral(_)),
-            "Third token should be string literal"
-        );
+        let non_adjacent = setup_lexer("\"hello\" ; \"world\"");
+        insta::assert_yaml_snapshot!(non_adjacent);
     }
 
     #[test]
     fn test_special_tokens() {
         // EndOfFile - empty string should produce EndOfFile when included
-        let token_kinds = setup_lexer_with_eof("", true);
-        assert_eq!(token_kinds.len(), 1, "Expected 1 token for empty string");
-        assert_eq!(
-            token_kinds[0],
-            TokenKind::EndOfFile,
-            "Empty string should produce EndOfFile"
-        );
+        let empty_tokens = setup_lexer_with_eof("", true);
 
         // Unknown - unrecognized character should produce Unknown
-        let token_kinds = setup_lexer("@");
-        assert_eq!(token_kinds.len(), 1, "Expected 1 token for unknown character");
-        assert_eq!(
-            token_kinds[0],
-            TokenKind::Unknown,
-            "Unrecognized character should produce Unknown"
-        );
+        let unknown_tokens = setup_lexer("@");
+
+        insta::assert_yaml_snapshot!((empty_tokens, unknown_tokens));
     }
 
     #[test]
@@ -296,25 +152,17 @@ mod tests {
         // Test edge cases in string literal unescaping
         let test_cases = vec![
             // \x with no digits - should keep the x
-            ("\"\\xg\"", "\\xg"),
+            "\"\\xg\"",
             // \x with invalid unicode value (overflow) - should use replacement character
             // \x110000 is > 0x10FFFF
-            ("\"\\x110000\"", "\u{FFFD}"),
+            "\"\\x110000\"",
             // \? escape
-            ("\"\\?\"", "?"),
+            "\"\\?\"",
             // Unknown escape sequence (e.g. \q) - should keep the character
-            ("\"\\q\"", "q"),
+            "\"\\q\"",
         ];
 
-        for (input, expected) in test_cases {
-            let token_kinds = setup_lexer(input);
-            assert_eq!(token_kinds.len(), 1, "Expected 1 token for input: {}", input);
-
-            if let TokenKind::StringLiteral(sid) = token_kinds[0] {
-                assert_eq!(sid.as_str(), expected, "Failed for input: {}", input);
-            } else {
-                panic!("Expected StringLiteral for input: {}", input);
-            }
-        }
+        let results = setup_lexer_snapshot(test_cases);
+        insta::assert_yaml_snapshot!(results);
     }
 }

--- a/src/tests/snapshots/cendol__tests__lexer__tests__c11_keywords.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__c11_keywords.snap
@@ -1,0 +1,91 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 60
+expression: results
+---
+- - auto
+  - - Auto
+- - break
+  - - Break
+- - case
+  - - Case
+- - char
+  - - Char
+- - const
+  - - Const
+- - continue
+  - - Continue
+- - default
+  - - Default
+- - do
+  - - Do
+- - double
+  - - Double
+- - else
+  - - Else
+- - enum
+  - - Enum
+- - extern
+  - - Extern
+- - float
+  - - Float
+- - for
+  - - For
+- - goto
+  - - Goto
+- - if
+  - - If
+- - inline
+  - - Inline
+- - int
+  - - Int
+- - long
+  - - Long
+- - register
+  - - Register
+- - restrict
+  - - Restrict
+- - return
+  - - Return
+- - short
+  - - Short
+- - signed
+  - - Signed
+- - sizeof
+  - - Sizeof
+- - static
+  - - Static
+- - struct
+  - - Struct
+- - switch
+  - - Switch
+- - typedef
+  - - Typedef
+- - union
+  - - Union
+- - unsigned
+  - - Unsigned
+- - void
+  - - Void
+- - volatile
+  - - Volatile
+- - while
+  - - While
+- - _Alignas
+  - - Alignas
+- - _Alignof
+  - - Alignof
+- - _Atomic
+  - - Atomic
+- - _Bool
+  - - Bool
+- - _Complex
+  - - Complex
+- - _Generic
+  - - Generic
+- - _Noreturn
+  - - Noreturn
+- - _Static_assert
+  - - StaticAssert
+- - _Thread_local
+  - - ThreadLocal

--- a/src/tests/snapshots/cendol__tests__lexer__tests__identifiers.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__identifiers.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 113
+expression: results
+---
+- - variable
+  - - Identifier: variable
+- - my_var
+  - - Identifier: my_var
+- - _private
+  - - Identifier: _private
+- - var123
+  - - Identifier: var123
+- - a
+  - - Identifier: a
+- - _
+  - - Identifier: _

--- a/src/tests/snapshots/cendol__tests__lexer__tests__literals.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__literals.snap
@@ -1,0 +1,145 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 106
+expression: results
+---
+- - Integers
+  - - - "42"
+      - - IntegerConstant:
+            - 42
+            - ~
+    - - "0x1A"
+      - - IntegerConstant:
+            - 26
+            - ~
+    - - "077"
+      - - IntegerConstant:
+            - 63
+            - ~
+    - - 1ll
+      - - IntegerConstant:
+            - 1
+            - LL
+    - - 42u
+      - - IntegerConstant:
+            - 42
+            - U
+    - - 123l
+      - - IntegerConstant:
+            - 123
+            - L
+    - - 456ul
+      - - IntegerConstant:
+            - 456
+            - UL
+    - - 789lu
+      - - IntegerConstant:
+            - 789
+            - UL
+    - - 1000ull
+      - - IntegerConstant:
+            - 1000
+            - ULL
+    - - 2000llu
+      - - IntegerConstant:
+            - 2000
+            - ULL
+    - - "0x1Au"
+      - - IntegerConstant:
+            - 26
+            - U
+    - - "0xFFll"
+      - - IntegerConstant:
+            - 255
+            - LL
+    - - "0x10UL"
+      - - IntegerConstant:
+            - 16
+            - UL
+    - - "0x20LU"
+      - - IntegerConstant:
+            - 32
+            - UL
+    - - "0x40ULL"
+      - - IntegerConstant:
+            - 64
+            - ULL
+    - - "0x80LLU"
+      - - IntegerConstant:
+            - 128
+            - ULL
+    - - 077u
+      - - IntegerConstant:
+            - 63
+            - U
+    - - 0123l
+      - - IntegerConstant:
+            - 83
+            - L
+    - - 0777ul
+      - - IntegerConstant:
+            - 511
+            - UL
+    - - 0123lu
+      - - IntegerConstant:
+            - 83
+            - UL
+    - - 0777ull
+      - - IntegerConstant:
+            - 511
+            - ULL
+    - - 0123llu
+      - - IntegerConstant:
+            - 83
+            - ULL
+    - - 1LL
+      - - IntegerConstant:
+            - 1
+            - LL
+    - - 42U
+      - - IntegerConstant:
+            - 42
+            - U
+    - - 123L
+      - - IntegerConstant:
+            - 123
+            - L
+    - - 456UL
+      - - IntegerConstant:
+            - 456
+            - UL
+    - - 789LU
+      - - IntegerConstant:
+            - 789
+            - UL
+    - - 1000ULL
+      - - IntegerConstant:
+            - 1000
+            - ULL
+    - - 2000LLU
+      - - IntegerConstant:
+            - 2000
+            - ULL
+- - Floats
+  - - - "1.5"
+      - - FloatConstant:
+            - 1.5
+            - ~
+    - - "1.23e-4"
+      - - FloatConstant:
+            - 0.000123
+            - ~
+    - - "0x1.2p3"
+      - - FloatConstant:
+            - 9
+            - ~
+- - Chars
+  - - - "'a'"
+      - - CharacterConstant: 97
+    - - "'\\n'"
+      - - CharacterConstant: 10
+- - Strings
+  - - - "\"hello\""
+      - - StringLiteral: hello
+    - - "\"world\\n\""
+      - - StringLiteral: "world\n"

--- a/src/tests/snapshots/cendol__tests__lexer__tests__operators_and_punctuation.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__operators_and_punctuation.snap
@@ -1,0 +1,97 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 73
+expression: results
+---
+- - +
+  - - Plus
+- - "-"
+  - - Minus
+- - "*"
+  - - Star
+- - /
+  - - Slash
+- - "%"
+  - - Percent
+- - "&"
+  - - And
+- - "|"
+  - - Or
+- - ^
+  - - Xor
+- - "!"
+  - - Not
+- - "~"
+  - - Tilde
+- - "<"
+  - - Less
+- - ">"
+  - - Greater
+- - "<="
+  - - LessEqual
+- - ">="
+  - - GreaterEqual
+- - "=="
+  - - Equal
+- - "!="
+  - - NotEqual
+- - "<<"
+  - - LeftShift
+- - ">>"
+  - - RightShift
+- - "="
+  - - Assign
+- - +=
+  - - PlusAssign
+- - "-="
+  - - MinusAssign
+- - "*="
+  - - StarAssign
+- - /=
+  - - DivAssign
+- - "%="
+  - - ModAssign
+- - "&="
+  - - AndAssign
+- - "|="
+  - - OrAssign
+- - ^=
+  - - XorAssign
+- - "<<="
+  - - LeftShiftAssign
+- - ">>="
+  - - RightShiftAssign
+- - ++
+  - - Increment
+- - "--"
+  - - Decrement
+- - "->"
+  - - Arrow
+- - "."
+  - - Dot
+- - "?"
+  - - Question
+- - ":"
+  - - Colon
+- - ","
+  - - Comma
+- - ;
+  - - Semicolon
+- - (
+  - - LeftParen
+- - )
+  - - RightParen
+- - "["
+  - - LeftBracket
+- - "]"
+  - - RightBracket
+- - "{"
+  - - LeftBrace
+- - "}"
+  - - RightBrace
+- - "..."
+  - - Ellipsis
+- - "&&"
+  - - LogicAnd
+- - "||"
+  - - LogicOr

--- a/src/tests/snapshots/cendol__tests__lexer__tests__special_tokens.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__special_tokens.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 148
+expression: "(empty_tokens, unknown_tokens)"
+---
+- - EndOfFile
+- - Unknown

--- a/src/tests/snapshots/cendol__tests__lexer__tests__string_escapes_edge_cases.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__string_escapes_edge_cases.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 167
+expression: results
+---
+- - "\"\\xg\""
+  - - StringLiteral: "\\xg"
+- - "\"\\x110000\""
+  - - StringLiteral: �
+- - "\"\\?\""
+  - - StringLiteral: "?"
+- - "\"\\q\""
+  - - StringLiteral: q

--- a/src/tests/snapshots/cendol__tests__lexer__tests__string_literal_concatenation-2.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__string_literal_concatenation-2.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 137
+expression: non_adjacent
+---
+- StringLiteral: hello
+- Semicolon
+- StringLiteral: world

--- a/src/tests/snapshots/cendol__tests__lexer__tests__string_literal_concatenation.snap
+++ b/src/tests/snapshots/cendol__tests__lexer__tests__string_literal_concatenation.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/lexer.rs
+assertion_line: 133
+expression: results
+---
+- - "\"hello\" \"world\""
+  - - StringLiteral: helloworld
+- - "\"hello\"   \"world\""
+  - - StringLiteral: helloworld
+- - "\"a\" \"b\" \"c\""
+  - - StringLiteral: abc
+- - "\"hello\\n\" \"world\""
+  - - StringLiteral: "hello\nworld"
+- - "\"start\" \" middle \" \"end\""
+  - - StringLiteral: start middle end


### PR DESCRIPTION
Refactored `src/tests/lexer.rs` to use `cargo-insta` snapshots for all test cases. This replaces manual `assert_eq!` loops with data-driven snapshot tests, covering keywords, operators, literals (int, float, char, string), identifiers, and edge cases like string concatenation and escapes. Added a helper `setup_lexer_snapshot` to facilitate this. Verified all tests pass.

---
*PR created automatically by Jules for task [16082479472311266729](https://jules.google.com/task/16082479472311266729) started by @fajarkudaile*