### PR TITLE
Verify c-testsuite/00130.c and fix clippy warnings

### DIFF
--- a/.jules/reno.md
+++ b/.jules/reno.md
@@ -36,3 +36,4 @@ c-testsuite/tests/single-exec/00200.c
 c-testsuite/tests/single-exec/00124.c
 c-testsuite/tests/single-exec/00040.c
 c-testsuite/tests/single-exec/00050.c
+c-testsuite/tests/single-exec/00130.c

--- a/src/ast/literal_parsing.rs
+++ b/src/ast/literal_parsing.rs
@@ -201,10 +201,7 @@ fn parse_hex_float_literal(text: &str) -> Option<f64> {
         while let Some(&c) = chars.peek() {
             if let Some(digit) = c.to_digit(10) {
                 // Use checked arithmetic to prevent overflow, replicating .parse() behavior.
-                exp_val = match exp_val.checked_mul(10).and_then(|v| v.checked_add(digit as i32)) {
-                    Some(val) => val,
-                    None => return None, // Overflow
-                };
+                exp_val = exp_val.checked_mul(10).and_then(|v| v.checked_add(digit as i32))?;
                 exp_digits += 1;
                 chars.next();
             } else {

--- a/src/driver/cli.rs
+++ b/src/driver/cli.rs
@@ -332,8 +332,8 @@ mod tests {
         let config = cli.into_config().expect("Failed to create config");
 
         assert_eq!(config.stop_after, CompilePhase::Mir);
-        assert_eq!(config.verbose, true);
-        assert_eq!(config.suppress_line_markers, true);
+        assert!(config.verbose);
+        assert!(config.suppress_line_markers);
         assert_eq!(config.preprocessor.max_include_depth, 50);
         assert_eq!(config.target.to_string(), "x86_64-unknown-linux-gnu");
 

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -2044,10 +2044,10 @@ impl<'a> SemanticAnalyzer<'a> {
                     }
 
                     // Constraint 1: The controlling expression... shall have type compatible with at most one...
-                    if self.registry.is_compatible(unqualified_ctrl_ty, unqualified_assoc_ty) {
-                        if selected_expr_ref.is_none() {
-                            selected_expr_ref = Some(ga.result_expr);
-                        }
+                    if self.registry.is_compatible(unqualified_ctrl_ty, unqualified_assoc_ty)
+                        && selected_expr_ref.is_none()
+                    {
+                        selected_expr_ref = Some(ga.result_expr);
                     }
                 } else {
                     // This is the 'default' association.

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -71,6 +71,7 @@ impl Type {
         flat_offsets: &mut Vec<u16>,
         base_offset: u16,
     ) {
+        #[allow(clippy::collapsible_if)]
         if let TypeKind::Record { members, .. } = &self.kind {
             if let Some(TypeLayout {
                 kind: LayoutKind::Record { fields, .. },

--- a/src/tests/pp_macros.rs
+++ b/src/tests/pp_macros.rs
@@ -159,8 +159,10 @@ fn test_redefine_builtin_macro_should_fail() {
 #define __DATE__ "123"
 __DATE__
 "#;
-    let mut config = PPConfig::default();
-    config.current_time = Some(Utc.with_ymd_and_hms(2026, 1, 28, 0, 0, 0).unwrap());
+    let config = PPConfig {
+        current_time: Some(Utc.with_ymd_and_hms(2026, 1, 28, 0, 0, 0).unwrap()),
+        ..PPConfig::default()
+    };
     let (tokens, diags) = setup_pp_snapshot_with_diags_and_config(src, Some(config));
     insta::assert_yaml_snapshot!((tokens, diags), @r#"
     - - kind: StringLiteral


### PR DESCRIPTION
This change verifies `c-testsuite/tests/single-exec/00130.c` (multidimensional arrays and pointers) and adds it to the list of fixed files. It also cleans up several `cargo clippy` warnings found during validation.

---
*PR created automatically by Jules for task [12848591416615102067](https://jules.google.com/task/12848591416615102067) started by @fajarkudaile*