### PR TITLE
Fix array size deduction for strings and compound literals

### DIFF
--- a/src/tests/semantic_init.rs
+++ b/src/tests/semantic_init.rs
@@ -401,6 +401,27 @@ fn test_string_literal_array_init() {
 }
 
 #[test]
+fn test_braced_wide_string_init() {
+    let source = r#"
+        typedef int wchar_t;
+        typedef unsigned short char16_t;
+        typedef unsigned int char32_t;
+
+        wchar_t s[] = { L"hello" };
+        char16_t s16[] = { u"hi" };
+        char32_t s32[] = { U"hey" };
+
+        int main() {
+            if (sizeof(s) != 24) return 1; // 6 * 4
+            if (sizeof(s16) != 6) return 2; // 3 * 2
+            if (sizeof(s32) != 16) return 3; // 4 * 4
+            return 0;
+        }
+    "#;
+    assert_eq!(run_c_code_exit_status(source), 0);
+}
+
+#[test]
 fn test_nested_struct_designator() {
     let source = r#"
         struct SEA { int i; int j; };


### PR DESCRIPTION
This PR fixes several bugs and missing features related to array size deduction in the semantic lowering phase:

1. **String Literal Sizing:** Previously, the compiler used the source length of string literals (including quotes and prefixes) plus one to deduce array sizes. This resulted in incorrect `sizeof` values for regular, wide, and unicode strings. We now use `parse_string_literal` to get the actual number of elements.
2. **Brace-Enclosed Strings:** Initializing a character array with a string literal enclosed in braces (e.g., `char s[] = {"abc"}`) previously resulted in a size of 1. We now correctly handle this special C11 case.
3. **Compound Literals:** Incomplete array types in compound literals (e.g., `(char[]){"abc"}`) were not having their sizes deduced, leading to errors when applying `sizeof` to them. Deduction is now performed during lowering.

Tests in `src/tests/semantic_init.rs` have been updated to verify these changes.

---
*PR created automatically by Jules for task [13525528477248446084](https://jules.google.com/task/13525528477248446084) started by @bungcip*