### PR TITLE
Fix struct brace elision with array members

### DIFF
--- a/src/semantic/lower_initializer.rs
+++ b/src/semantic/lower_initializer.rs
@@ -289,6 +289,11 @@ impl<'a> AstToMirLowerer<'a> {
                 )
             };
 
+            // Stop if we have filled the array with positional initializers
+            if designator_info.is_none() && size > 0 && current_idx >= size {
+                break;
+            }
+
             let (start, end) = if let Some((d_start, _)) = designator_info {
                 match self.ast.get_kind(d_start) {
                     NodeKind::Designator(Designator::ArrayIndex(_))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -69,5 +69,6 @@ pub mod complex_arithmetic;
 pub mod complex_types;
 pub mod guardian_alignment;
 pub mod guardian_atomic;
+pub mod guardian_brace_elision;
 pub mod semantic_const_eval_extensions;
 pub mod test_generic_lvalue;

--- a/src/tests/guardian_brace_elision.rs
+++ b/src/tests/guardian_brace_elision.rs
@@ -1,0 +1,35 @@
+use crate::tests::codegen_common::run_c_code_with_output;
+
+#[test]
+fn test_struct_brace_elision_init() {
+    let source = r#"
+    int printf(const char *fmt, ...);
+    typedef unsigned char u8;
+
+    struct S {
+        u8 c[2];
+    };
+
+    struct U {
+        struct S s;
+        u8 y;
+    };
+
+    struct U u = {4, 5, 6};
+
+    int main()
+    {
+      // We check if brace elision correctly filled u.s.c[0] and u.s.c[1],
+      // and stopped so that u.y got 6.
+      if (u.s.c[0] == 4 && u.s.c[1] == 5 && u.y == 6) {
+          printf("OK");
+          return 0;
+      }
+      printf("FAIL: c[0]=%d, c[1]=%d, y=%d\n", u.s.c[0], u.s.c[1], u.y);
+      return 1;
+    }
+    "#;
+
+    let output = run_c_code_with_output(source);
+    assert_eq!(output, "OK");
+}


### PR DESCRIPTION
Fixes a bug where struct brace elision with array members caused miscompilation.
The issue was that `lower_array_initializer_from_iter` did not stop when the array
size was reached, consuming elements meant for subsequent struct fields.

* Modified `src/semantic/lower_initializer.rs` to break the array initialization loop
  when `current_idx >= size` for positional initializers.
* Added `src/tests/guardian_brace_elision.rs` to verify the fix with the reported reproduction case.
* Registered the new test in `src/tests.rs`.

---
*PR created automatically by Jules for task [16281338731635254971](https://jules.google.com/task/16281338731635254971) started by @bungcip*