### PR TITLE
test(coverage): add test for const eval division by zero

### DIFF
--- a/src/tests/semantic_const_eval.rs
+++ b/src/tests/semantic_const_eval.rs
@@ -272,3 +272,13 @@ fn test_logical_short_circuit_and() {
     ---
     ");
 }
+
+#[test]
+fn test_div_by_zero() {
+    let output = format_const_eval_batch(&["1 / 0"]);
+    insta::assert_snapshot!(output, @r"
+    Expression: 1 / 0
+    Result: None
+    ---
+    ");
+}


### PR DESCRIPTION
Added a unit test to `src/tests/semantic_const_eval.rs` to verify that division by zero in constant expressions returns `None`, increasing coverage of the error handling path in `eval_const_expr`.

---
*PR created automatically by Jules for task [12263437752140914756](https://jules.google.com/task/12263437752140914756) started by @bungcip*