### PR TITLE
Implement __builtin_offsetof support

### DIFF
--- a/src/ast/dumper.rs
+++ b/src/ast/dumper.rs
@@ -217,7 +217,7 @@ impl AstDumper {
             NodeKind::CompoundLiteral(qual_type, _) => {
                 type_refs.insert(qual_type.ty());
             }
-            NodeKind::BuiltinVaArg(qual_type, _) => {
+            NodeKind::BuiltinVaArg(qual_type, _) | NodeKind::BuiltinOffsetof(qual_type, _) => {
                 type_refs.insert(qual_type.ty());
             }
             NodeKind::BuiltinVaStart(_, _)
@@ -399,6 +399,9 @@ impl AstDumper {
             ParsedNodeKind::BuiltinExpect(exp, c) => {
                 writeln!(f, "BuiltinExpect({}, {})", exp.get(), c.get())
             }
+            ParsedNodeKind::BuiltinOffsetof(ty, expr) => {
+                writeln!(f, "BuiltinOffsetof({:?}, {})", ty, expr.get())
+            }
             ParsedNodeKind::AtomicOp(op, args) => {
                 let args_str = args.iter().map(|a| a.get().to_string()).collect::<Vec<_>>().join(", ");
                 writeln!(f, "AtomicOp({:?}, args=[{}])", op, args_str)
@@ -565,6 +568,9 @@ impl AstDumper {
             }
             NodeKind::BuiltinExpect(exp, c) => {
                 writeln!(f, "BuiltinExpect({}, {})", exp.get(), c.get())
+            }
+            NodeKind::BuiltinOffsetof(ty, expr) => {
+                writeln!(f, "BuiltinOffsetof({}, {})", ty, expr.get())
             }
             NodeKind::AtomicOp(op, args_start, args_len) => {
                 let start = args_start.get();

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -47,6 +47,7 @@ pub enum NodeKind {
 
     Cast(QualType, NodeRef),
     BuiltinVaArg(QualType, NodeRef),
+    BuiltinOffsetof(QualType, NodeRef),
     BuiltinVaStart(NodeRef, NodeRef),
     BuiltinVaEnd(NodeRef),
     BuiltinVaCopy(NodeRef, NodeRef),
@@ -136,6 +137,7 @@ impl NodeKind {
             | NodeKind::MemberAccess(child, ..)
             | NodeKind::Cast(_, child)
             | NodeKind::BuiltinVaArg(_, child)
+            | NodeKind::BuiltinOffsetof(_, child)
             | NodeKind::BuiltinVaEnd(child)
             | NodeKind::SizeOfExpr(child)
             | NodeKind::CompoundLiteral(_, child)

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -80,6 +80,7 @@ pub enum ParsedNodeKind {
 
     Cast(ParsedType, ParsedNodeRef),
     BuiltinVaArg(ParsedType, ParsedNodeRef),
+    BuiltinOffsetof(ParsedType, ParsedNodeRef),
     BuiltinVaStart(ParsedNodeRef, ParsedNodeRef),
     BuiltinVaEnd(ParsedNodeRef),
     BuiltinVaCopy(ParsedNodeRef, ParsedNodeRef),

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -83,6 +83,10 @@ impl<'a> MirGen<'a> {
             }
             NodeKind::SizeOfType(ty) => self.emit_type_query(ty.ty(), true),
             NodeKind::AlignOf(ty) => self.emit_type_query(ty.ty(), false),
+            NodeKind::BuiltinOffsetof(..) => {
+                let val = eval_const_expr(&self.const_ctx(), expr_ref).expect("offsetof should be constant");
+                self.create_int_operand(val)
+            }
             NodeKind::GenericSelection(gs) => self.emit_generic_selection(gs, need_value, expr_ref),
             NodeKind::GnuStatementExpression(stmt, result_expr) => {
                 self.emit_gnu_stmt_expr(*stmt, *result_expr, need_value)

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -402,6 +402,12 @@ pub enum SemanticError {
 
     #[error("continue statement not in loop statement")]
     ContinueNotInLoop { span: SourceSpan },
+
+    #[error("subscripted value is not an array (have '{found}')")]
+    ExpectedArrayType { found: String, span: SourceSpan },
+
+    #[error("invalid designator in 'offsetof'")]
+    InvalidOffsetofDesignator { span: SourceSpan },
 }
 
 impl SemanticError {
@@ -478,6 +484,8 @@ impl SemanticError {
             SemanticError::AlignmentTooLoose { span, .. } => *span,
             SemanticError::BreakNotInLoop { span } => *span,
             SemanticError::ContinueNotInLoop { span } => *span,
+            SemanticError::ExpectedArrayType { span, .. } => *span,
+            SemanticError::InvalidOffsetofDesignator { span } => *span,
         }
     }
 }

--- a/src/driver/compiler.rs
+++ b/src/driver/compiler.rs
@@ -70,11 +70,11 @@ impl CompilerDriver {
                 PathOrBuffer::Buffer(_, _) => false,
             };
 
-            if is_external_object {
-                if let PathOrBuffer::Path(path) = input_file {
-                    outputs.external_object_files.push(path);
-                    continue;
-                }
+            if is_external_object
+                && let PathOrBuffer::Path(path) = input_file
+            {
+                outputs.external_object_files.push(path);
+                continue;
             }
 
             let source_id = match input_file {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,7 @@ fn main() {
     // Clap does not strictly support single-dash long options (e.g. -std=c99), so we manually
     // map them to double-dash options (e.g. --std=c99) before parsing.
     let args = std::env::args().map(|arg| {
-        if arg.starts_with("-std=") {
-            format!("-{}", arg)
-        } else if arg.starts_with("-target=") {
+        if arg.starts_with("-std=") || arg.starts_with("-target=") {
             format!("-{}", arg)
         } else if arg == "-pedantic" {
             "--pedantic".to_string()

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -80,6 +80,7 @@ pub enum TokenKind {
     BuiltinVaEnd,
     BuiltinVaCopy,
     BuiltinExpect,
+    BuiltinOffsetof,
     Asm,
 
     // Atomic builtins
@@ -398,6 +399,7 @@ fn keyword_map() -> &'static hashbrown::HashMap<StringId, TokenKind> {
         m.insert(StringId::new("__builtin_va_end"), TokenKind::BuiltinVaEnd);
         m.insert(StringId::new("__builtin_va_copy"), TokenKind::BuiltinVaCopy);
         m.insert(StringId::new("__builtin_expect"), TokenKind::BuiltinExpect);
+        m.insert(StringId::new("__builtin_offsetof"), TokenKind::BuiltinOffsetof);
         m.insert(StringId::new("__atomic_load_n"), TokenKind::BuiltinAtomicLoadN);
         m.insert(StringId::new("__atomic_store_n"), TokenKind::BuiltinAtomicStoreN);
         m.insert(StringId::new("__atomic_exchange_n"), TokenKind::BuiltinAtomicExchangeN);

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -20,6 +20,7 @@ pub struct SemanticInfo {
     pub conversions: Vec<SmallVec<[Conversion; 1]>>,
     pub value_categories: Vec<ValueCategory>,
     pub generic_selections: HashMap<usize, NodeRef>, // Maps NodeIndex of GenericSelection to selected result_expr
+    pub offsetof_results: HashMap<usize, i64>,       // Maps NodeIndex of BuiltinOffsetof to computed offset
 }
 
 impl SemanticInfo {
@@ -29,6 +30,7 @@ impl SemanticInfo {
             conversions: vec![SmallVec::new(); n],
             value_categories: vec![ValueCategory::RValue; n],
             generic_selections: HashMap::new(),
+            offsetof_results: HashMap::new(),
         }
     }
 }
@@ -1720,6 +1722,7 @@ impl<'a> SemanticAnalyzer<'a> {
                 self.visit_node(*c);
                 ty
             }
+            NodeKind::BuiltinOffsetof(ty, expr) => self.visit_builtin_offsetof(*ty, *expr, node_ref),
             NodeKind::AtomicOp(op, args_start, args_len) => {
                 let span = self.ast.get_span(node_ref);
                 self.visit_atomic_op(*op, *args_start, *args_len, span)
@@ -2116,6 +2119,109 @@ impl<'a> SemanticAnalyzer<'a> {
                 span: self.ast.get_span(node_ref),
             });
             None
+        }
+    }
+
+    fn visit_builtin_offsetof(&mut self, ty: QualType, expr_ref: NodeRef, node_ref: NodeRef) -> Option<QualType> {
+        self.visit_type_expressions(ty);
+
+        let mut current_ty = ty;
+        let mut offset = 0i64;
+
+        if !self.compute_offsetof_recursive(expr_ref, &mut current_ty, &mut offset) {
+            let res_ty = QualType::unqualified(self.registry.type_long_unsigned);
+            return Some(res_ty);
+        }
+
+        self.semantic_info.offsetof_results.insert(node_ref.index(), offset);
+        let res_ty = QualType::unqualified(self.registry.type_long_unsigned);
+        Some(res_ty)
+    }
+
+    fn compute_offsetof_recursive(&mut self, node_ref: NodeRef, current_ty: &mut QualType, offset: &mut i64) -> bool {
+        let kind = *self.ast.get_kind(node_ref);
+        match kind {
+            NodeKind::Dummy => true,
+            NodeKind::MemberAccess(base, member_name, is_arrow) => {
+                if !self.compute_offsetof_recursive(base, current_ty, offset) {
+                    return false;
+                }
+
+                let record_ty = if is_arrow {
+                    self.registry.get_pointee(current_ty.ty()).map(|qt| qt.ty())
+                } else {
+                    Some(current_ty.ty())
+                };
+
+                let Some(record_ty) = record_ty else {
+                    self.report_error(SemanticError::MemberAccessOnNonRecord {
+                        ty: self.registry.display_qual_type(*current_ty),
+                        span: self.ast.get_span(node_ref),
+                    });
+                    return false;
+                };
+
+                if !record_ty.is_record() {
+                    self.report_error(SemanticError::MemberAccessOnNonRecord {
+                        ty: self.registry.display_qual_type(QualType::unqualified(record_ty)),
+                        span: self.ast.get_span(node_ref),
+                    });
+                    return false;
+                }
+
+                let mut flat_members = Vec::new();
+                let mut flat_offsets = Vec::new();
+                let ty_obj = self.registry.get(record_ty);
+                ty_obj.flatten_members_with_layouts(self.registry, &mut flat_members, &mut flat_offsets, 0);
+
+                if let Some(idx) = flat_members.iter().position(|m| m.name == Some(member_name)) {
+                    *offset += flat_offsets[idx] as i64;
+                    *current_ty = flat_members[idx].member_type;
+                    true
+                } else {
+                    self.report_error(SemanticError::MemberNotFound {
+                        name: member_name,
+                        ty: self.registry.display_type(record_ty),
+                        span: self.ast.get_span(node_ref),
+                    });
+                    false
+                }
+            }
+            NodeKind::IndexAccess(base, index) => {
+                if !self.compute_offsetof_recursive(base, current_ty, offset) {
+                    return false;
+                }
+
+                let elem_ty = self.registry.get_array_element(current_ty.ty());
+                let Some(elem_ty) = elem_ty else {
+                    self.report_error(SemanticError::ExpectedArrayType {
+                        found: self.registry.display_qual_type(*current_ty),
+                        span: self.ast.get_span(node_ref),
+                    });
+                    return false;
+                };
+
+                self.visit_node(index);
+                let index_val = crate::semantic::const_eval::eval_const_expr(&self.const_ctx(), index);
+                let Some(index_val) = index_val else {
+                    // C11 7.19p3: "integer constant expression"
+                    self.report_error(SemanticError::NonConstantInitializer {
+                        span: self.ast.get_span(index),
+                    });
+                    return false;
+                };
+
+                let layout = self.registry.get_layout(elem_ty);
+                *offset += index_val * (layout.size as i64);
+                *current_ty = QualType::unqualified(elem_ty);
+                true
+            }
+            _ => {
+                self.report_error(SemanticError::InvalidOffsetofDesignator {
+                    span: self.ast.get_span(node_ref),
+                });
+                false
+            }
         }
     }
 }

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -2293,6 +2293,14 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                 self.ast.kinds[node.index()] = NodeKind::BuiltinVaArg(ty, e);
                 smallvec![node]
             }
+            ParsedNodeKind::BuiltinOffsetof(ty_name, expr) => {
+                let node = self.get_or_push_slot(target_slots, span);
+                let e = self.visit_expression(*expr);
+                let ty = convert_to_qual_type(self, *ty_name, span)
+                    .unwrap_or(QualType::unqualified(self.registry.type_error));
+                self.ast.kinds[node.index()] = NodeKind::BuiltinOffsetof(ty, e);
+                smallvec![node]
+            }
             ParsedNodeKind::BuiltinVaStart(ap, last) => {
                 let node = self.get_or_push_slot(target_slots, span);
                 let a = self.visit_expression(*ap);
@@ -2688,6 +2696,9 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                 }
             }
             ParsedNodeKind::BuiltinVaArg(_, expr) => {
+                self.collect_labels(*expr);
+            }
+            ParsedNodeKind::BuiltinOffsetof(_, expr) => {
                 self.collect_labels(*expr);
             }
             ParsedNodeKind::BuiltinVaStart(ap, last) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -57,6 +57,7 @@ pub mod semantic_alignment_constraints;
 pub mod semantic_composite;
 pub mod test_utils;
 
+pub mod builtin_offsetof;
 pub mod codegen_cast_init;
 pub mod codegen_regr;
 pub mod guardian_addr_sizeof_constraints;

--- a/src/tests/builtin_offsetof.rs
+++ b/src/tests/builtin_offsetof.rs
@@ -1,0 +1,120 @@
+use crate::tests::codegen_common::run_c_code_with_output;
+
+#[test]
+fn test_builtin_offsetof_simple() {
+    let source = r#"
+        struct S {
+            char a;
+            int b;
+            char c;
+        };
+        int printf(const char *, ...);
+        int main() {
+            printf("%d %d %d", (int)__builtin_offsetof(struct S, a),
+                               (int)__builtin_offsetof(struct S, b),
+                               (int)__builtin_offsetof(struct S, c));
+            return 0;
+        }
+    "#;
+    let output = run_c_code_with_output(source);
+    // On x86_64: char a (0), padding (1-3), int b (4), char c (8)
+    assert_eq!(output, "0 4 8");
+}
+
+#[test]
+fn test_builtin_offsetof_nested() {
+    let source = r#"
+        struct Inner {
+            char x;
+            int y;
+        };
+        struct Outer {
+            char a;
+            struct Inner b;
+        };
+        int printf(const char *, ...);
+        int main() {
+            printf("%d %d", (int)__builtin_offsetof(struct Outer, b.x),
+                             (int)__builtin_offsetof(struct Outer, b.y));
+            return 0;
+        }
+    "#;
+    let output = run_c_code_with_output(source);
+    // Outer: char a (0), padding (1-3), Inner b (4)
+    // Inner: char x (0), padding (1-3), int y (4)
+    // b.x is at 4 + 0 = 4
+    // b.y is at 4 + 4 = 8
+    assert_eq!(output, "4 8");
+}
+
+#[test]
+fn test_builtin_offsetof_array() {
+    let source = r#"
+        struct S {
+            int a[10];
+            int b;
+        };
+        int printf(const char *, ...);
+        int main() {
+            printf("%d %d", (int)__builtin_offsetof(struct S, a[0]),
+                             (int)__builtin_offsetof(struct S, a[5]));
+            return 0;
+        }
+    "#;
+    let output = run_c_code_with_output(source);
+    assert_eq!(output, "0 20");
+}
+
+#[test]
+fn test_builtin_offsetof_anonymous() {
+    let source = r#"
+        struct S {
+            char a;
+            struct {
+                char b;
+                int c;
+            };
+        };
+        int printf(const char *, ...);
+        int main() {
+            printf("%d %d", (int)__builtin_offsetof(struct S, b),
+                             (int)__builtin_offsetof(struct S, c));
+            return 0;
+        }
+    "#;
+    let output = run_c_code_with_output(source);
+    // S: char a (0), anonymous struct (starts at 4 due to int c alignment)
+    // anonymous: char b (0), int c (4)
+    // b is at 4 + 0 = 4
+    // c is at 4 + 4 = 8
+    assert_eq!(output, "4 8");
+}
+
+#[test]
+fn test_builtin_offsetof_stddef() {
+    let source = r#"
+        #include <stddef.h>
+        struct S { int a; int b; };
+        int printf(const char *, ...);
+        int main() {
+            printf("%d", (int)offsetof(struct S, b));
+            return 0;
+        }
+    "#;
+    let output = run_c_code_with_output(source);
+    assert_eq!(output, "4");
+}
+
+#[test]
+fn test_builtin_offsetof_constant_context() {
+    let source = r#"
+        struct S { char a; int b; };
+        int main() {
+            int arr[__builtin_offsetof(struct S, b)];
+            return sizeof(arr) / sizeof(int);
+        }
+    "#;
+    use crate::tests::codegen_common::run_c_code_exit_status;
+    let status = run_c_code_exit_status(source);
+    assert_eq!(status, 4);
+}


### PR DESCRIPTION
Implemented `__builtin_offsetof` from lexer to codegen, including support for constant contexts like array sizes. Handled nested structs, arrays, and anonymous members. Added comprehensive unit tests.

---
*PR created automatically by Jules for task [17832729161467681237](https://jules.google.com/task/17832729161467681237) started by @bungcip*