### PR TITLE
Cleanup: Remove dead code in LangOptions and SourceManager

### DIFF
--- a/src/lang_options.rs
+++ b/src/lang_options.rs
@@ -24,12 +24,6 @@ pub struct LangOptions {
 }
 
 impl LangOptions {
-    pub(crate) fn c11() -> Self {
-        LangOptions {
-            c_standard: Some(CStandard::C11),
-        }
-    }
-
     /// Check if C11 standard is enabled
     pub(crate) fn is_c11(&self) -> bool {
         matches!(self.c_standard, Some(CStandard::C11))
@@ -42,7 +36,9 @@ mod tests {
 
     #[test]
     fn test_lang_options_c11() {
-        let options = LangOptions::c11();
+        let options = LangOptions {
+            c_standard: Some(CStandard::C11),
+        };
         assert!(options.is_c11());
         assert_eq!(options.c_standard, Some(CStandard::C11));
     }

--- a/src/source_manager.rs
+++ b/src/source_manager.rs
@@ -422,6 +422,7 @@ impl SourceManager {
 
     /// Get the source text for a given span
     /// Since we only support UTF-8, we can assume the bytes are valid UTF-8
+    #[cfg(test)]
     pub(crate) fn get_source_text(&self, span: SourceSpan) -> &str {
         let buffer = self.get_buffer(span.source_id());
         let start = span.start().offset() as usize;

--- a/src/tests/pp_lexical.rs
+++ b/src/tests/pp_lexical.rs
@@ -1,5 +1,5 @@
 use crate::ast::StringId;
-use crate::lang_options::LangOptions;
+use crate::lang_options::{CStandard, LangOptions};
 use crate::pp::PPConfig;
 use crate::pp::{PPTokenFlags, PPTokenKind};
 use crate::test_tokens;
@@ -382,7 +382,9 @@ int u32 = 1;
 #endif
 "#;
     let config = PPConfig {
-        lang_options: LangOptions::c11(),
+        lang_options: LangOptions {
+            c_standard: Some(CStandard::C11),
+        },
         ..Default::default()
     };
     let (tokens, _) = setup_preprocessor_test_with_diagnostics(src, Some(config)).unwrap();


### PR DESCRIPTION
This PR addresses cleanup tasks identified by Rendi.

1.  **`src/lang_options.rs`**: Removed `LangOptions::c11()`. This helper was only used in tests, and direct struct initialization is cleaner and avoids dead code warnings in the main build.
2.  **`src/source_manager.rs`**: Added `#[cfg(test)]` to `get_source_text`. This method is useful for tests but unused in the compiler's main execution path, triggering warnings.
3.  **`src/tests/pp_lexical.rs`**: Updated to reflect the removal of `LangOptions::c11()`.

Verification:
- `cargo check` passes with no warnings.
- `cargo test` passes.


---
*PR created automatically by Jules for task [5017175788695330841](https://jules.google.com/task/5017175788695330841) started by @bungcip*