### PR TITLE
Increase coverage for SourceManager::get_buffer_arc panic

### DIFF
--- a/src/tests/driver_source_manager.rs
+++ b/src/tests/driver_source_manager.rs
@@ -533,3 +533,11 @@ fn test_source_span_mixed_ids() {
     assert_eq!(span.start().offset(), 10);
     assert_eq!(span.end().offset(), 10);
 }
+
+#[test]
+#[should_panic(expected = "invalid source_id SourceId(999)")]
+fn test_source_manager_get_buffer_arc_invalid_id() {
+    let sm = SourceManager::new();
+    let invalid_id = SourceId::new(999);
+    sm.get_buffer_arc(invalid_id);
+}


### PR DESCRIPTION
This PR increases code coverage by adding a unit test for the panic path in `SourceManager::get_buffer_arc`.

### Changes
- Modified `src/tests/driver_source_manager.rs`:
    - Added `test_source_manager_get_buffer_arc_invalid_id` test case.

### Coverage
- Verified locally with `cargo llvm-cov`. The panic path in `get_buffer_arc` is now covered.


---
*PR created automatically by Jules for task [3661309117583064156](https://jules.google.com/task/3661309117583064156) started by @bungcip*