### PR TITLE
Refactor: Address Clippy warnings and simplify control flow

### DIFF
--- a/src/parser/declarator.rs
+++ b/src/parser/declarator.rs
@@ -68,7 +68,7 @@ fn peek_past_attribute(parser: &Parser, mut start_offset: u32) -> Option<Token> 
         if let Some(t) = parser.peek_token(start_offset) {
             if t.kind != TokenKind::Attribute {
                 // Not an attribute, so we are done
-                return Some(t.clone());
+                return Some(*t);
             }
             // It is an attribute, loop again (start_offset points to it)
         } else {

--- a/src/pp/header_search.rs
+++ b/src/pp/header_search.rs
@@ -68,11 +68,9 @@ impl HeaderSearch {
         if !is_angled {
             for path_str in &self.quoted_includes {
                 let path: &Path = Path::new(path_str);
-                if !found_current {
-                    if current_dir.starts_with(path) {
-                        found_current = true;
-                        continue;
-                    }
+                if !found_current && current_dir.starts_with(path) {
+                    found_current = true;
+                    continue;
                 }
 
                 if found_current {
@@ -86,11 +84,9 @@ impl HeaderSearch {
 
         for path_str in &self.angled_includes {
             let path: &Path = Path::new(path_str);
-            if !found_current {
-                if current_dir.starts_with(path) {
-                    found_current = true;
-                    continue;
-                }
+            if !found_current && current_dir.starts_with(path) {
+                found_current = true;
+                continue;
             }
 
             if found_current {
@@ -102,11 +98,9 @@ impl HeaderSearch {
         }
 
         for path in &self.system_path {
-            if !found_current {
-                if current_dir.starts_with(path) {
-                    found_current = true;
-                    continue;
-                }
+            if !found_current && current_dir.starts_with(path) {
+                found_current = true;
+                continue;
             }
 
             if found_current {
@@ -118,11 +112,9 @@ impl HeaderSearch {
         }
 
         for path in &self.framework_path {
-            if !found_current {
-                if current_dir.starts_with(path) {
-                    found_current = true;
-                    continue;
-                }
+            if !found_current && current_dir.starts_with(path) {
+                found_current = true;
+                continue;
             }
 
             if found_current {

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -1443,17 +1443,15 @@ impl<'src> Preprocessor<'src> {
             });
         }
 
-        if is_angled {
-            if let Some(id) = self.built_in_file_ids.get(path).copied() {
-                let is_recursive = if let Some(current) = self.lexer_stack.last() {
-                    current.source_id == id
-                } else {
-                    false
-                };
+        if is_angled && let Some(id) = self.built_in_file_ids.get(path).copied() {
+            let is_recursive = if let Some(current) = self.lexer_stack.last() {
+                current.source_id == id
+            } else {
+                false
+            };
 
-                if !is_recursive {
-                    return Ok(id);
-                }
+            if !is_recursive {
+                return Ok(id);
             }
         }
 

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -2469,10 +2469,10 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             sym_ref
         } else {
             let name_str = name.as_str();
-            if name_str.starts_with("__builtin_") {
-                if let Some(sym_ref) = self.handle_builtin_implicit_decl(name, name_str, span) {
-                    return sym_ref;
-                }
+            if name_str.starts_with("__builtin_")
+                && let Some(sym_ref) = self.handle_builtin_implicit_decl(name, name_str, span)
+            {
+                return sym_ref;
             }
             self.report_error(SemanticError::UndeclaredIdentifier { name, span });
             SymbolRef::new(1).expect("SymbolRef 1 creation failed")

--- a/src/tests/semantic_common.rs
+++ b/src/tests/semantic_common.rs
@@ -63,7 +63,7 @@ pub fn setup_analysis(source: &str) -> (Ast, TypeRegistry, crate::semantic::Symb
 }
 
 pub fn find_layout<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::types::TypeLayout {
-    let s_ty = find_record_type(&registry, name);
+    let s_ty = find_record_type(registry, name);
     s_ty.layout.as_ref().expect("Layout not computed for S")
 }
 


### PR DESCRIPTION
This PR addresses several Clippy warnings and simplifies control flow in the preprocessor and semantic analysis modules. It includes:
1.  **Refactoring `if` statements:** Collapsed nested `if` statements into single expressions using `&&` and `let_chains` where appropriate (e.g., in `resolve_next_path` and `resolve_ident`).
2.  **Performance/Correctness:** Removed an unnecessary `clone()` on a `Copy` type (`Token`) in the parser.
3.  **Code Cleanup:** Removed a needless borrow in test utilities.

All changes have been verified with `cargo test` and `cargo clippy`. The use of `let_chains` is supported by the project's rustc version (1.91.0).

---
*PR created automatically by Jules for task [10778405982222573291](https://jules.google.com/task/10778405982222573291) started by @bungcip*