### PR TITLE
Remove unused ArraySize enum

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -6,7 +6,6 @@
 
 use serde::Serialize;
 
-use crate::semantic::TypeQualifiers;
 use crate::{
     ast::{NameId, NodeRef, SymbolRef, TypeRef},
     semantic::{QualType, ScopeId},
@@ -541,23 +540,6 @@ impl BinaryOp {
             _ => None,
         }
     }
-}
-// Array sizes
-#[derive(Debug, Clone, Copy, Serialize)]
-pub enum ArraySize {
-    Expression {
-        expr: NodeRef,
-        qualifiers: TypeQualifiers,
-    },
-    Star {
-        qualifiers: TypeQualifiers,
-    }, // [*] VLA
-    Incomplete, // []
-    VlaSpecifier {
-        is_static: bool,
-        qualifiers: TypeQualifiers,
-        size: Option<NodeRef>,
-    }, // for VLA
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]


### PR DESCRIPTION
Identified and removed the unused `ArraySize` enum in `src/ast/nodes.rs`.
Verified that `ParsedArraySize` (in `src/ast/parsed.rs`) and `ArraySizeType` (in `src/semantic/types.rs`) are used instead.
Verified that removing `ArraySize` does not cause compilation errors or test failures.
Also removed the now unused import of `TypeQualifiers` in `src/ast/nodes.rs`.
Ran `cargo check` and `cargo test` to ensure correctness.

---
*PR created automatically by Jules for task [9645040709675006294](https://jules.google.com/task/9645040709675006294) started by @bungcip*