### PR TITLE
Refactor compiler to use LinkGen and ObjectGen

### DIFF
--- a/src/codegen/clif_gen.rs
+++ b/src/codegen/clif_gen.rs
@@ -2604,11 +2604,7 @@ impl ClifGen {
         }
 
         // Finalize and return the compiled code
-        let product = self.module.finish();
-        let code = product
-            .object
-            .write()
-            .map_err(|e| format!("Failed to write object file: {:?}", e))?;
+        let code = crate::codegen::ObjectGen::finalize(self.module)?;
 
         if emit_kind == EmitKind::Object {
             Ok(ClifOutput::ObjectFile(code))

--- a/src/driver/compiler.rs
+++ b/src/driver/compiler.rs
@@ -413,63 +413,19 @@ impl CompilerDriver {
                         "a.out".into()
                     };
 
-                    // Link the object file into an executable using clang
-                    let mut clang_cmd = std::process::Command::new("clang");
-                    clang_cmd.args(&object_files_to_link);
+                    // Configure linker
+                    let link_config = crate::codegen::LinkConfig {
+                        output_path,
+                        library_paths: self.config.library_paths.clone(),
+                        libraries: self.config.libraries.clone(),
+                        optimization: self.config.optimization.clone(),
+                        debug_info: self.config.debug_info,
+                        verbose: self.config.verbose,
+                    };
 
-                    // Add library paths
-                    for path in &self.config.library_paths {
-                        clang_cmd.arg("-L").arg(path);
-                    }
-
-                    // Add libraries
-                    for lib in &self.config.libraries {
-                        clang_cmd.arg(format!("-l{}", lib));
-                    }
-
-                    // Add optimization flags if present
-                    if let Some(opt) = &self.config.optimization {
-                        clang_cmd.arg(format!("-O{}", opt));
-                    }
-
-                    // Add debug info if requested
-                    if self.config.debug_info {
-                        clang_cmd.arg("-g");
-                    }
-
-                    // Default to linking math library for now as it was before,
-                    // but we might want to let the user specify it via -lm
-                    if !self.config.libraries.contains(&"m".to_string()) {
-                        clang_cmd.arg("-lm");
-                    }
-
-                    // Suppress linker warnings about deprecated libc functions (tempnam, tmpnam, gets, etc.)
-                    // These warnings come from glibc, not from the compiled code
-                    clang_cmd.arg("-Wl,-w");
-
-                    if self.config.verbose {
-                        println!("Executing linker: {:?}", clang_cmd);
-                    }
-
-                    let status = clang_cmd
-                        .arg("-o")
-                        .arg(&output_path)
-                        .status()
-                        .map_err(|e| DriverError::IoError(format!("Failed to execute clang for linking: {}", e)))?;
-
-                    if !status.success() {
-                        return Err(DriverError::CompilationFailed);
-                    }
-
-                    // Set executable permissions on the output file
-                    use std::os::unix::fs::PermissionsExt;
-                    if let Ok(metadata) = std::fs::metadata(&output_path) {
-                        let mut permissions = metadata.permissions();
-                        permissions.set_mode(0o755); // rwxr-xr-x
-                        if let Err(e) = std::fs::set_permissions(&output_path, permissions) {
-                            eprintln!("Warning: Failed to set executable permissions: {}", e);
-                        }
-                    }
+                    // Link using LinkGen
+                    crate::codegen::LinkGen::link(&object_files_to_link, &link_config)
+                        .map_err(|e| DriverError::IoError(e.to_string()))?;
                 }
             }
             Err(e) => match e {


### PR DESCRIPTION
Refactored the compiler driver and code generation modules to utilize the `LinkGen` and `ObjectGen` abstractions.

- `src/codegen/clif_gen.rs`: Replaced manual object file finalization with `ObjectGen::finalize`.
- `src/driver/compiler.rs`: Replaced manual `clang` invocation and permission setting with `LinkGen::link` using `LinkConfig`.

This change centralizes object file generation and linking logic, improving code maintainability and separation of concerns.


---
*PR created automatically by Jules for task [2065165702488308681](https://jules.google.com/task/2065165702488308681) started by @bungcip*