### PR TITLE
Fix integer promotion for unary + and - operators

### DIFF
--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -258,6 +258,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             ast: self.ast,
             symbol_table: self.symbol_table,
             registry: self.registry,
+            semantic_info: None,
         }
     }
 }
@@ -999,6 +1000,7 @@ fn lower_decl_specifiers(specs: &[ParsedDeclSpecifier], ctx: &mut LowerCtx, span
                             ast: ctx.ast,
                             symbol_table: ctx.symbol_table,
                             registry: ctx.registry,
+                            semantic_info: None,
                         };
                         if let Some(val) = const_eval::eval_const_expr(&const_ctx, lowered_expr) {
                             if val > 0 && (val as u64).is_power_of_two() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -38,6 +38,7 @@ pub mod semantic_lowering;
 pub mod semantic_mir;
 pub mod semantic_negative;
 pub mod semantic_regr_comma;
+pub mod semantic_regr_unary_promotion;
 pub mod semantic_validation;
 
 pub mod parser_decl;

--- a/src/tests/semantic_regr_unary_promotion.rs
+++ b/src/tests/semantic_regr_unary_promotion.rs
@@ -1,0 +1,55 @@
+use crate::tests::test_utils::run_pipeline_to_mir;
+
+#[test]
+fn test_unary_promotion_small_types() {
+    let src = r#"
+        #define IS_INT(x) _Generic((x), int: 1, default: 0)
+
+        void test() {
+            unsigned short us = 1;
+            short s = 1;
+            unsigned char uc = 1;
+            signed char sc = 1;
+            char c = 1;
+
+            // Unary + should promote to int
+            _Static_assert(IS_INT(+us), "+unsigned short should be int");
+            _Static_assert(IS_INT(+s), "+short should be int");
+            _Static_assert(IS_INT(+uc), "+unsigned char should be int");
+            _Static_assert(IS_INT(+sc), "+signed char should be int");
+            _Static_assert(IS_INT(+c), "+char should be int");
+
+            // Unary - should promote to int
+            _Static_assert(IS_INT(-us), "-unsigned short should be int");
+            _Static_assert(IS_INT(-s), "-short should be int");
+            _Static_assert(IS_INT(-uc), "-unsigned char should be int");
+            _Static_assert(IS_INT(-sc), "-signed char should be int");
+            _Static_assert(IS_INT(-c), "-char should be int");
+        }
+    "#;
+    run_pipeline_to_mir(src);
+}
+
+#[test]
+fn test_unary_promotion_no_promote() {
+    let src = r#"
+        #define IS_LONG(x) _Generic((x), long: 1, default: 0)
+        #define IS_ULONG(x) _Generic((x), unsigned long: 1, default: 0)
+        #define IS_LLONG(x) _Generic((x), long long: 1, default: 0)
+
+        void test() {
+            long l = 1;
+            unsigned long ul = 1;
+            long long ll = 1;
+
+            // Unary + should preserve larger types (but strip qualifiers if any)
+            _Static_assert(IS_LONG(+l), "+long should be long");
+            _Static_assert(IS_ULONG(+ul), "+unsigned long should be unsigned long");
+            _Static_assert(IS_LLONG(+ll), "+long long should be long long");
+
+            _Static_assert(IS_LONG(-l), "-long should be long");
+            _Static_assert(IS_ULONG(-ul), "-unsigned long should be unsigned long");
+        }
+    "#;
+    run_pipeline_to_mir(src);
+}


### PR DESCRIPTION
Implemented integer promotion for unary plus and minus operators in `src/semantic/analyzer.rs` and ensured their application in `src/semantic/lower_expression.rs`. Extended `ConstEvalCtx` to support `_Generic` selection evaluation by accessing `SemanticInfo`. Added a regression test suite `src/tests/semantic_regr_unary_promotion.rs` utilizing `_Static_assert` and `_Generic` to verify the fix.

---
*PR created automatically by Jules for task [18404773944799003237](https://jules.google.com/task/18404773944799003237) started by @bungcip*