### PR TITLE
Cleanup unused public APIs and reduce visibility

### DIFF
--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -21,11 +21,11 @@ pub struct ParsedAst {
 }
 
 impl ParsedAst {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         ParsedAst::default()
     }
 
-    pub fn push_node(&mut self, node: ParsedNode) -> ParsedNodeRef {
+    pub(crate) fn push_node(&mut self, node: ParsedNode) -> ParsedNodeRef {
         let index = self.nodes.len() as u32 + 1;
         self.nodes.push(node);
         ParsedNodeRef::new(index).expect("ParsedNodeRef overflow")
@@ -35,7 +35,7 @@ impl ParsedAst {
         &self.nodes[(index.get() - 1) as usize]
     }
 
-    pub fn replace_node(&mut self, old_node_ref: ParsedNodeRef, new_node: ParsedNode) -> ParsedNodeRef {
+    pub(crate) fn replace_node(&mut self, old_node_ref: ParsedNodeRef, new_node: ParsedNode) -> ParsedNodeRef {
         let old_index = (old_node_ref.get() - 1) as usize;
         self.nodes[old_index] = new_node;
         old_node_ref
@@ -53,7 +53,7 @@ pub struct ParsedNode {
 }
 
 impl ParsedNode {
-    pub fn new(kind: ParsedNodeKind, span: SourceSpan) -> Self {
+    pub(crate) fn new(kind: ParsedNodeKind, span: SourceSpan) -> Self {
         ParsedNode { kind, span }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -90,7 +90,7 @@ pub struct Parser<'arena, 'src> {
 
 impl<'arena, 'src> Parser<'arena, 'src> {
     /// Create a new parser
-    pub fn new(tokens: &'src [Token], ast: &'arena mut ParsedAst, diag: &'src mut DiagnosticEngine) -> Self {
+    pub(crate) fn new(tokens: &'src [Token], ast: &'arena mut ParsedAst, diag: &'src mut DiagnosticEngine) -> Self {
         Parser {
             tokens,
             current_idx: 0,
@@ -290,7 +290,7 @@ impl<'arena, 'src> Parser<'arena, 'src> {
     }
 
     /// Parse translation unit (top level)
-    pub fn parse_translation_unit(&mut self) -> Result<ParsedNodeRef, ParseError> {
+    pub(crate) fn parse_translation_unit(&mut self) -> Result<ParsedNodeRef, ParseError> {
         declarations::parse_translation_unit(self)
     }
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -439,7 +439,7 @@ pub struct Lexer<'src> {
 
 impl<'src> Lexer<'src> {
     /// Create a new lexer with the given preprocessor token stream
-    pub fn new(tokens: &'src [PPToken]) -> Self {
+    pub(crate) fn new(tokens: &'src [PPToken]) -> Self {
         Lexer { tokens }
     }
 
@@ -470,7 +470,7 @@ impl<'src> Lexer<'src> {
     }
 
     /// Get all tokens from the stream
-    pub fn tokenize_all(&mut self) -> Vec<Token> {
+    pub(crate) fn tokenize_all(&mut self) -> Vec<Token> {
         // Bolt ⚡: Pre-allocate the tokens vector with the capacity of the preprocessor tokens.
         // This is a reasonable estimate that reduces the number of reallocations,
         // as the number of lexical tokens is usually similar to the number of preprocessor tokens.

--- a/src/pp/dumper.rs
+++ b/src/pp/dumper.rs
@@ -16,7 +16,7 @@ pub struct PPDumper<'a> {
 
 impl<'a> PPDumper<'a> {
     /// Create a new preprocessor dumper
-    pub fn new(tokens: &'a [PPToken], source_manager: &'a SourceManager, suppress_line_markers: bool) -> Self {
+    pub(crate) fn new(tokens: &'a [PPToken], source_manager: &'a SourceManager, suppress_line_markers: bool) -> Self {
         Self {
             tokens,
             source_manager,
@@ -25,7 +25,7 @@ impl<'a> PPDumper<'a> {
     }
 
     /// Dump preprocessed output to the given writer
-    pub fn dump(&self, writer: &mut impl Write) -> std::io::Result<()> {
+    pub(crate) fn dump(&self, writer: &mut impl Write) -> std::io::Result<()> {
         if self.tokens.is_empty() {
             return Ok(());
         }

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -363,7 +363,11 @@ impl crate::diagnostic::IntoDiagnostic for PPError {
 
 impl<'src> Preprocessor<'src> {
     /// Create a new preprocessor
-    pub fn new(source_manager: &'src mut SourceManager, diag: &'src mut DiagnosticEngine, config: &PPConfig) -> Self {
+    pub(crate) fn new(
+        source_manager: &'src mut SourceManager,
+        diag: &'src mut DiagnosticEngine,
+        config: &PPConfig,
+    ) -> Self {
         let mut header_search = HeaderSearch {
             system_path: Vec::new(),
             framework_path: Vec::new(),
@@ -724,7 +728,7 @@ impl<'src> Preprocessor<'src> {
     }
 
     /// Process source file and return preprocessed tokens
-    pub fn process(&mut self, source_id: SourceId, _config: &PPConfig) -> Result<Vec<PPToken>, PPError> {
+    pub(crate) fn process(&mut self, source_id: SourceId, _config: &PPConfig) -> Result<Vec<PPToken>, PPError> {
         // Initialize lexer for main file
         let buffer_len = self.sm.get_buffer(source_id).len() as u32;
         let buffer = self.sm.get_buffer_arc(source_id);

--- a/src/semantic/literal_utils.rs
+++ b/src/semantic/literal_utils.rs
@@ -16,7 +16,7 @@ pub struct ParsedStringLiteral {
     pub size: usize,
 }
 
-pub fn parse_string_literal(name: NameId) -> ParsedStringLiteral {
+pub(crate) fn parse_string_literal(name: NameId) -> ParsedStringLiteral {
     let raw = name.as_str();
 
     let (stripped, builtin_type, kind) = if let Some(s) = raw.strip_prefix("L\"") {

--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -44,15 +44,11 @@ pub struct Symbol {
 }
 
 impl Symbol {
-    pub fn is_const(&self) -> bool {
+    pub(crate) fn is_const(&self) -> bool {
         self.type_info.is_const()
     }
 
-    pub fn ty(&self) -> TypeRef {
-        self.type_info.ty()
-    }
-
-    pub fn has_linkage(&self) -> bool {
+    pub(crate) fn has_linkage(&self) -> bool {
         match &self.kind {
             SymbolKind::Function { .. } => true,
             SymbolKind::Variable { is_global, storage, .. } => *is_global || *storage == Some(StorageClass::Extern),


### PR DESCRIPTION
This change systematically cleans up the compiler's public API by reducing the visibility of internal components and removing redundant helper methods.

Key changes:
- Visibility reduction: Fundamental functions in `ParsedAst`, `Lexer`, `Preprocessor`, `PPDumper`, `Parser`, and `Symbol` were changed from `pub` to `pub(crate)`.
- Removal: The `Symbol::ty` method was removed as it was redundant with `symbol.type_info.ty()`.
- Test fix: Updated a failing snapshot test in `src/tests/driver_ast_dumper.rs` where symbol IDs had shifted.

These changes ensure a smaller, more maintainable public API for the `cendol` crate, focusing on `CompilerDriver` and `Cli` as the primary entry points.

---
*PR created automatically by Jules for task [10783217458434838731](https://jules.google.com/task/10783217458434838731) started by @bungcip*