### PR TITLE
Remove dead code in preprocessor lexer

### DIFF
--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -1088,10 +1088,6 @@ impl PPLexer {
 
                 if let Some(next_ch) = self.next_char() {
                     chars.push(next_ch);
-                    if next_ch == b'\n' {
-                        // This is line splicing within a string - the newline is consumed as part of the escape
-                        continue;
-                    }
                 }
             } else if ch >= 0x80 {
                 // Handle UTF-8 multi-byte characters


### PR DESCRIPTION
Removed unreachable code in `src/pp/pp_lexer.rs` that attempted to handle line splicing in string literals, which is already handled by `next_char`. This simplifies the lexer logic without changing behavior.

---
*PR created automatically by Jules for task [3315278433777089205](https://jules.google.com/task/3315278433777089205) started by @bungcip*