### PR TITLE
⚡ Bolt: Use Arc<[u8]> for source buffers to avoid redundant clones

### DIFF
--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -1,6 +1,7 @@
 use crate::ast::StringId;
 use crate::ast::literal_parsing;
 use crate::source_manager::{SourceId, SourceLoc};
+use std::sync::Arc;
 
 // Packed token flags for preprocessor tokens
 bitflags::bitflags! {
@@ -178,7 +179,7 @@ impl PPToken {
 /// Manages lexing from different source buffers
 pub(crate) struct PPLexer {
     pub(crate) source_id: SourceId,
-    buffer: Vec<u8>,
+    buffer: Arc<[u8]>,
     pub(crate) position: u32, // its okay to use u32 here since source files are limited to 4 MB
     line_starts: Vec<u32>,
     put_back_token: Option<PPToken>,
@@ -188,7 +189,7 @@ pub(crate) struct PPLexer {
 }
 
 impl PPLexer {
-    pub(crate) fn new(source_id: SourceId, buffer: Vec<u8>) -> Self {
+    pub(crate) fn new(source_id: SourceId, buffer: Arc<[u8]>) -> Self {
         let line_starts = vec![0]; // First line starts at offset 0
 
         PPLexer {

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -599,7 +599,7 @@ impl<'src> Preprocessor<'src> {
     pub fn process(&mut self, source_id: SourceId, _config: &PPConfig) -> Result<Vec<PPToken>, PPError> {
         // Initialize lexer for main file
         let buffer_len = self.sm.get_buffer(source_id).len() as u32;
-        let buffer = self.sm.get_buffer(source_id).to_vec();
+        let buffer = self.sm.get_buffer_arc(source_id);
 
         self.lexer_stack.push(PPLexer::new(source_id, buffer));
         self.sm.calculate_line_starts(source_id);
@@ -972,8 +972,8 @@ impl<'src> Preprocessor<'src> {
         let source_id = self
             .sm
             .add_buffer(pragma_content.as_bytes().to_vec(), "<_Pragma>", None);
-        let buffer = self.sm.get_buffer(source_id);
-        let mut temp_lexer = PPLexer::new(source_id, buffer.to_vec());
+        let buffer = self.sm.get_buffer_arc(source_id);
+        let mut temp_lexer = PPLexer::new(source_id, buffer);
 
         // Collect all tokens from the pragma content
         let mut tokens = Vec::new();
@@ -1240,8 +1240,8 @@ impl<'src> Preprocessor<'src> {
             self.expect_eod()?;
         }
 
-        let buffer = self.sm.get_buffer(include_source_id);
-        self.lexer_stack.push(PPLexer::new(include_source_id, buffer.to_vec()));
+        let buffer = self.sm.get_buffer_arc(include_source_id);
+        self.lexer_stack.push(PPLexer::new(include_source_id, buffer));
         self.include_depth += 1;
 
         Ok(())
@@ -2214,8 +2214,8 @@ impl<'src> Preprocessor<'src> {
         let virtual_id = self.sm.add_virtual_buffer(virtual_buffer, "<pasted-tokens>", None);
 
         // Create a temporary lexer to lex the pasted text
-        let buffer = self.sm.get_buffer(virtual_id);
-        let mut lexer = PPLexer::new(virtual_id, buffer.to_vec());
+        let buffer = self.sm.get_buffer_arc(virtual_id);
+        let mut lexer = PPLexer::new(virtual_id, buffer);
 
         let mut tokens = Vec::new();
         while let Some(token) = lexer.next_token() {

--- a/src/tests/pp_common.rs
+++ b/src/tests/pp_common.rs
@@ -129,7 +129,7 @@ impl TestLexer {
 pub fn create_test_pp_lexer(src: &str) -> TestLexer {
     let mut source_manager = SourceManager::new();
     let id = source_manager.add_buffer(src.as_bytes().to_vec(), "<test>", None);
-    let lexer = crate::pp::pp_lexer::PPLexer::new(id, src.as_bytes().to_vec());
+    let lexer = crate::pp::pp_lexer::PPLexer::new(id, std::sync::Arc::from(src.as_bytes().to_vec()));
     TestLexer { lexer }
 }
 


### PR DESCRIPTION
Identified a performance bottleneck where source buffers were being cloned into every new lexer. Implemented `Arc<[u8]>` sharing for buffers in `SourceManager` and `PPLexer`, and updated the `Preprocessor` to use `get_buffer_arc` to avoid redundant clones. Verified with tests and `cargo check`.

---
*PR created automatically by Jules for task [13882345167658617499](https://jules.google.com/task/13882345167658617499) started by @bungcip*