### PR TITLE
Refactor semantic tests to use snapshot testing

### DIFF
--- a/src/tests/semantic_regr_comma.rs
+++ b/src/tests/semantic_regr_comma.rs
@@ -1,4 +1,4 @@
-use crate::tests::test_utils::run_pipeline_to_mir;
+use crate::tests::semantic_common::setup_mir;
 
 #[test]
 fn test_comma_operator_crash() {
@@ -11,7 +11,39 @@ fn test_comma_operator_crash() {
             return 0;
         }
     "#;
-    run_pipeline_to_mir(src);
+    let mir = setup_mir(src);
+    insta::assert_snapshot!(mir, @r"
+    type %t0 = i32
+    type %t1 = void
+    type %t2 = i8
+    type %t3 = ptr<%t2>
+
+    fn main() -> i32
+    {
+
+      bb2:
+        return const 0
+    }
+
+    fn test(%param0: ptr<i8>, %param1: ptr<i8>) -> void
+    {
+      locals {
+        %3: ptr<i8>
+        %4: ptr<i8>
+        %5: ptr<i8>
+        %6: ptr<i8>
+      }
+
+      bb1:
+        %3 = %param0
+        %4 = ptradd(%param0, const 1)
+        %param0 = %4
+        %5 = %param1
+        %6 = ptradd(%param1, const 1)
+        %param1 = %6
+        return
+    }
+    ");
 }
 
 #[test]
@@ -24,7 +56,34 @@ fn test_comma_operator_types() {
             char *q = (x++, p);
         }
     "#;
-    run_pipeline_to_mir(src);
+    let mir = setup_mir(src);
+    insta::assert_snapshot!(mir, @r"
+    type %t0 = void
+    type %t1 = i32
+    type %t2 = i8
+    type %t3 = ptr<%t2>
+    type %t4 = ptr<%t0>
+
+    fn test() -> void
+    {
+      locals {
+        %x: i32
+        %p: ptr<i8>
+        %q: ptr<i8>
+        %4: i32
+        %5: i32
+      }
+
+      bb1:
+        %x = const 0
+        %p = cast<ptr<i8>>(const 0)
+        %4 = %x
+        %5 = %x + const 1
+        %x = %5
+        %q = %p
+        return
+    }
+    ");
 }
 
 #[test]
@@ -35,5 +94,42 @@ fn test_comma_operator_loop() {
                 ;
         }
     "#;
-    run_pipeline_to_mir(src);
+    let mir = setup_mir(src);
+    insta::assert_snapshot!(mir, @r"
+    type %t0 = void
+    type %t1 = i8
+    type %t2 = ptr<%t1>
+    type %t3 = i32
+
+    fn loop(%param0: ptr<i8>, %param1: ptr<i8>) -> void
+    {
+      locals {
+        %3: ptr<i8>
+        %4: ptr<i8>
+        %5: ptr<i8>
+        %6: ptr<i8>
+      }
+
+      bb1:
+        br bb2
+
+      bb2:
+        cond_br deref(%param1), bb3, bb5
+
+      bb3:
+        br bb4
+
+      bb4:
+        %3 = %param1
+        %4 = ptradd(%param1, const 1)
+        %param1 = %4
+        %5 = %param0
+        %6 = ptradd(%param0, const 1)
+        %param0 = %6
+        br bb2
+
+      bb5:
+        return
+    }
+    ");
 }


### PR DESCRIPTION
This PR refactors several test modules to use snapshot testing with `cargo-insta`. This improves test coverage and maintainability by verifying the full structure of the generated MIR and diagnostics, rather than relying on fragile manual assertions or simple crash checks. The affected modules are `semantic_expr.rs`, `semantic_functions.rs`, and `semantic_regr_comma.rs`.

---
*PR created automatically by Jules for task [11171048958853035849](https://jules.google.com/task/11171048958853035849) started by @fajarkudaile*