### PR TITLE
Fix nested designated initializer miscompilation

### DIFF
--- a/src/tests/semantic_init.rs
+++ b/src/tests/semantic_init.rs
@@ -489,6 +489,31 @@ fn test_string_literal_array_init() {
 }
 
 #[test]
+fn test_nested_struct_designator() {
+    let source = r#"
+        struct SEA { int i; int j; };
+        struct SEB { struct SEA a; };
+        struct SEB b = { .a.j = 5 };
+        int main() { return 0; }
+    "#;
+    let mir = setup_mir(source);
+    insta::assert_snapshot!(mir, @r"
+    type %t0 = i32
+    type %t1 = struct SEB { a: %t2 }
+    type %t2 = struct SEA { i: %t0, j: %t0 }
+
+    global @b: %t1 = const struct_literal { 0: const struct_literal { 1: const 5 } }
+
+    fn main() -> i32
+    {
+
+      bb1:
+        return const 0
+    }
+    ");
+}
+
+#[test]
 fn test_wide_string_init() {
     run_full_pass(
         r#"


### PR DESCRIPTION
Implemented `lower_initializer_with_designators` to handle chains of designators recursively.
Updated `lower_initializer_list` and `lower_array_initializer` to use this new helper when multiple designators are present.
Verified with regression test and manual reproduction.

---
*PR created automatically by Jules for task [9479162493947987942](https://jules.google.com/task/9479162493947987942) started by @bungcip*