### PR TITLE
Fix variadic macro flags and named argument handling

### DIFF
--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -3080,7 +3080,9 @@ impl<'src> Preprocessor<'src> {
                         PPTokenKind::RightParen => break,
                         PPTokenKind::Ellipsis => {
                             variadic = Some(sym);
-                            flags |= MacroFlags::C99_VARARGS;
+                            // Remove the parameter from the list as it is variadic
+                            params.pop();
+                            flags |= MacroFlags::GNU_VARARGS;
                             let rparen = self.lex_token().ok_or(PPError::UnexpectedEndOfFile)?;
                             if rparen.kind != PPTokenKind::RightParen {
                                 return Err(PPError::InvalidMacroParameter {
@@ -3100,7 +3102,7 @@ impl<'src> Preprocessor<'src> {
                     }
                 }
                 PPTokenKind::Ellipsis => {
-                    flags |= MacroFlags::GNU_VARARGS;
+                    flags |= MacroFlags::C99_VARARGS;
                     variadic = Some(StringId::new("__VA_ARGS__"));
                     let rparen = self.lex_token().ok_or(PPError::UnexpectedEndOfFile)?;
                     if rparen.kind != PPTokenKind::RightParen {

--- a/src/tests/pp_macros.rs
+++ b/src/tests/pp_macros.rs
@@ -239,3 +239,38 @@ OK
       text: OK
     "#);
 }
+
+// GNU Extensions
+#[test]
+fn test_gnu_named_variadic_macros() {
+    let src = r#"
+#define M(a, args...) args
+M(1, 2, 3, 4)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: Number
+      text: "2"
+    - kind: Comma
+      text: ","
+    - kind: Number
+      text: "3"
+    - kind: Comma
+      text: ","
+    - kind: Number
+      text: "4"
+    "#);
+}
+
+#[test]
+fn test_gnu_comma_swallowing() {
+    let src = r#"
+#define M(a, args...) a, ## args
+M(1)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: Number
+      text: "1"
+    "#);
+}


### PR DESCRIPTION
This PR fixes a bug in the preprocessor where C11 and GNU variadic macro flags were swapped. It also fixes the handling of GNU named variadic macros (e.g. `#define M(args...) args`) which were incorrectly treating the variadic identifier as a regular parameter, causing incomplete expansion. The fix ensures named variadic arguments are properly recognized and allows GNU comma swallowing extension to work correctly.

---
*PR created automatically by Jules for task [1652499398192357986](https://jules.google.com/task/1652499398192357986) started by @fajarkudaile*