### PR TITLE
Cleanup unused and internal public APIs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -127,7 +127,7 @@ impl NodeRef {
 
     /// Create an iterator over a range of consecutive NodeRefs, starting from `self`.
     #[inline]
-    pub fn range(self, len: impl Into<u32>) -> NodeRefRange {
+    pub(crate) fn range(self, len: impl Into<u32>) -> NodeRefRange {
         NodeRefRange {
             current: self.get(),
             end: self.get() + len.into(),

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -21,27 +21,27 @@ pub struct ParsedAst {
 }
 
 impl ParsedAst {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         ParsedAst::default()
     }
 
-    pub fn push_node(&mut self, node: ParsedNode) -> ParsedNodeRef {
+    pub(crate) fn push_node(&mut self, node: ParsedNode) -> ParsedNodeRef {
         let index = self.nodes.len() as u32 + 1;
         self.nodes.push(node);
         ParsedNodeRef::new(index).expect("ParsedNodeRef overflow")
     }
 
-    pub fn get_node(&self, index: ParsedNodeRef) -> &ParsedNode {
+    pub(crate) fn get_node(&self, index: ParsedNodeRef) -> &ParsedNode {
         &self.nodes[(index.get() - 1) as usize]
     }
 
-    pub fn replace_node(&mut self, old_node_ref: ParsedNodeRef, new_node: ParsedNode) -> ParsedNodeRef {
+    pub(crate) fn replace_node(&mut self, old_node_ref: ParsedNodeRef, new_node: ParsedNode) -> ParsedNodeRef {
         let old_index = (old_node_ref.get() - 1) as usize;
         self.nodes[old_index] = new_node;
         old_node_ref
     }
 
-    pub fn get_root(&self) -> ParsedNodeRef {
+    pub(crate) fn get_root(&self) -> ParsedNodeRef {
         ParsedNodeRef::new(1).expect("Parsed AST empty")
     }
 }
@@ -53,7 +53,7 @@ pub struct ParsedNode {
 }
 
 impl ParsedNode {
-    pub fn new(kind: ParsedNodeKind, span: SourceSpan) -> Self {
+    pub(crate) fn new(kind: ParsedNodeKind, span: SourceSpan) -> Self {
         ParsedNode { kind, span }
     }
 }

--- a/src/driver/cli.rs
+++ b/src/driver/cli.rs
@@ -199,7 +199,7 @@ impl Cli {
     }
 
     /// Convert CLI arguments into compilation configuration
-    pub fn into_config(self) -> Result<CompileConfig, String> {
+    pub(crate) fn into_config(self) -> Result<CompileConfig, String> {
         // Validate input files first
         self.validate_input_files()?;
 

--- a/src/mir/dumper.rs
+++ b/src/mir/dumper.rs
@@ -37,12 +37,12 @@ pub struct MirDumper<'a> {
 
 impl<'a> MirDumper<'a> {
     /// Create a new MIR dumper
-    pub fn new(mir: &'a MirProgram, config: &'a MirDumpConfig) -> Self {
+    pub(crate) fn new(mir: &'a MirProgram, config: &'a MirDumpConfig) -> Self {
         Self { mir, config }
     }
 
     /// Generate the complete MIR dump
-    pub fn generate_mir_dump(&self) -> Result<String, std::fmt::Error> {
+    pub(crate) fn generate_mir_dump(&self) -> Result<String, std::fmt::Error> {
         let mut output = String::new();
 
         // Dump module header

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -90,7 +90,7 @@ pub struct Parser<'arena, 'src> {
 
 impl<'arena, 'src> Parser<'arena, 'src> {
     /// Create a new parser
-    pub fn new(tokens: &'src [Token], ast: &'arena mut ParsedAst, diag: &'src mut DiagnosticEngine) -> Self {
+    pub(crate) fn new(tokens: &'src [Token], ast: &'arena mut ParsedAst, diag: &'src mut DiagnosticEngine) -> Self {
         Parser {
             tokens,
             current_idx: 0,
@@ -290,7 +290,7 @@ impl<'arena, 'src> Parser<'arena, 'src> {
     }
 
     /// Parse translation unit (top level)
-    pub fn parse_translation_unit(&mut self) -> Result<ParsedNodeRef, ParseError> {
+    pub(crate) fn parse_translation_unit(&mut self) -> Result<ParsedNodeRef, ParseError> {
         declarations::parse_translation_unit(self)
     }
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -420,7 +420,7 @@ pub struct Lexer<'src> {
 
 impl<'src> Lexer<'src> {
     /// Create a new lexer with the given preprocessor token stream
-    pub fn new(tokens: &'src [PPToken]) -> Self {
+    pub(crate) fn new(tokens: &'src [PPToken]) -> Self {
         Lexer { tokens }
     }
 
@@ -451,7 +451,7 @@ impl<'src> Lexer<'src> {
     }
 
     /// Get all tokens from the stream
-    pub fn tokenize_all(&mut self) -> Vec<Token> {
+    pub(crate) fn tokenize_all(&mut self) -> Vec<Token> {
         // Bolt ⚡: Pre-allocate the tokens vector with the capacity of the preprocessor tokens.
         // This is a reasonable estimate that reduces the number of reallocations,
         // as the number of lexical tokens is usually similar to the number of preprocessor tokens.

--- a/src/pp/dumper.rs
+++ b/src/pp/dumper.rs
@@ -16,7 +16,7 @@ pub struct PPDumper<'a> {
 
 impl<'a> PPDumper<'a> {
     /// Create a new preprocessor dumper
-    pub fn new(tokens: &'a [PPToken], source_manager: &'a SourceManager, suppress_line_markers: bool) -> Self {
+    pub(crate) fn new(tokens: &'a [PPToken], source_manager: &'a SourceManager, suppress_line_markers: bool) -> Self {
         Self {
             tokens,
             source_manager,
@@ -25,7 +25,7 @@ impl<'a> PPDumper<'a> {
     }
 
     /// Dump preprocessed output to the given writer
-    pub fn dump(&self, writer: &mut impl Write) -> std::io::Result<()> {
+    pub(crate) fn dump(&self, writer: &mut impl Write) -> std::io::Result<()> {
         if self.tokens.is_empty() {
             return Ok(());
         }

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -311,7 +311,7 @@ impl From<PPError> for Diagnostic {
 
 impl<'src> Preprocessor<'src> {
     /// Create a new preprocessor
-    pub fn new(source_manager: &'src mut SourceManager, diag: &'src mut DiagnosticEngine, config: &PPConfig) -> Self {
+    pub(crate) fn new(source_manager: &'src mut SourceManager, diag: &'src mut DiagnosticEngine, config: &PPConfig) -> Self {
         let mut header_search = HeaderSearch {
             system_path: Vec::new(),
             framework_path: Vec::new(),
@@ -596,7 +596,7 @@ impl<'src> Preprocessor<'src> {
     }
 
     /// Process source file and return preprocessed tokens
-    pub fn process(&mut self, source_id: SourceId, _config: &PPConfig) -> Result<Vec<PPToken>, PPError> {
+    pub(crate) fn process(&mut self, source_id: SourceId, _config: &PPConfig) -> Result<Vec<PPToken>, PPError> {
         // Initialize lexer for main file
         let buffer_len = self.sm.get_buffer(source_id).len() as u32;
         let buffer = self.sm.get_buffer_arc(source_id);

--- a/src/semantic/literal_utils.rs
+++ b/src/semantic/literal_utils.rs
@@ -16,7 +16,7 @@ pub struct ParsedStringLiteral {
     pub size: usize,
 }
 
-pub fn parse_string_literal(name: NameId) -> ParsedStringLiteral {
+pub(crate) fn parse_string_literal(name: NameId) -> ParsedStringLiteral {
     let raw = name.as_str();
 
     let (stripped, builtin_type, kind) = if let Some(s) = raw.strip_prefix("L\"") {

--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -44,15 +44,7 @@ pub struct Symbol {
 }
 
 impl Symbol {
-    pub fn is_const(&self) -> bool {
-        self.type_info.is_const()
-    }
-
-    pub fn ty(&self) -> TypeRef {
-        self.type_info.ty()
-    }
-
-    pub fn has_linkage(&self) -> bool {
+    pub(crate) fn has_linkage(&self) -> bool {
         match &self.kind {
             SymbolKind::Function { .. } => true,
             SymbolKind::Variable { is_global, storage, .. } => *is_global || *storage == Some(StorageClass::Extern),


### PR DESCRIPTION
Systematically cleaned up unused or overly exposed public APIs by downgrading visibility to `pub(crate)` or removing unused code. 

Key changes:
- Restricted entry points for Lexer, Parser, Preprocessor, and MIR dumper to crate-internal visibility.
- Removed unused `Symbol::is_const` and `Symbol::ty` in `src/semantic/symbol_table.rs`.
- Downgraded `Symbol::has_linkage`, `NodeRef::range`, and several `ParsedAst` methods to `pub(crate)`.
- Verified no dead code warnings were introduced and all tests passed.
- Removed temporary debugging files identified during code review.

---
*PR created automatically by Jules for task [18216337146085464191](https://jules.google.com/task/18216337146085464191) started by @bungcip*