### PR TITLE
feat(pp): implement C11 null directive

### DIFF
--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -949,6 +949,7 @@ impl<'src> Preprocessor<'src> {
                     }
                 }
             }
+            PPTokenKind::Eod => Ok(()),
             _ => {
                 self.report_diagnostic_simple(
                     DiagnosticLevel::Error,
@@ -2022,6 +2023,7 @@ impl<'src> Preprocessor<'src> {
             match token.kind {
                 PPTokenKind::Hash if i + 1 < macro_info.tokens.len() => {
                     let next = &macro_info.tokens[i + 1];
+                    #[allow(clippy::collapsible_if)]
                     if let PPTokenKind::Identifier(sym) = next.kind {
                         if let Some(arg) = self.get_macro_param_tokens(macro_info, sym, args, token.location) {
                             result.push(self.stringify_tokens(&arg, token.location)?);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,6 +21,7 @@ pub mod pp_internal;
 pub mod pp_lexical;
 pub mod pp_macros;
 pub mod pp_misc;
+pub mod pp_null_directive;
 pub mod pp_output_dump;
 pub mod pp_pragma;
 

--- a/src/tests/pp_null_directive.rs
+++ b/src/tests/pp_null_directive.rs
@@ -1,0 +1,12 @@
+use crate::tests::pp_common::setup_pp_snapshot_with_diags;
+
+#[test]
+fn test_null_directive() {
+    let src = r#"
+#
+#
+OK
+"#;
+    let (tokens, diags) = setup_pp_snapshot_with_diags(src);
+    insta::assert_yaml_snapshot!((tokens, diags));
+}

--- a/src/tests/snapshots/cendol__tests__pp_null_directive__null_directive.snap
+++ b/src/tests/snapshots/cendol__tests__pp_null_directive__null_directive.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/pp_null_directive.rs
+expression: "(tokens, diags)"
+---
+- - kind: Identifier
+    text: OK
+- []


### PR DESCRIPTION
Implemented C11 null directive support (Section 6.10.7) where a `#` followed by a newline is treated as a no-op instead of an error. Added a regression test to verify correct behavior.

---
*PR created automatically by Jules for task [17179488924304160189](https://jules.google.com/task/17179488924304160189) started by @fajarkudaile*