### PR TITLE
⚡ Bolt: optimize preprocessor recursion check and lexer allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-07-25 - Two-Pass Allocation for Sequential Items
 **Learning:** A common performance anti-pattern in this codebase is processing a peekable iterator in a single pass, where an intermediate collection (like a `String` or `Vec`) is built up, leading to multiple costly reallocations.
 **Action:** For future optimizations involving sequential item processing, I will favor a two-pass approach. First, iterate (or peek ahead) to calculate the final required capacity. Second, perform a single allocation with `with_capacity`. Third, iterate again to populate the collection. This avoids N reallocations, providing a significant performance improvement.
+
+## 2026-01-31 - Path Comparison and Loop Invariant Hoisting
+**Learning:** Calling `format!` and `to_string_lossy()` inside a hot loop (like `is_recursive_expansion`) is a major performance bottleneck due to repeated heap allocations. Direct `Path` comparison is faster as it avoids allocations when the path is already UTF-8.
+**Action:** Always hoist `format!` and other allocations out of loops. Prefer `Path` comparison over string conversion when dealing with file paths.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -756,7 +756,10 @@ impl PPLexer {
     where
         F: FnMut(&mut S, u8) -> bool,
     {
-        let mut chars = vec![first_ch];
+        // ⚡ Bolt: Pre-allocate the vector with a reasonable capacity to avoid
+        // multiple reallocations during identifier/number lexing.
+        let mut chars = Vec::with_capacity(32);
+        chars.push(first_ch);
         while let Some(ch) = self.peek_char() {
             if pred(&mut state, ch) {
                 chars.push(self.next_char().unwrap());
@@ -860,7 +863,9 @@ impl PPLexer {
     }
 
     fn lex_identifier(&mut self, start_pos: u32, first_ch: u8, flags: PPTokenFlags) -> PPToken {
-        let mut text = String::new();
+        // ⚡ Bolt: Pre-allocate the string with a reasonable capacity to avoid
+        // multiple reallocations during identifier lexing.
+        let mut text = String::with_capacity(32);
         let mut length = 0u16;
 
         // Handle first character

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -2767,20 +2767,17 @@ impl<'src> Preprocessor<'src> {
                                             // Check if we are at the start (ignoring processed tokens) and it looks like a header
                                             // If args[0] is '<' or string literal, we stop immediately.
                                             // Note: We check j==0 because we only care if the *result* starts with header.
-                                            if j == 0 && !args.is_empty() {
-                                                if args[0].kind == PPTokenKind::Less
-                                                    || matches!(args[0].kind, PPTokenKind::StringLiteral(_))
-                                                {
-                                                    break;
-                                                }
+                                            if j == 0
+                                                && !args.is_empty()
+                                                && (args[0].kind == PPTokenKind::Less
+                                                    || matches!(args[0].kind, PPTokenKind::StringLiteral(_)))
+                                            {
+                                                break;
                                             }
 
                                             // Try expand args[j]
                                             // We manually expand one step
-                                            let expanded_opt = match self.expand_macro(&args[j]) {
-                                                Ok(e) => e,
-                                                Err(_) => None,
-                                            };
+                                            let expanded_opt = self.expand_macro(&args[j]).unwrap_or_default();
 
                                             if let Some(expanded) = expanded_opt {
                                                 // Splice
@@ -3018,15 +3015,19 @@ impl<'src> Preprocessor<'src> {
 
         // println!("Checking recursion for {} starting at {:?}", macro_name, current_id);
 
+        // ⚡ Bolt: Optimized to avoid allocating a String with `format!` in a loop.
+        // We pre-calculate the expected virtual path and use direct `Path` comparison,
+        // which is faster and avoids unnecessary string conversions.
+        let expected_name = format!("<macro_{}>", macro_name);
+        let expected_path = Path::new(&expected_name);
+
         while depth < MAX_DEPTH {
             if let Some(file_info) = self.source_manager.get_file_info(current_id) {
                 // println!("  Depth {}: Path {}", depth, file_info.path.display());
 
                 // Check if this file is a virtual buffer for the macro
                 // Virtual buffers for macros are named "<macro_{name}>"
-                let expected_name = format!("<macro_{}>", macro_name);
-                let path_str = file_info.path.to_string_lossy();
-                if path_str == expected_name {
+                if file_info.path == expected_path {
                     // println!("  -> FOUND RECURSION");
                     return true;
                 }


### PR DESCRIPTION
This PR implements several small but impactful performance optimizations in the preprocessor and lexer:

1.  **Hoisted `format!` in `is_recursive_expansion`**: The `format!` call was moved outside the loop to avoid allocating a new `String` on every iteration of the recursion check (which is called for every identifier during macro expansion).
2.  **Fast Path Comparison**: Replaced `to_string_lossy()` and string comparison with direct `Path` comparison in `is_recursive_expansion`, avoiding unnecessary UTF-8 validation and allocations.
3.  **Pre-allocated Lexer Buffers**: Added `with_capacity(32)` to the buffers used for lexing identifiers and numbers in `PPLexer`, reducing reallocations for the most common token lengths.
4.  **Clippy Cleanups**: Fixed collapsible `if` and manual `unwrap_or_default` warnings in `preprocessor.rs` to maintain code health.

These changes reduce allocation pressure in the hottest paths of the preprocessor.

---
*PR created automatically by Jules for task [7370234627888193088](https://jules.google.com/task/7370234627888193088) started by @bungcip*