### PR TITLE
🛡️ Guardian: Enforce C11 restrict qualifier constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -34,3 +34,8 @@ Action: Implement and enforce alignment constraints during the semantic lowering
 
 Learning: C11 (6.7.2.4 and 6.7.3) enforces strict constraints on _Atomic. The qualifier is prohibited on array and function types. The _Atomic(type-name) specifier is even stricter: it also prohibits already atomic types and qualified types, and it requires the type-name to designate an object type. Redundant _Atomic qualifiers in a specifier-qualifier list are allowed and collapsed, but nested _Atomic specifiers are specifically prohibited by the specifier's constraints.
 Action: Enforce _Atomic constraints during semantic lowering in both qualifier merging and type-name resolution. Ensure that _Atomic(type-name) correctly results in an atomic-qualified version of the inner type.
+
+2025-05-20 - [Restrict Qualifier Constraints]
+
+Learning: C11 `restrict` constraints (6.7.3p2) require that it shall be a pointer type AND the pointed-to type shall be an object type or incomplete type. A function type is NOT an object type or an incomplete type. Therefore, `void (* restrict f)(void);` is invalid and must be rejected during semantic analysis.
+Action: Enforce pointed-to type constraints for the `restrict` qualifier in `merge_qualifiers_with_check` by ensuring the target type is not a function type.

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -220,8 +220,16 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
         add: TypeQualifiers,
         span: SourceSpan,
     ) -> QualType {
-        if add.contains(TypeQualifiers::RESTRICT) && !base.is_pointer() {
-            self.report_error(SemanticError::InvalidRestrict { span });
+        if add.contains(TypeQualifiers::RESTRICT) {
+            let is_valid = if let TypeKind::Pointer { pointee } = &self.registry.get(base.ty()).kind {
+                !pointee.is_function()
+            } else {
+                false
+            };
+
+            if !is_valid {
+                self.report_error(SemanticError::InvalidRestrict { span });
+            }
         }
         if add.contains(TypeQualifiers::ATOMIC) {
             if base.is_array() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -62,6 +62,7 @@ pub mod codegen_regr;
 pub mod guardian_addr_sizeof_constraints;
 pub mod guardian_bitfields;
 pub mod guardian_pointer_arithmetic;
+pub mod guardian_restrict_constraints;
 pub mod mir_unit;
 pub mod parser_type_conflict;
 pub mod pp_u8_literal;

--- a/src/tests/guardian_restrict_constraints.rs
+++ b/src/tests/guardian_restrict_constraints.rs
@@ -1,0 +1,27 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_message;
+
+#[test]
+fn test_restrict_on_function_pointer_prohibited() {
+    // C11 6.7.3p2: restrict shall be a pointer type, and the type it points to
+    // shall be an object type or an incomplete type.
+    // A function type is NOT an object type or an incomplete type.
+    run_fail_with_message(
+        r#"
+        void (* restrict f)(void);
+        "#,
+        CompilePhase::Mir,
+        "restrict requires a pointer type",
+    );
+}
+
+#[test]
+fn test_restrict_on_non_pointer_prohibited() {
+    run_fail_with_message(
+        r#"
+        int restrict x;
+        "#,
+        CompilePhase::Mir,
+        "restrict requires a pointer type",
+    );
+}


### PR DESCRIPTION
Identified and fixed a C11 compliance issue where the `restrict` qualifier was being incorrectly accepted on function pointers.

Key changes:
- Updated `merge_qualifiers_with_check` in `src/semantic/lowering.rs` to validate that `restrict` is only applied to pointers to object/incomplete types (specifically rejecting function types).
- Added `src/tests/guardian_restrict_constraints.rs` with negative test cases for invalid `restrict` usage.
- Registered the new test module in `src/tests.rs`.
- Updated `.jules/guardian.md` with the discovery and fix details.

---
*PR created automatically by Jules for task [10236967995250144595](https://jules.google.com/task/10236967995250144595) started by @bungcip*