### PR TITLE
Fix AST dumper snapshot tests due to TypeRef ID shift

### DIFF
--- a/src/tests/driver_ast_dumper.rs
+++ b/src/tests/driver_ast_dumper.rs
@@ -285,9 +285,9 @@ fn test_dump_parsed_ast_with_switch() {
 #[test]
 fn test_dump_parser_ast() {
     let output = dump_parser_ast("int main() { return 0; }");
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     1: TranslationUnit(decls=2..2) (parser kind)
-    2: Function(name=main, symbol=1, ty=TypeRef(base=19, class=Function, ptr=0, arr=None), params=[], body=4)
+    2: Function(name=main, symbol=1, ty=TypeRef(base=20, class=Function, ptr=0, arr=None), params=[], body=4)
     3: LiteralString(main)
     4: CompoundStatement(stmts=5..5)
     5: Return(6)
@@ -298,10 +298,10 @@ fn test_dump_parser_ast() {
 #[test]
 fn test_dump_parser_ast_with_functions() {
     let output = dump_parser_ast("int add(int a, int b) { return a + b; } int main() { return add(2, 3); }");
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     1: TranslationUnit(decls=2..3) (parser kind)
-    2: Function(name=add, symbol=1, ty=TypeRef(base=19, class=Function, ptr=0, arr=None), params=5..6, body=7)
-    3: Function(name=main, symbol=5, ty=TypeRef(base=20, class=Function, ptr=0, arr=None), params=[], body=13)
+    2: Function(name=add, symbol=1, ty=TypeRef(base=20, class=Function, ptr=0, arr=None), params=5..6, body=7)
+    3: Function(name=main, symbol=5, ty=TypeRef(base=21, class=Function, ptr=0, arr=None), params=[], body=13)
     4: LiteralString(add)
     5: Param(symbol=3, ty=QualType(8))
     6: Param(symbol=4, ty=QualType(8))
@@ -323,11 +323,12 @@ fn test_dump_parser_ast_with_functions() {
 #[test]
 fn test_dump_type_registry() {
     let output = dump_type_registry("int main() { int x = 42; float y = 3.14; return x + (int)y; }");
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
+
     === TypeRegistry (Used TypeRefs) ===
     TypeRef(8): int
     TypeRef(14): float
-    TypeRef(19): int()
+    TypeRef(20): int()
     ");
 }
 
@@ -336,11 +337,12 @@ fn test_dump_type_registry_with_complex_types() {
     let output = dump_type_registry(
         "struct Point { int x; int y; }; int main() { struct Point p = {1, 2}; int *ptr = &p.x; float arr[10]; return 0; }",
     );
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
+
     === TypeRegistry (Used TypeRefs) ===
     TypeRef(8): int
-    TypeRef(20): int()
-    TypeRef(19): struct Point
+    TypeRef(21): int()
+    TypeRef(20): struct Point
     TypeRef(8): int*
     TypeRef(14): float[10]
     ");
@@ -353,13 +355,13 @@ fn test_dump_parser_ast_with_designated_initializers() {
     );
     insta::assert_snapshot!(output, @r#"
     1: TranslationUnit(decls=2..3) (parser kind)
-    2: RecordDecl(name=Some("Point"), ty=1048595, is_union=false, members=4..5)
-    3: Function(name=main, symbol=2, ty=TypeRef(base=20, class=Function, ptr=0, arr=None), params=[], body=7)
+    2: RecordDecl(name=Some("Point"), ty=1048596, is_union=false, members=4..5)
+    3: Function(name=main, symbol=2, ty=TypeRef(base=21, class=Function, ptr=0, arr=None), params=[], body=7)
     4: FieldDecl(name=Some("x"), ty=Int)
     5: FieldDecl(name=Some("y"), ty=Int)
     6: LiteralString(main)
     7: CompoundStatement(stmts=8..10)
-    8: VarDecl(name=p, ty=TypeRef(base=19, class=Record, ptr=0, arr=None), storage=None)
+    8: VarDecl(name=p, ty=TypeRef(base=20, class=Record, ptr=0, arr=None), storage=None)
     9: VarDecl(name=arr, ty=TypeRef(base=8, class=Array, ptr=0, arr=Some(5)), storage=None)
     10: Return(28)
     11: InitializerList(inits=12..13)


### PR DESCRIPTION
Updated snapshot tests in `src/tests/driver_ast_dumper.rs` to account for shifted `TypeRef` IDs caused by the addition of a new builtin type (`Complex` marker). Verified that all tests pass.

---
*PR created automatically by Jules for task [14620239271083725437](https://jules.google.com/task/14620239271083725437) started by @bungcip*