### PR TITLE
Clean up unused and unnecessarily public APIs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -127,7 +127,7 @@ impl NodeRef {
 
     /// Create an iterator over a range of consecutive NodeRefs, starting from `self`.
     #[inline]
-    pub fn range(self, len: impl Into<u32>) -> NodeRefRange {
+    pub(crate) fn range(self, len: impl Into<u32>) -> NodeRefRange {
         NodeRefRange {
             current: self.get(),
             end: self.get() + len.into(),

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -21,27 +21,27 @@ pub struct ParsedAst {
 }
 
 impl ParsedAst {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         ParsedAst::default()
     }
 
-    pub fn push_node(&mut self, node: ParsedNode) -> ParsedNodeRef {
+    pub(crate) fn push_node(&mut self, node: ParsedNode) -> ParsedNodeRef {
         let index = self.nodes.len() as u32 + 1;
         self.nodes.push(node);
         ParsedNodeRef::new(index).expect("ParsedNodeRef overflow")
     }
 
-    pub fn get_node(&self, index: ParsedNodeRef) -> &ParsedNode {
+    pub(crate) fn get_node(&self, index: ParsedNodeRef) -> &ParsedNode {
         &self.nodes[(index.get() - 1) as usize]
     }
 
-    pub fn replace_node(&mut self, old_node_ref: ParsedNodeRef, new_node: ParsedNode) -> ParsedNodeRef {
+    pub(crate) fn replace_node(&mut self, old_node_ref: ParsedNodeRef, new_node: ParsedNode) -> ParsedNodeRef {
         let old_index = (old_node_ref.get() - 1) as usize;
         self.nodes[old_index] = new_node;
         old_node_ref
     }
 
-    pub fn get_root(&self) -> ParsedNodeRef {
+    pub(crate) fn get_root(&self) -> ParsedNodeRef {
         ParsedNodeRef::new(1).expect("Parsed AST empty")
     }
 }
@@ -53,7 +53,7 @@ pub struct ParsedNode {
 }
 
 impl ParsedNode {
-    pub fn new(kind: ParsedNodeKind, span: SourceSpan) -> Self {
+    pub(crate) fn new(kind: ParsedNodeKind, span: SourceSpan) -> Self {
         ParsedNode { kind, span }
     }
 }

--- a/src/driver/cli.rs
+++ b/src/driver/cli.rs
@@ -199,7 +199,7 @@ impl Cli {
     }
 
     /// Convert CLI arguments into compilation configuration
-    pub fn into_config(self) -> Result<CompileConfig, String> {
+    pub(crate) fn into_config(self) -> Result<CompileConfig, String> {
         // Validate input files first
         self.validate_input_files()?;
 

--- a/src/mir/dumper.rs
+++ b/src/mir/dumper.rs
@@ -37,12 +37,12 @@ pub struct MirDumper<'a> {
 
 impl<'a> MirDumper<'a> {
     /// Create a new MIR dumper
-    pub fn new(mir: &'a MirProgram, config: &'a MirDumpConfig) -> Self {
+    pub(crate) fn new(mir: &'a MirProgram, config: &'a MirDumpConfig) -> Self {
         Self { mir, config }
     }
 
     /// Generate the complete MIR dump
-    pub fn generate_mir_dump(&self) -> Result<String, std::fmt::Error> {
+    pub(crate) fn generate_mir_dump(&self) -> Result<String, std::fmt::Error> {
         let mut output = String::new();
 
         // Dump module header

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -90,7 +90,7 @@ pub struct Parser<'arena, 'src> {
 
 impl<'arena, 'src> Parser<'arena, 'src> {
     /// Create a new parser
-    pub fn new(tokens: &'src [Token], ast: &'arena mut ParsedAst, diag: &'src mut DiagnosticEngine) -> Self {
+    pub(crate) fn new(tokens: &'src [Token], ast: &'arena mut ParsedAst, diag: &'src mut DiagnosticEngine) -> Self {
         Parser {
             tokens,
             current_idx: 0,
@@ -290,7 +290,7 @@ impl<'arena, 'src> Parser<'arena, 'src> {
     }
 
     /// Parse translation unit (top level)
-    pub fn parse_translation_unit(&mut self) -> Result<ParsedNodeRef, ParseError> {
+    pub(crate) fn parse_translation_unit(&mut self) -> Result<ParsedNodeRef, ParseError> {
         declarations::parse_translation_unit(self)
     }
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -420,7 +420,7 @@ pub struct Lexer<'src> {
 
 impl<'src> Lexer<'src> {
     /// Create a new lexer with the given preprocessor token stream
-    pub fn new(tokens: &'src [PPToken]) -> Self {
+    pub(crate) fn new(tokens: &'src [PPToken]) -> Self {
         Lexer { tokens }
     }
 
@@ -451,7 +451,7 @@ impl<'src> Lexer<'src> {
     }
 
     /// Get all tokens from the stream
-    pub fn tokenize_all(&mut self) -> Vec<Token> {
+    pub(crate) fn tokenize_all(&mut self) -> Vec<Token> {
         // Bolt ⚡: Pre-allocate the tokens vector with the capacity of the preprocessor tokens.
         // This is a reasonable estimate that reduces the number of reallocations,
         // as the number of lexical tokens is usually similar to the number of preprocessor tokens.

--- a/src/pp/dumper.rs
+++ b/src/pp/dumper.rs
@@ -16,7 +16,7 @@ pub struct PPDumper<'a> {
 
 impl<'a> PPDumper<'a> {
     /// Create a new preprocessor dumper
-    pub fn new(tokens: &'a [PPToken], source_manager: &'a SourceManager, suppress_line_markers: bool) -> Self {
+    pub(crate) fn new(tokens: &'a [PPToken], source_manager: &'a SourceManager, suppress_line_markers: bool) -> Self {
         Self {
             tokens,
             source_manager,
@@ -25,7 +25,7 @@ impl<'a> PPDumper<'a> {
     }
 
     /// Dump preprocessed output to the given writer
-    pub fn dump(&self, writer: &mut impl Write) -> std::io::Result<()> {
+    pub(crate) fn dump(&self, writer: &mut impl Write) -> std::io::Result<()> {
         if self.tokens.is_empty() {
             return Ok(());
         }

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -311,7 +311,7 @@ impl From<PPError> for Diagnostic {
 
 impl<'src> Preprocessor<'src> {
     /// Create a new preprocessor
-    pub fn new(source_manager: &'src mut SourceManager, diag: &'src mut DiagnosticEngine, config: &PPConfig) -> Self {
+    pub(crate) fn new(source_manager: &'src mut SourceManager, diag: &'src mut DiagnosticEngine, config: &PPConfig) -> Self {
         let mut header_search = HeaderSearch {
             system_path: Vec::new(),
             framework_path: Vec::new(),
@@ -596,7 +596,7 @@ impl<'src> Preprocessor<'src> {
     }
 
     /// Process source file and return preprocessed tokens
-    pub fn process(&mut self, source_id: SourceId, _config: &PPConfig) -> Result<Vec<PPToken>, PPError> {
+    pub(crate) fn process(&mut self, source_id: SourceId, _config: &PPConfig) -> Result<Vec<PPToken>, PPError> {
         // Initialize lexer for main file
         let buffer_len = self.sm.get_buffer(source_id).len() as u32;
         let buffer = self.sm.get_buffer_arc(source_id);

--- a/src/semantic/literal_utils.rs
+++ b/src/semantic/literal_utils.rs
@@ -16,7 +16,7 @@ pub struct ParsedStringLiteral {
     pub size: usize,
 }
 
-pub fn parse_string_literal(name: NameId) -> ParsedStringLiteral {
+pub(crate) fn parse_string_literal(name: NameId) -> ParsedStringLiteral {
     let raw = name.as_str();
 
     let (stripped, builtin_type, kind) = if let Some(s) = raw.strip_prefix("L\"") {

--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -44,15 +44,11 @@ pub struct Symbol {
 }
 
 impl Symbol {
-    pub fn is_const(&self) -> bool {
+    pub(crate) fn is_const(&self) -> bool {
         self.type_info.is_const()
     }
 
-    pub fn ty(&self) -> TypeRef {
-        self.type_info.ty()
-    }
-
-    pub fn has_linkage(&self) -> bool {
+    pub(crate) fn has_linkage(&self) -> bool {
         match &self.kind {
             SymbolKind::Function { .. } => true,
             SymbolKind::Variable { is_global, storage, .. } => *is_global || *storage == Some(StorageClass::Extern),

--- a/src/tests/codegen_common.rs
+++ b/src/tests/codegen_common.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use tempfile::NamedTempFile;
 
 /// setup test with output is cranelift ir
-pub fn setup_cranelift(c_code: &str) -> String {
+pub(crate) fn setup_cranelift(c_code: &str) -> String {
     let (driver, pipeline_result) = test_utils::run_pipeline(c_code, CompilePhase::Cranelift);
     match pipeline_result {
         Err(_) => {
@@ -19,7 +19,7 @@ pub fn setup_cranelift(c_code: &str) -> String {
     }
 }
 
-pub fn run_c_code_with_output(source: &str) -> String {
+pub(crate) fn run_c_code_with_output(source: &str) -> String {
     let temp_file = NamedTempFile::new().unwrap();
     let temp_path = temp_file.into_temp_path();
     let exe_path = temp_path.to_path_buf();

--- a/src/tests/pp_common.rs
+++ b/src/tests/pp_common.rs
@@ -26,16 +26,16 @@ impl From<&PPToken> for DebugToken {
     }
 }
 
-pub fn setup_pp_snapshot(src: &str) -> Vec<DebugToken> {
+pub(crate) fn setup_pp_snapshot(src: &str) -> Vec<DebugToken> {
     let (tokens, _) = setup_preprocessor_test_with_diagnostics(src, None).unwrap();
     tokens.iter().map(DebugToken::from).collect()
 }
 
-pub fn setup_pp_snapshot_with_diags(src: &str) -> (Vec<DebugToken>, Vec<String>) {
+pub(crate) fn setup_pp_snapshot_with_diags(src: &str) -> (Vec<DebugToken>, Vec<String>) {
     setup_pp_snapshot_with_diags_and_config(src, None)
 }
 
-pub fn setup_pp_snapshot_with_diags_and_config(src: &str, config: Option<PPConfig>) -> (Vec<DebugToken>, Vec<String>) {
+pub(crate) fn setup_pp_snapshot_with_diags_and_config(src: &str, config: Option<PPConfig>) -> (Vec<DebugToken>, Vec<String>) {
     // Return a Result-like structure for the snapshot
     match setup_preprocessor_test_with_diagnostics(src, config) {
         Ok((tokens, diags)) => {
@@ -47,7 +47,7 @@ pub fn setup_pp_snapshot_with_diags_and_config(src: &str, config: Option<PPConfi
     }
 }
 
-pub fn setup_multi_file_pp_snapshot(
+pub(crate) fn setup_multi_file_pp_snapshot(
     files: Vec<(&str, &str)>,
     main_file: &str,
     config: Option<PPConfig>,
@@ -63,14 +63,14 @@ pub fn setup_multi_file_pp_snapshot(
 }
 
 /// Helper function to set up preprocessor testing and return diagnostics
-pub fn setup_preprocessor_test_with_diagnostics(
+pub(crate) fn setup_preprocessor_test_with_diagnostics(
     src: &str,
     config: Option<PPConfig>,
 ) -> Result<(Vec<PPToken>, Vec<crate::diagnostic::Diagnostic>), PPError> {
     setup_multi_file_pp_with_diagnostics(vec![("<test>", src)], "<test>", config)
 }
 
-pub fn setup_multi_file_pp_with_diagnostics(
+pub(crate) fn setup_multi_file_pp_with_diagnostics(
     files: Vec<(&str, &str)>,
     main_file_name: &str,
     config: Option<PPConfig>,
@@ -85,7 +85,7 @@ pub fn setup_multi_file_pp_with_diagnostics(
     Ok((significant_tokens, diagnostics))
 }
 
-pub fn setup_multi_file_pp_with_diagnostics_raw(
+pub(crate) fn setup_multi_file_pp_with_diagnostics_raw(
     files: Vec<(&str, &str)>,
     main_file_name: &str,
     config: Option<PPConfig>,
@@ -121,12 +121,12 @@ pub struct TestLexer {
 }
 
 impl TestLexer {
-    pub fn next_token(&mut self) -> Option<PPToken> {
+    pub(crate) fn next_token(&mut self) -> Option<PPToken> {
         self.lexer.next_token()
     }
 }
 
-pub fn create_test_pp_lexer(src: &str) -> TestLexer {
+pub(crate) fn create_test_pp_lexer(src: &str) -> TestLexer {
     let mut source_manager = SourceManager::new();
     let id = source_manager.add_buffer(src.as_bytes().to_vec(), "<test>", None);
     let lexer = crate::pp::pp_lexer::PPLexer::new(id, std::sync::Arc::from(src.as_bytes().to_vec()));

--- a/src/tests/semantic_common.rs
+++ b/src/tests/semantic_common.rs
@@ -7,7 +7,7 @@ use crate::mir::dumper::{MirDumpConfig, MirDumper};
 use crate::semantic::TypeRegistry;
 use crate::tests::test_utils;
 
-pub fn setup_mir(source: &str) -> String {
+pub(crate) fn setup_mir(source: &str) -> String {
     let (driver, result) = test_utils::run_pipeline(source, CompilePhase::Mir);
     let mut out = match result {
         Ok(out) => out,
@@ -24,7 +24,7 @@ pub fn setup_mir(source: &str) -> String {
     dumper.generate_mir_dump().expect("Failed to generate MIR dump")
 }
 
-pub fn setup_lowering(source: &str) -> (Ast, TypeRegistry, crate::semantic::SymbolTable) {
+pub(crate) fn setup_lowering(source: &str) -> (Ast, TypeRegistry, crate::semantic::SymbolTable) {
     let (driver, result) = test_utils::run_pipeline(source, CompilePhase::SemanticLowering);
     let out = match result {
         Ok(out) => out,
@@ -39,7 +39,7 @@ pub fn setup_lowering(source: &str) -> (Ast, TypeRegistry, crate::semantic::Symb
     )
 }
 
-pub fn setup_analysis(source: &str) -> (Ast, TypeRegistry, crate::semantic::SymbolTable) {
+pub(crate) fn setup_analysis(source: &str) -> (Ast, TypeRegistry, crate::semantic::SymbolTable) {
     let (driver, result) = test_utils::run_pipeline(source, CompilePhase::SemanticLowering);
     let out = match result {
         Ok(out) => out,
@@ -64,12 +64,12 @@ pub fn setup_analysis(source: &str) -> (Ast, TypeRegistry, crate::semantic::Symb
     (ast, registry, symbol_table)
 }
 
-pub fn find_layout<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::types::TypeLayout {
+pub(crate) fn find_layout<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::types::TypeLayout {
     let s_ty = find_record_type(&registry, name);
     s_ty.layout.as_ref().expect("Layout not computed for S")
 }
 
-pub fn find_record_type<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::Type {
+pub(crate) fn find_record_type<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::Type {
     registry
         .types
         .iter()
@@ -86,7 +86,7 @@ pub fn find_record_type<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate
         .unwrap_or_else(|| panic!("Record type '{}' not found in registry", name))
 }
 
-pub fn find_var_decl<'a>(ast: &'a Ast, name: &str) -> &'a crate::ast::VarDeclData {
+pub(crate) fn find_var_decl<'a>(ast: &'a Ast, name: &str) -> &'a crate::ast::VarDeclData {
     ast.kinds
         .iter()
         .find_map(|kind| {
@@ -104,7 +104,7 @@ pub fn find_var_decl<'a>(ast: &'a Ast, name: &str) -> &'a crate::ast::VarDeclDat
 // TODO: remove this function and refactor unit test to appropriate phase, if needed to run full pass
 //       unit test must check the result.
 //       this function only check if unit test not error but not checking if result is correct or not
-pub fn run_full_pass(source: &str) {
+pub(crate) fn run_full_pass(source: &str) {
     let config = CompileConfig::from_virtual_file(source.to_string(), CompilePhase::EmitObject);
     let mut driver = CompilerDriver::from_config(config);
     let result = driver.run();
@@ -117,7 +117,7 @@ pub fn run_full_pass(source: &str) {
     }
 }
 
-pub fn find_enum_constant(symbol_table: &crate::semantic::SymbolTable, name: &str) -> i64 {
+pub(crate) fn find_enum_constant(symbol_table: &crate::semantic::SymbolTable, name: &str) -> i64 {
     symbol_table
         .entries
         .iter()

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -52,30 +52,30 @@ pub(crate) fn sort_clif_ir(ir: &str) -> String {
     functions.join("\n\n")
 }
 
-pub fn run_pass(source: &str, phase: CompilePhase) {
+pub(crate) fn run_pass(source: &str, phase: CompilePhase) {
     let (driver, result) = run_pipeline(source, phase);
     if result.is_err() {
         panic!("Compilation failed unexpectedly: {:?}", driver.get_diagnostics());
     }
 }
 
-pub fn run_fail(source: &str, phase: CompilePhase) -> CompilerDriver {
+pub(crate) fn run_fail(source: &str, phase: CompilePhase) -> CompilerDriver {
     let (driver, result) = run_pipeline(source, phase);
     assert!(result.is_err(), "Compilation should have failed");
     driver
 }
 
-pub fn run_fail_with_message(source: &str, phase: CompilePhase, message: &str) {
+pub(crate) fn run_fail_with_message(source: &str, phase: CompilePhase, message: &str) {
     let driver = run_fail(source, phase);
     check_diagnostic_message_only(&driver, message);
 }
 
-pub fn run_fail_with_diagnostic(source: &str, phase: CompilePhase, message: &str, line: u32, col: u32) {
+pub(crate) fn run_fail_with_diagnostic(source: &str, phase: CompilePhase, message: &str, line: u32, col: u32) {
     let driver = run_fail(source, phase);
     check_diagnostic(&driver, message, line, col);
 }
 
-pub fn check_diagnostic(driver: &CompilerDriver, message: &str, line: u32, col: u32) {
+pub(crate) fn check_diagnostic(driver: &CompilerDriver, message: &str, line: u32, col: u32) {
     let diagnostics = driver.get_diagnostics();
     let found = diagnostics.iter().any(|d| {
         if d.message.contains(message)
@@ -94,7 +94,7 @@ pub fn check_diagnostic(driver: &CompilerDriver, message: &str, line: u32, col: 
     );
 }
 
-pub fn check_diagnostic_message_only(driver: &CompilerDriver, message: &str) {
+pub(crate) fn check_diagnostic_message_only(driver: &CompilerDriver, message: &str) {
     let diagnostics = driver.get_diagnostics();
     let found = diagnostics.iter().any(|d| d.message.contains(message));
     assert!(
@@ -104,7 +104,7 @@ pub fn check_diagnostic_message_only(driver: &CompilerDriver, message: &str) {
     );
 }
 
-pub fn setup_diagnostics_output(source: &str) -> String {
+pub(crate) fn setup_diagnostics_output(source: &str) -> String {
     let (driver, _) = run_pipeline(source, CompilePhase::Mir);
     let diagnostics = driver.get_diagnostics();
 
@@ -122,7 +122,7 @@ pub fn setup_diagnostics_output(source: &str) -> String {
     )
 }
 
-pub fn run_pass_with_diagnostic(source: &str, phase: CompilePhase, message: &str, line: u32, col: u32) {
+pub(crate) fn run_pass_with_diagnostic(source: &str, phase: CompilePhase, message: &str, line: u32, col: u32) {
     let (driver, result) = run_pipeline(source, phase);
     assert!(result.is_ok(), "Compilation should have succeeded");
     check_diagnostic(&driver, message, line, col);


### PR DESCRIPTION
Systematic cleanup of unused public APIs and visibility downgrades to enforce a minimal public API boundary. All internal implementation details are now correctly marked as `pub(crate)`. Unused `Symbol::ty` was removed.

---
*PR created automatically by Jules for task [14591427934341486606](https://jules.google.com/task/14591427934341486606) started by @bungcip*