### PR TITLE
Fix deterministic Clif dump generation and update snapshots

### DIFF
--- a/src/mir/codegen.rs
+++ b/src/mir/codegen.rs
@@ -2567,7 +2567,11 @@ impl MirToCraneliftLowerer {
         } else {
             // For Clif dump, concatenate all function IRs
             let mut clif_dump = String::new();
-            for (func_name, func_ir) in &self.compiled_functions {
+            let mut func_names: Vec<_> = self.compiled_functions.keys().collect();
+            func_names.sort();
+
+            for func_name in func_names {
+                let func_ir = self.compiled_functions.get(func_name).unwrap();
                 clif_dump.push_str(&format!("; Function: {}\n", func_name));
                 clif_dump.push_str(func_ir);
                 clif_dump.push_str("\n\n");

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -569,8 +569,6 @@ impl<'src> Preprocessor<'src> {
         }
     }
 
-    /// Convert a list of tokens to a path string
-
     /// Check if a header exists
     pub(crate) fn check_header_exists(&self, path: &str, is_angled: bool) -> bool {
         let current_dir = self

--- a/src/tests/snapshots/cendol__tests__codegen_calls__indirect_function_call.snap
+++ b/src/tests/snapshots/cendol__tests__codegen_calls__indirect_function_call.snap
@@ -26,7 +26,6 @@ block0:
     return v4
 }
 
-
 ; Function: target
 function u0:0(i32) -> i32 system_v {
     ss0 = explicit_slot 4

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -32,11 +32,11 @@ pub(crate) fn sort_clif_ir(ir: &str) -> String {
             continue;
         }
 
-        if chunk.starts_with("; Function:") {
+        if chunk.trim_start().starts_with("; Function:") {
             if !current_function.is_empty() {
                 functions.push(current_function);
             }
-            current_function = chunk.to_string();
+            current_function = chunk.trim_start().to_string();
         } else {
             if !current_function.is_empty() {
                 current_function.push_str("\n\n");


### PR DESCRIPTION
This PR fixes a test failure in `tests::codegen_calls::test_indirect_function_call` caused by non-deterministic order of functions in the generated Clif IR dump.

The issue stemmed from iterating over a `HashMap` in `compile_module`, which produced random function order. This PR:
1.  Sorts function names in `compile_module` before generating the dump.
2.  Improves `test_utils::sort_clif_ir` to robustly handle whitespace when splitting chunks, ensuring the test utility itself sorts correctly even if the input format varies slightly.
3.  Updates the relevant snapshot to reflect the consistent output.
4.  Cleans up a minor clippy warning.

---
*PR created automatically by Jules for task [14634656774879942346](https://jules.google.com/task/14634656774879942346) started by @bungcip*