### PR TITLE
Fix array initialization regression with compatible aggregates

### DIFF
--- a/src/semantic/lower_initializer.rs
+++ b/src/semantic/lower_initializer.rs
@@ -323,7 +323,16 @@ impl<'a> AstToMirLowerer<'a> {
                 let is_braced_init = matches!(init_kind, NodeKind::InitializerList(_));
                 let is_string_literal = matches!(init_kind, NodeKind::Literal(literal::Literal::String(_)));
 
-                if is_aggregate_elem && !is_braced_init && !is_string_literal {
+                let is_compatible_aggregate = if !is_braced_init && !is_string_literal {
+                    self.ast
+                        .get_resolved_type(initializer)
+                        .map(|ty| self.registry.is_compatible(ty, element_ty))
+                        .unwrap_or(false)
+                } else {
+                    false
+                };
+
+                if is_aggregate_elem && !is_braced_init && !is_string_literal && !is_compatible_aggregate {
                     match elem_type_kind {
                         TypeKind::Record { .. } => {
                             let (mut sub_members, mut sub_offsets) = (Vec::new(), Vec::new());

--- a/src/tests/semantic_init.rs
+++ b/src/tests/semantic_init.rs
@@ -159,6 +159,7 @@ fn test_initializer_list_crash_regression() {
     type %t2 = u8
     type %t3 = struct anonymous {  }
 
+    global @.L.str0: %t3 = const struct_literal {  }
     global @ce: %t1 = const struct_literal { 0: const 1, 1: const struct_literal {  }, 2: const 18 }
 
     fn main() -> i32


### PR DESCRIPTION
This PR fixes a regression where array initialization with compatible aggregate expressions (like compound literals) was incorrectly triggering recursive brace elision. This caused nested struct literals in MIR output for what should be direct assignments.

Changes:
- Modified `src/semantic/lower_initializer.rs`: Added `is_compatible_aggregate` check in `lower_array_initializer_from_iter`.
- Modified `src/tests/semantic_init.rs`: Updated snapshot for `test_initializer_list_crash_regression`.

This fixes the failures in `tests::semantic_types::test_struct_copy_init` and `tests::semantic_init::test_initializer_list_crash_regression`.

---
*PR created automatically by Jules for task [6107268334970879065](https://jules.google.com/task/6107268334970879065) started by @bungcip*