### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -567,25 +567,25 @@ impl<'src> Lexer<'src> {
     /// Extract parts from a string literal symbol: (prefix, content_without_quotes)
     fn extract_literal_parts(s: &str) -> Option<(&str, &str)> {
         if let Some(rest) = s.strip_prefix("L\"") {
-            if rest.ends_with('"') {
-                return Some(("L", &rest[..rest.len() - 1]));
+            if let Some(inner) = rest.strip_suffix('"') {
+                return Some(("L", inner));
             }
         } else if let Some(rest) = s.strip_prefix("u\"") {
-            if rest.ends_with('"') {
-                return Some(("u", &rest[..rest.len() - 1]));
+            if let Some(inner) = rest.strip_suffix('"') {
+                return Some(("u", inner));
             }
         } else if let Some(rest) = s.strip_prefix("U\"") {
-            if rest.ends_with('"') {
-                return Some(("U", &rest[..rest.len() - 1]));
+            if let Some(inner) = rest.strip_suffix('"') {
+                return Some(("U", inner));
             }
         } else if let Some(rest) = s.strip_prefix("u8\"") {
-            if rest.ends_with('"') {
-                return Some(("u8", &rest[..rest.len() - 1]));
+            if let Some(inner) = rest.strip_suffix('"') {
+                return Some(("u8", inner));
             }
         } else if let Some(rest) = s.strip_prefix("\"")
-            && rest.ends_with('"')
+            && let Some(inner) = rest.strip_suffix('"')
         {
-            return Some(("", &rest[..rest.len() - 1]));
+            return Some(("", inner));
         }
         None
     }

--- a/src/tests/semantic_const_eval_extensions.rs
+++ b/src/tests/semantic_const_eval_extensions.rs
@@ -15,10 +15,10 @@ fn snapshot_const_eval(name: &str, expr: &str) {
         tu.decl_start
             .range(tu.decl_len)
             .find_map(|decl_ref| {
-                if let NodeKind::VarDecl(data) = ast.get_kind(decl_ref) {
-                    if data.name.to_string() == "test_var" {
-                        return data.init;
-                    }
+                if let NodeKind::VarDecl(data) = ast.get_kind(decl_ref)
+                    && data.name.to_string() == "test_var"
+                {
+                    return data.init;
                 }
                 None
             })


### PR DESCRIPTION
Resolved clippy warnings:
- Replaced manual suffix stripping with `strip_suffix` in `src/parser/lexer.rs`.
- Collapsed nested `if` statements using `let_chains` in `src/tests/semantic_const_eval_extensions.rs` and `src/parser/lexer.rs`.


---
*PR created automatically by Jules for task [1698663944558049052](https://jules.google.com/task/1698663944558049052) started by @bungcip*