### PR TITLE
Cleanup unused code warnings

### DIFF
--- a/src/lang_options.rs
+++ b/src/lang_options.rs
@@ -24,6 +24,7 @@ pub struct LangOptions {
 }
 
 impl LangOptions {
+    #[cfg(test)]
     pub(crate) fn c11() -> Self {
         LangOptions {
             c_standard: Some(CStandard::C11),

--- a/src/source_manager.rs
+++ b/src/source_manager.rs
@@ -422,6 +422,7 @@ impl SourceManager {
 
     /// Get the source text for a given span
     /// Since we only support UTF-8, we can assume the bytes are valid UTF-8
+    #[cfg(test)]
     pub(crate) fn get_source_text(&self, span: SourceSpan) -> &str {
         let buffer = self.get_buffer(span.source_id());
         let start = span.start().offset() as usize;


### PR DESCRIPTION
Audited the codebase for unused code. Identified `LangOptions::c11` and `SourceManager::get_source_text` as unused in production code but required for tests. Marked them with `#[cfg(test)]` to prevent compiler warnings while maintaining test functionality. Verified that other reported unused items were false positives (e.g. trait implementations).

---
*PR created automatically by Jules for task [18351633304102897954](https://jules.google.com/task/18351633304102897954) started by @bungcip*