### PR TITLE
Refactor codegen tests to use snapshots and ensure deterministic IR

### DIFF
--- a/src/tests/codegen_calls.rs
+++ b/src/tests/codegen_calls.rs
@@ -2,6 +2,7 @@
 use crate::ast::NameId;
 use crate::mir::codegen::{ClifOutput, EmitKind, MirToCraneliftLowerer};
 use crate::mir::{CallTarget, MirModuleId, MirStmt, MirType, Operand, Place, Terminator};
+use crate::tests::test_utils;
 
 #[test]
 fn test_indirect_function_call() {
@@ -88,8 +89,7 @@ fn test_indirect_function_call() {
 
     match result {
         Ok(ClifOutput::ClifDump(clif_ir)) => {
-            println!("{}", clif_ir);
-            assert!(clif_ir.contains("call_indirect"), "Expected call_indirect instruction");
+            insta::assert_snapshot!(test_utils::sort_clif_ir(&clif_ir));
         }
         Ok(ClifOutput::ObjectFile(_)) => panic!("Expected Clif dump"),
         Err(e) => panic!("Error: {}", e),
@@ -133,7 +133,10 @@ fn test_global_function_pointer_init() {
     let result = lowerer.compile_module(EmitKind::Clif);
 
     match result {
-        Ok(_) => (), // Success if no panic
+        Ok(ClifOutput::ClifDump(clif_ir)) => {
+            insta::assert_snapshot!(test_utils::sort_clif_ir(&clif_ir));
+        }
+        Ok(ClifOutput::ObjectFile(_)) => panic!("Expected Clif dump"),
         Err(e) => panic!("Compilation failed: {}", e),
     }
 }

--- a/src/tests/codegen_switch.rs
+++ b/src/tests/codegen_switch.rs
@@ -1,5 +1,6 @@
 //! Tests for switch statement codegen
 use crate::tests::codegen_common::setup_cranelift;
+use crate::tests::test_utils;
 
 #[test]
 fn test_switch_unreachable_cases() {
@@ -23,15 +24,5 @@ fn test_switch_unreachable_cases() {
     "#;
 
     let clif_ir = setup_cranelift(source);
-    println!("{}", clif_ir);
-
-    // Count calls to printf.
-    // There should be 3 calls (one for each case).
-    // If cases are skipped, there will be fewer calls.
-    let call_count = clif_ir.matches("call_indirect").count();
-    assert_eq!(
-        call_count, 3,
-        "Expected 3 calls to printf, found {}. Missing cases?",
-        call_count
-    );
+    insta::assert_snapshot!(test_utils::sort_clif_ir(&clif_ir));
 }

--- a/src/tests/snapshots/cendol__tests__codegen_basics__boolean_logic_lowering.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_basics__boolean_logic_lowering.snap
@@ -1,0 +1,90 @@
+---
+source: src/tests/codegen_basics.rs
+assertion_line: 172
+expression: clif_dump
+---
+; Function: main
+function u0:0() -> i32 system_v {
+    ss0 = explicit_slot 4
+    ss1 = explicit_slot 4
+    ss2 = explicit_slot 4
+    ss3 = explicit_slot 4
+    ss4 = explicit_slot 4
+    ss5 = explicit_slot 4
+
+block0:
+    v0 = iconst.i32 4
+    v48 = stack_addr.i64 ss0
+    store notrap v0, v48  ; v0 = 4
+    v47 = stack_addr.i64 ss0
+    v1 = load.i32 notrap v47
+    v2 = iconst.i32 0
+    v3 = icmp eq v1, v2  ; v2 = 0
+    v4 = iconst.i32 1
+    v5 = iconst.i32 0
+    v6 = select v3, v4, v5  ; v4 = 1, v5 = 0
+    v46 = stack_addr.i64 ss1
+    store notrap v6, v46
+    v45 = stack_addr.i64 ss1
+    v7 = load.i32 notrap v45
+    v8 = iconst.i32 0
+    v9 = icmp ne v7, v8  ; v8 = 0
+    v10 = iconst.i32 1
+    v11 = iconst.i32 0
+    v12 = select v9, v10, v11  ; v10 = 1, v11 = 0
+    v44 = stack_addr.i64 ss2
+    store notrap v12, v44
+    v43 = stack_addr.i64 ss2
+    v13 = load.i32 notrap v43
+    brif v13, block1, block2
+
+block2:
+    jump block3
+
+block3:
+    v42 = stack_addr.i64 ss0
+    v14 = load.i32 notrap v42
+    v15 = iconst.i32 0
+    v16 = icmp eq v14, v15  ; v15 = 0
+    v17 = iconst.i32 1
+    v18 = iconst.i32 0
+    v19 = select v16, v17, v18  ; v17 = 1, v18 = 0
+    v41 = stack_addr.i64 ss3
+    store notrap v19, v41
+    v40 = stack_addr.i64 ss3
+    v20 = load.i32 notrap v40
+    v21 = iconst.i32 0
+    v22 = icmp eq v20, v21  ; v21 = 0
+    v23 = iconst.i32 1
+    v24 = iconst.i32 0
+    v25 = select v22, v23, v24  ; v23 = 1, v24 = 0
+    v39 = stack_addr.i64 ss4
+    store notrap v25, v39
+    v38 = stack_addr.i64 ss4
+    v26 = load.i32 notrap v38
+    v27 = iconst.i32 1
+    v28 = icmp ne v26, v27  ; v27 = 1
+    v29 = iconst.i32 1
+    v30 = iconst.i32 0
+    v31 = select v28, v29, v30  ; v29 = 1, v30 = 0
+    v37 = stack_addr.i64 ss5
+    store notrap v31, v37
+    v36 = stack_addr.i64 ss5
+    v32 = load.i32 notrap v36
+    brif v32, block4, block5
+
+block5:
+    jump block6
+
+block6:
+    v33 = iconst.i32 0
+    return v33  ; v33 = 0
+
+block4:
+    v34 = iconst.i32 1
+    return v34  ; v34 = 1
+
+block1:
+    v35 = iconst.i32 1
+    return v35  ; v35 = 1
+}

--- a/src/tests/snapshots/cendol__tests__codegen_basics__f128_constant_promotion.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_basics__f128_constant_promotion.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/codegen_basics.rs
+assertion_line: 221
+expression: clif_ir
+---
+; Function: main
+function u0:0() system_v {
+    ss0 = explicit_slot 16
+    gv0 = symbol colocated userextname0
+
+block0:
+    v0 = symbol_value.i64 gv0
+    v1 = load.f128 readonly v0
+    v2 = stack_addr.i64 ss0
+    store notrap v1, v2
+    return
+}

--- a/src/tests/snapshots/cendol__tests__codegen_basics__float_to_char_conversion.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_basics__float_to_char_conversion.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/codegen_basics.rs
+assertion_line: 186
+expression: clif_dump
+---
+; Function: main
+function u0:0() -> i32 system_v {
+    ss0 = explicit_slot 1
+    ss1 = explicit_slot 2
+
+block0:
+    v0 = f64const 0x1.8400000000000p6
+    v1 = fcvt_to_uint.i32 v0  ; v0 = 0x1.8400000000000p6
+    v2 = ireduce.i8 v1
+    v8 = stack_addr.i64 ss0
+    store notrap v2, v8
+    v3 = f64const 0x1.8800000000000p6
+    v4 = fcvt_to_uint.i32 v3  ; v3 = 0x1.8800000000000p6
+    v5 = ireduce.i16 v4
+    v7 = stack_addr.i64 ss1
+    store notrap v5, v7
+    v6 = iconst.i32 0
+    return v6  ; v6 = 0
+}

--- a/src/tests/snapshots/cendol__tests__codegen_basics__store_deref_pointer.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_basics__store_deref_pointer.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/codegen_basics.rs
+assertion_line: 152
+expression: clif_ir
+---
+; Function: main
+function u0:0() system_v {
+    ss0 = explicit_slot 4
+    ss1 = explicit_slot 8
+
+block0:
+    v0 = iconst.i32 10
+    v6 = stack_addr.i64 ss0
+    store notrap v0, v6  ; v0 = 10
+    v1 = stack_addr.i64 ss0
+    v5 = stack_addr.i64 ss1
+    store notrap v1, v5
+    v2 = iconst.i32 42
+    v4 = stack_addr.i64 ss1
+    v3 = load.i64 notrap v4
+    store v2, v3  ; v2 = 42
+    return
+}

--- a/src/tests/snapshots/cendol__tests__codegen_basics__store_statement_lowering.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_basics__store_statement_lowering.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/codegen_basics.rs
+assertion_line: 98
+expression: clif_ir
+---
+; Function: main
+function u0:0() system_v {
+    ss0 = explicit_slot 4
+
+block0:
+    v0 = iconst.i32 42
+    v1 = stack_addr.i64 ss0
+    store notrap v0, v1  ; v0 = 42
+    return
+}

--- a/src/tests/snapshots/cendol__tests__codegen_calls__global_function_pointer_init.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_calls__global_function_pointer_init.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/codegen_calls.rs
+assertion_line: 136
+expression: clif_ir
+---
+; Function: target
+function u0:0(i32) -> i32 system_v {
+    ss0 = explicit_slot 4
+
+block0(v0: i32):
+    v2 = stack_addr.i64 ss0
+    store notrap v0, v2
+    v1 = iconst.i32 0
+    return v1  ; v1 = 0
+}

--- a/src/tests/snapshots/cendol__tests__codegen_calls__indirect_function_call.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_calls__indirect_function_call.snap
@@ -1,0 +1,40 @@
+---
+source: src/tests/codegen_calls.rs
+assertion_line: 92
+expression: "test_utils::sort_clif_ir(&clif_ir)"
+---
+; Function: main
+function u0:0() -> i32 system_v {
+    ss0 = explicit_slot 8
+    ss1 = explicit_slot 4
+    sig0 = (i32) -> i32 system_v
+    sig1 = (i32) -> i32 system_v
+    fn0 = colocated u0:0 sig0
+
+block0:
+    v0 = func_addr.i64 fn0
+    v8 = stack_addr.i64 ss0
+    store notrap v0, v8
+    v7 = stack_addr.i64 ss0
+    v1 = load.i64 notrap v7
+    v2 = iconst.i32 42
+    v3 = call_indirect sig1, v1(v2)  ; v2 = 42
+    v6 = stack_addr.i64 ss1
+    store notrap v3, v6
+    v5 = stack_addr.i64 ss1
+    v4 = load.i32 notrap v5
+    return v4
+}
+
+
+; Function: target
+function u0:0(i32) -> i32 system_v {
+    ss0 = explicit_slot 4
+
+block0(v0: i32):
+    v3 = stack_addr.i64 ss0
+    store notrap v0, v3
+    v2 = stack_addr.i64 ss0
+    v1 = load.i32 notrap v2
+    return v1
+}

--- a/src/tests/snapshots/cendol__tests__codegen_switch__switch_unreachable_cases.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_switch__switch_unreachable_cases.snap
@@ -1,0 +1,93 @@
+---
+source: src/tests/codegen_switch.rs
+assertion_line: 27
+expression: "test_utils::sort_clif_ir(&clif_ir)"
+---
+; Function: main
+function u0:0() -> i32 system_v {
+    ss0 = explicit_slot 4
+    ss1 = explicit_slot 1
+    ss2 = explicit_slot 1
+    gv0 = symbol colocated userextname0
+    gv1 = symbol colocated userextname3
+    gv2 = symbol colocated userextname4
+    sig0 = (i64) -> i32 system_v
+    sig1 = (i64) -> i32 system_v
+    sig2 = (i64, i64) -> i64, i64 system_v
+    sig3 = (i64) -> i32 system_v
+    sig4 = (i64) -> i32 system_v
+    sig5 = (i64, i64) -> i64, i64 system_v
+    sig6 = (i64) -> i32 system_v
+    sig7 = (i64) -> i32 system_v
+    sig8 = (i64, i64) -> i64, i64 system_v
+    fn0 = u0:1 sig0
+    fn1 = colocated u0:2 sig2
+    fn2 = u0:1 sig3
+    fn3 = colocated u0:2 sig5
+    fn4 = u0:1 sig6
+    fn5 = colocated u0:2 sig8
+
+block0:
+    v0 = iconst.i32 0
+    v42 = stack_addr.i64 ss0
+    store notrap v0, v42  ; v0 = 0
+    v41 = stack_addr.i64 ss0
+    v1 = load.i32 notrap v41
+    v2 = iconst.i32 1
+    v3 = icmp eq v1, v2  ; v2 = 1
+    v4 = iconst.i8 1
+    v5 = iconst.i8 0
+    v6 = select v3, v4, v5  ; v4 = 1, v5 = 0
+    v40 = stack_addr.i64 ss1
+    store notrap v6, v40
+    v39 = stack_addr.i64 ss1
+    v7 = load.i8 notrap v39
+    v8 = uextend.i32 v7
+    brif v8, block2, block5
+
+block5:
+    v38 = stack_addr.i64 ss0
+    v9 = load.i32 notrap v38
+    v10 = iconst.i32 2
+    v11 = icmp eq v9, v10  ; v10 = 2
+    v12 = iconst.i8 1
+    v13 = iconst.i8 0
+    v14 = select v11, v12, v13  ; v12 = 1, v13 = 0
+    v37 = stack_addr.i64 ss2
+    store notrap v14, v37
+    v36 = stack_addr.i64 ss2
+    v15 = load.i8 notrap v36
+    v16 = uextend.i32 v15
+    brif v16, block3, block6
+
+block6:
+    jump block4
+
+block4:
+    v17 = symbol_value.i64 gv0
+    v18 = func_addr.i64 fn0
+    v19 = iconst.i64 0
+    v20, v21 = call fn1(v19, v18)  ; v19 = 0
+    v22 = call_indirect sig1, v21(v17)
+    jump block1
+
+block1:
+    v23 = iconst.i32 0
+    return v23  ; v23 = 0
+
+block3:
+    v24 = symbol_value.i64 gv1
+    v25 = func_addr.i64 fn2
+    v26 = iconst.i64 0
+    v27, v28 = call fn3(v26, v25)  ; v26 = 0
+    v29 = call_indirect sig4, v28(v24)
+    jump block1
+
+block2:
+    v30 = symbol_value.i64 gv2
+    v31 = func_addr.i64 fn4
+    v32 = iconst.i64 0
+    v33, v34 = call fn5(v32, v31)  ; v32 = 0
+    v35 = call_indirect sig7, v34(v30)
+    jump block1
+}

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -21,3 +21,35 @@ pub(crate) fn run_pipeline_to_mir(source: &str) -> PipelineOutputs {
     }
     result.unwrap()
 }
+
+pub(crate) fn sort_clif_ir(ir: &str) -> String {
+    let chunks: Vec<&str> = ir.split("\n\n").collect();
+    let mut functions = Vec::new();
+    let mut current_function = String::new();
+
+    for chunk in chunks {
+        if chunk.trim().is_empty() {
+            continue;
+        }
+
+        if chunk.starts_with("; Function:") {
+            if !current_function.is_empty() {
+                functions.push(current_function);
+            }
+            current_function = chunk.to_string();
+        } else {
+            if !current_function.is_empty() {
+                current_function.push_str("\n\n");
+                current_function.push_str(chunk);
+            } else {
+                current_function = chunk.to_string();
+            }
+        }
+    }
+    if !current_function.is_empty() {
+        functions.push(current_function);
+    }
+
+    functions.sort();
+    functions.join("\n\n")
+}


### PR DESCRIPTION
This PR improves the testing strategy for the backend codegen by:
1.  Migrating assertion-based tests in `src/tests/codegen_basics.rs`, `src/tests/codegen_switch.rs`, and `src/tests/codegen_calls.rs` to snapshot tests using `cargo-insta`. This provides full verification of the generated Cranelift IR instead of fragile substring checks.
2.  Fixing a non-determinism issue in `MirToCraneliftLowerer::compile_module` in `src/mir/codegen.rs`. Previously, it iterated over `HashMap`s for declarations, leading to unstable `FuncId` and `DataId` assignments. It now iterates over `MirModule` vectors (`functions` and `globals`) which preserve declaration order.
3.  Adding a `sort_clif_ir` utility in `src/tests/test_utils.rs` to sort multi-function IR dumps textually, further stabilizing snapshots against block reordering (though the primary fix handles the ID stability).

Tests verified:
- `cargo test codegen` passes with stable snapshots.

---
*PR created automatically by Jules for task [14109317770020394451](https://jules.google.com/task/14109317770020394451) started by @fajarkudaile*