### PR TITLE
Fix preprocessor token pasting with empty macro arguments

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,6 +23,7 @@ pub mod pp_macros;
 pub mod pp_misc;
 pub mod pp_null_directive;
 pub mod pp_output_dump;
+pub mod pp_placemarker;
 pub mod pp_pragma;
 
 pub mod semantic_arrays;

--- a/src/tests/pp_placemarker.rs
+++ b/src/tests/pp_placemarker.rs
@@ -1,0 +1,42 @@
+use crate::tests::pp_common::setup_pp_snapshot;
+
+#[test]
+fn test_placemarker_concatenation() {
+    let src = r#"
+#define M(a, b) a ## b
+M(, 1)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: Number
+      text: "1"
+    "#);
+}
+
+#[test]
+fn test_placemarker_concatenation_with_prefix() {
+    let src = r#"
+#define M(a, b) X a ## b
+M(, 1)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: Identifier
+      text: X
+    - kind: Number
+      text: "1"
+    "#);
+}
+
+#[test]
+fn test_placemarker_concatenation_chained() {
+    let src = r#"
+#define M(a, b, c) a ## b ## c
+M(, , C)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: Identifier
+      text: C
+    "#);
+}


### PR DESCRIPTION
Fix preprocessor token pasting with empty macro arguments (placemarkers)

---
*PR created automatically by Jules for task [16815097969210909552](https://jules.google.com/task/16815097969210909552) started by @fajarkudaile*