### PR TITLE
Support lvalue category for _Generic expressions

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -235,6 +235,13 @@ impl<'a> SemanticAnalyzer<'a> {
             NodeKind::MemberAccess(obj_ref, _, is_arrow) => *is_arrow || self.is_lvalue(*obj_ref),
             NodeKind::Literal(literal::Literal::String(_)) => true,
             NodeKind::CompoundLiteral(..) => true,
+            NodeKind::GenericSelection(_) => {
+                if let Some(&selected) = self.semantic_info.generic_selections.get(&node_ref.index()) {
+                    self.is_lvalue(selected)
+                } else {
+                    false
+                }
+            }
             _ => false,
         }
     }

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -84,7 +84,7 @@ impl Type {
                         let inner_type = registry.get(member.member_type.ty());
                         inner_type.flatten_members_with_layouts(registry, flat_members, flat_offsets, offset);
                     } else {
-                        flat_members.push(member.clone());
+                        flat_members.push(*member);
                         flat_offsets.push(offset);
                     }
                 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -69,3 +69,4 @@ pub mod complex_types;
 pub mod guardian_alignment;
 pub mod guardian_atomic;
 pub mod semantic_const_eval_extensions;
+pub mod test_generic_lvalue;

--- a/src/tests/test_generic_lvalue.rs
+++ b/src/tests/test_generic_lvalue.rs
@@ -1,0 +1,36 @@
+#[cfg(test)]
+mod tests {
+    use crate::driver::artifact::CompilePhase;
+    use crate::tests::semantic_common::run_pass;
+
+    #[test]
+    fn test_generic_selection_lvalue() {
+        run_pass(
+            r#"
+        int main() {
+            int x = 0;
+            _Generic(0, int: x, default: x) = 10;
+            if (x != 10) return 1;
+            return 0;
+        }
+        "#,
+            CompilePhase::Mir,
+        );
+    }
+
+    #[test]
+    fn test_generic_selection_lvalue_struct() {
+        run_pass(
+            r#"
+        struct S { int a; };
+        int main() {
+            struct S s = {0};
+            _Generic(0, int: s, default: s).a = 10;
+            if (s.a != 10) return 1;
+            return 0;
+        }
+        "#,
+            CompilePhase::Mir,
+        );
+    }
+}


### PR DESCRIPTION
Implemented lvalue support for C11 `_Generic` expressions, ensuring they can be used in contexts requiring lvalues (like assignment and address-of) when the selected branch is an lvalue. Added unit tests and fixed a minor clippy warning.

---
*PR created automatically by Jules for task [17071847783124858720](https://jules.google.com/task/17071847783124858720) started by @bungcip*