### PR TITLE
Verify support for string literals and pointer indexing (00026.c)

### DIFF
--- a/.jules/reno.md
+++ b/.jules/reno.md
@@ -37,3 +37,4 @@ c-testsuite/tests/single-exec/00124.c
 c-testsuite/tests/single-exec/00040.c
 c-testsuite/tests/single-exec/00050.c
 c-testsuite/tests/single-exec/00130.c
+c-testsuite/tests/single-exec/00026.c


### PR DESCRIPTION
Verified support for `c-testsuite/tests/single-exec/00026.c` which tests string literals and pointer indexing. The file compiled and executed with the expected return code (0) without any compiler changes, confirming existing support. Added the file to the tracking list.

---
*PR created automatically by Jules for task [13938257071744584303](https://jules.google.com/task/13938257071744584303) started by @fajarkudaile*