### PR TITLE
Clean up unused or unnecessarily public APIs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -127,7 +127,7 @@ impl NodeRef {
 
     /// Create an iterator over a range of consecutive NodeRefs, starting from `self`.
     #[inline]
-    pub fn range(self, len: impl Into<u32>) -> NodeRefRange {
+    pub(crate) fn range(self, len: impl Into<u32>) -> NodeRefRange {
         NodeRefRange {
             current: self.get(),
             end: self.get() + len.into(),
@@ -137,7 +137,7 @@ impl NodeRef {
 
 /// An iterator over a contiguous range of `NodeRef`s.
 #[derive(Clone, Debug)]
-pub struct NodeRefRange {
+pub(crate) struct NodeRefRange {
     current: u32,
     end: u32,
 }

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -31,7 +31,7 @@ impl ParsedAst {
         ParsedNodeRef::new(index).expect("ParsedNodeRef overflow")
     }
 
-    pub fn get_node(&self, index: ParsedNodeRef) -> &ParsedNode {
+    pub(crate) fn get_node(&self, index: ParsedNodeRef) -> &ParsedNode {
         &self.nodes[(index.get() - 1) as usize]
     }
 
@@ -41,7 +41,7 @@ impl ParsedAst {
         old_node_ref
     }
 
-    pub fn get_root(&self) -> ParsedNodeRef {
+    pub(crate) fn get_root(&self) -> ParsedNodeRef {
         ParsedNodeRef::new(1).expect("Parsed AST empty")
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -17,8 +17,8 @@ pub(crate) mod mir_gen_ops;
 
 // Re-export key types for public API
 pub use clif_gen::{ClifOutput, EmitKind};
-pub use link_gen::{LinkConfig, LinkGen};
-pub use object_gen::ObjectGen;
+pub(crate) use link_gen::{LinkConfig, LinkGen};
+pub(crate) use object_gen::ObjectGen;
 
 // Re-export crate-internal types
 pub(crate) use clif_gen::ClifGen;

--- a/src/codegen/clif_gen.rs
+++ b/src/codegen/clif_gen.rs
@@ -2604,11 +2604,8 @@ impl ClifGen {
         }
 
         // Finalize and return the compiled code
-        let product = self.module.finish();
-        let code = product
-            .object
-            .write()
-            .map_err(|e| format!("Failed to write object file: {:?}", e))?;
+        use crate::codegen::ObjectGen;
+        let code = ObjectGen::finalize(self.module)?;
 
         if emit_kind == EmitKind::Object {
             Ok(ClifOutput::ObjectFile(code))

--- a/src/codegen/link_gen.rs
+++ b/src/codegen/link_gen.rs
@@ -8,24 +8,24 @@ use std::process::Command;
 
 /// Configuration for the linker.
 #[derive(Debug, Clone, Default)]
-pub struct LinkConfig {
+pub(crate) struct LinkConfig {
     /// Output file path
-    pub output_path: PathBuf,
+    pub(crate) output_path: PathBuf,
     /// Library search paths (-L)
-    pub library_paths: Vec<PathBuf>,
+    pub(crate) library_paths: Vec<PathBuf>,
     /// Libraries to link (-l)
-    pub libraries: Vec<String>,
+    pub(crate) libraries: Vec<String>,
     /// Optimization level (e.g., "0", "1", "2", "3", "s")
-    pub optimization: Option<String>,
+    pub(crate) optimization: Option<String>,
     /// Include debug info (-g)
-    pub debug_info: bool,
+    pub(crate) debug_info: bool,
     /// Verbose output
-    pub verbose: bool,
+    pub(crate) verbose: bool,
 }
 
 /// Error type for linking operations.
 #[derive(Debug)]
-pub enum LinkError {
+pub(crate) enum LinkError {
     /// IO error during linking
     IoError(String),
     /// Linker returned non-zero exit code
@@ -44,7 +44,7 @@ impl std::fmt::Display for LinkError {
 impl std::error::Error for LinkError {}
 
 /// Links object files into an executable or library.
-pub struct LinkGen;
+pub(crate) struct LinkGen;
 
 impl LinkGen {
     /// Link object files into an executable using clang.
@@ -56,7 +56,7 @@ impl LinkGen {
     /// # Returns
     /// * `Ok(())` on success
     /// * `Err(LinkError)` on failure
-    pub fn link<P: AsRef<Path>>(object_files: &[P], config: &LinkConfig) -> Result<(), LinkError> {
+    pub(crate) fn link<P: AsRef<Path>>(object_files: &[P], config: &LinkConfig) -> Result<(), LinkError> {
         if object_files.is_empty() {
             return Ok(());
         }

--- a/src/codegen/object_gen.rs
+++ b/src/codegen/object_gen.rs
@@ -10,11 +10,11 @@ use cranelift_object::ObjectModule;
 /// Object file generator.
 ///
 /// This struct wraps the Cranelift ObjectModule finalization process.
-pub struct ObjectGen;
+pub(crate) struct ObjectGen;
 
 impl ObjectGen {
     /// Finalize an ObjectModule and produce the raw object file bytes.
-    pub fn finalize(module: ObjectModule) -> Result<Vec<u8>, String> {
+    pub(crate) fn finalize(module: ObjectModule) -> Result<Vec<u8>, String> {
         let product = module.finish();
         product
             .object

--- a/src/driver/cli.rs
+++ b/src/driver/cli.rs
@@ -207,7 +207,7 @@ impl Cli {
     }
 
     /// Convert CLI arguments into compilation configuration
-    pub fn into_config(self) -> Result<CompileConfig, String> {
+    pub(crate) fn into_config(self) -> Result<CompileConfig, String> {
         // Validate input files first
         self.validate_input_files()?;
 

--- a/src/driver/compiler.rs
+++ b/src/driver/compiler.rs
@@ -405,6 +405,9 @@ impl CompilerDriver {
 
                 // Link if we have object files and NOT compile_only
                 if !object_files_to_link.is_empty() && !self.config.compile_only {
+                    use crate::codegen::{LinkConfig, LinkGen};
+                    use crate::codegen::link_gen::LinkError;
+
                     // Determine the output path
                     let output_path = if let Some(output_path) = &self.config.output_path {
                         output_path.clone()
@@ -413,63 +416,19 @@ impl CompilerDriver {
                         "a.out".into()
                     };
 
-                    // Link the object file into an executable using clang
-                    let mut clang_cmd = std::process::Command::new("clang");
-                    clang_cmd.args(&object_files_to_link);
+                    let link_config = LinkConfig {
+                        output_path,
+                        library_paths: self.config.library_paths.clone(),
+                        libraries: self.config.libraries.clone(),
+                        optimization: self.config.optimization.clone(),
+                        debug_info: self.config.debug_info,
+                        verbose: self.config.verbose,
+                    };
 
-                    // Add library paths
-                    for path in &self.config.library_paths {
-                        clang_cmd.arg("-L").arg(path);
-                    }
-
-                    // Add libraries
-                    for lib in &self.config.libraries {
-                        clang_cmd.arg(format!("-l{}", lib));
-                    }
-
-                    // Add optimization flags if present
-                    if let Some(opt) = &self.config.optimization {
-                        clang_cmd.arg(format!("-O{}", opt));
-                    }
-
-                    // Add debug info if requested
-                    if self.config.debug_info {
-                        clang_cmd.arg("-g");
-                    }
-
-                    // Default to linking math library for now as it was before,
-                    // but we might want to let the user specify it via -lm
-                    if !self.config.libraries.contains(&"m".to_string()) {
-                        clang_cmd.arg("-lm");
-                    }
-
-                    // Suppress linker warnings about deprecated libc functions (tempnam, tmpnam, gets, etc.)
-                    // These warnings come from glibc, not from the compiled code
-                    clang_cmd.arg("-Wl,-w");
-
-                    if self.config.verbose {
-                        println!("Executing linker: {:?}", clang_cmd);
-                    }
-
-                    let status = clang_cmd
-                        .arg("-o")
-                        .arg(&output_path)
-                        .status()
-                        .map_err(|e| DriverError::IoError(format!("Failed to execute clang for linking: {}", e)))?;
-
-                    if !status.success() {
-                        return Err(DriverError::CompilationFailed);
-                    }
-
-                    // Set executable permissions on the output file
-                    use std::os::unix::fs::PermissionsExt;
-                    if let Ok(metadata) = std::fs::metadata(&output_path) {
-                        let mut permissions = metadata.permissions();
-                        permissions.set_mode(0o755); // rwxr-xr-x
-                        if let Err(e) = std::fs::set_permissions(&output_path, permissions) {
-                            eprintln!("Warning: Failed to set executable permissions: {}", e);
-                        }
-                    }
+                    LinkGen::link(&object_files_to_link, &link_config).map_err(|e| match e {
+                        LinkError::IoError(msg) => DriverError::IoError(msg),
+                        LinkError::LinkFailed => DriverError::CompilationFailed,
+                    })?;
                 }
             }
             Err(e) => match e {

--- a/src/mir/dumper.rs
+++ b/src/mir/dumper.rs
@@ -19,8 +19,8 @@ use crate::mir::MirProgram;
 
 /// Configuration for MIR dump output
 #[derive(Debug, Clone)]
-pub struct MirDumpConfig {
-    pub include_header: bool,
+pub(crate) struct MirDumpConfig {
+    pub(crate) include_header: bool,
 }
 
 impl Default for MirDumpConfig {
@@ -30,19 +30,19 @@ impl Default for MirDumpConfig {
 }
 
 /// Main MIR dumper that generates human-readable MIR output
-pub struct MirDumper<'a> {
+pub(crate) struct MirDumper<'a> {
     mir: &'a MirProgram,
     config: &'a MirDumpConfig,
 }
 
 impl<'a> MirDumper<'a> {
     /// Create a new MIR dumper
-    pub fn new(mir: &'a MirProgram, config: &'a MirDumpConfig) -> Self {
+    pub(crate) fn new(mir: &'a MirProgram, config: &'a MirDumpConfig) -> Self {
         Self { mir, config }
     }
 
     /// Generate the complete MIR dump
-    pub fn generate_mir_dump(&self) -> Result<String, std::fmt::Error> {
+    pub(crate) fn generate_mir_dump(&self) -> Result<String, std::fmt::Error> {
         let mut output = String::new();
 
         // Dump module header

--- a/src/tests/codegen_common.rs
+++ b/src/tests/codegen_common.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use tempfile::NamedTempFile;
 
 /// setup test with output is cranelift ir
-pub fn setup_cranelift(c_code: &str) -> String {
+pub(crate) fn setup_cranelift(c_code: &str) -> String {
     let (driver, pipeline_result) = test_utils::run_pipeline(c_code, CompilePhase::Cranelift);
     match pipeline_result {
         Err(_) => {
@@ -51,12 +51,12 @@ fn compile_and_run_c(source: &str) -> std::process::Output {
     Command::new(exe_path).output().expect("Failed to execute")
 }
 
-pub fn run_c_code_with_output(source: &str) -> String {
+pub(crate) fn run_c_code_with_output(source: &str) -> String {
     let run_output = compile_and_run_c(source);
     String::from_utf8_lossy(&run_output.stdout).to_string()
 }
 
-pub fn run_c_code_exit_status(source: &str) -> i32 {
+pub(crate) fn run_c_code_exit_status(source: &str) -> i32 {
     let run_output = compile_and_run_c(source);
     run_output.status.code().unwrap_or(-1)
 }

--- a/src/tests/pp_common.rs
+++ b/src/tests/pp_common.rs
@@ -4,9 +4,9 @@ use crate::tests::test_utils::setup_sm_and_diag;
 use serde::Serialize;
 
 #[derive(Serialize)]
-pub struct DebugToken {
-    pub kind: String,
-    pub text: String,
+pub(crate) struct DebugToken {
+    pub(crate) kind: String,
+    pub(crate) text: String,
 }
 
 impl From<&PPToken> for DebugToken {
@@ -26,16 +26,16 @@ impl From<&PPToken> for DebugToken {
     }
 }
 
-pub fn setup_pp_snapshot(src: &str) -> Vec<DebugToken> {
+pub(crate) fn setup_pp_snapshot(src: &str) -> Vec<DebugToken> {
     let (tokens, _) = setup_preprocessor_test_with_diagnostics(src, None).unwrap();
     tokens.iter().map(DebugToken::from).collect()
 }
 
-pub fn setup_pp_snapshot_with_diags(src: &str) -> (Vec<DebugToken>, Vec<String>) {
+pub(crate) fn setup_pp_snapshot_with_diags(src: &str) -> (Vec<DebugToken>, Vec<String>) {
     setup_pp_snapshot_with_diags_and_config(src, None)
 }
 
-pub fn setup_pp_snapshot_with_diags_and_config(src: &str, config: Option<PPConfig>) -> (Vec<DebugToken>, Vec<String>) {
+pub(crate) fn setup_pp_snapshot_with_diags_and_config(src: &str, config: Option<PPConfig>) -> (Vec<DebugToken>, Vec<String>) {
     // Return a Result-like structure for the snapshot
     match setup_preprocessor_test_with_diagnostics(src, config) {
         Ok((tokens, diags)) => {
@@ -47,7 +47,7 @@ pub fn setup_pp_snapshot_with_diags_and_config(src: &str, config: Option<PPConfi
     }
 }
 
-pub fn setup_multi_file_pp_snapshot(
+pub(crate) fn setup_multi_file_pp_snapshot(
     files: Vec<(&str, &str)>,
     main_file: &str,
     config: Option<PPConfig>,
@@ -63,14 +63,14 @@ pub fn setup_multi_file_pp_snapshot(
 }
 
 /// Helper function to set up preprocessor testing and return diagnostics
-pub fn setup_preprocessor_test_with_diagnostics(
+pub(crate) fn setup_preprocessor_test_with_diagnostics(
     src: &str,
     config: Option<PPConfig>,
 ) -> Result<(Vec<PPToken>, Vec<crate::diagnostic::Diagnostic>), PPError> {
     setup_multi_file_pp_with_diagnostics(vec![("<test>", src)], "<test>", config)
 }
 
-pub fn setup_multi_file_pp_with_diagnostics(
+pub(crate) fn setup_multi_file_pp_with_diagnostics(
     files: Vec<(&str, &str)>,
     main_file_name: &str,
     config: Option<PPConfig>,
@@ -85,7 +85,7 @@ pub fn setup_multi_file_pp_with_diagnostics(
     Ok((significant_tokens, diagnostics))
 }
 
-pub fn setup_multi_file_pp_with_diagnostics_raw(
+pub(crate) fn setup_multi_file_pp_with_diagnostics_raw(
     files: Vec<(&str, &str)>,
     main_file_name: &str,
     config: Option<PPConfig>,
@@ -115,17 +115,17 @@ pub fn setup_multi_file_pp_with_diagnostics_raw(
     Ok((tokens, diag.diagnostics().to_vec()))
 }
 
-pub struct TestLexer {
+pub(crate) struct TestLexer {
     lexer: crate::pp::pp_lexer::PPLexer,
 }
 
 impl TestLexer {
-    pub fn next_token(&mut self) -> Option<PPToken> {
+    pub(crate) fn next_token(&mut self) -> Option<PPToken> {
         self.lexer.next_token()
     }
 }
 
-pub fn create_test_pp_lexer(src: &str) -> TestLexer {
+pub(crate) fn create_test_pp_lexer(src: &str) -> TestLexer {
     let mut source_manager = SourceManager::new();
     let id = source_manager.add_buffer(src.as_bytes().to_vec(), "<test>", None);
     let lexer = crate::pp::pp_lexer::PPLexer::new(id, std::sync::Arc::from(src.as_bytes().to_vec()));

--- a/src/tests/semantic_common.rs
+++ b/src/tests/semantic_common.rs
@@ -5,7 +5,7 @@ use crate::mir::dumper::{MirDumpConfig, MirDumper};
 use crate::semantic::TypeRegistry;
 use crate::tests::test_utils;
 
-pub fn setup_mir(source: &str) -> String {
+pub(crate) fn setup_mir(source: &str) -> String {
     let (driver, result) = test_utils::run_pipeline(source, CompilePhase::Mir);
     let mut out = match result {
         Ok(out) => out,
@@ -22,7 +22,7 @@ pub fn setup_mir(source: &str) -> String {
     dumper.generate_mir_dump().expect("Failed to generate MIR dump")
 }
 
-pub fn setup_lowering(source: &str) -> (Ast, TypeRegistry, crate::semantic::SymbolTable) {
+pub(crate) fn setup_lowering(source: &str) -> (Ast, TypeRegistry, crate::semantic::SymbolTable) {
     let (driver, result) = test_utils::run_pipeline(source, CompilePhase::SemanticLowering);
     let out = match result {
         Ok(out) => out,
@@ -37,7 +37,7 @@ pub fn setup_lowering(source: &str) -> (Ast, TypeRegistry, crate::semantic::Symb
     )
 }
 
-pub fn setup_analysis(source: &str) -> (Ast, TypeRegistry, crate::semantic::SymbolTable) {
+pub(crate) fn setup_analysis(source: &str) -> (Ast, TypeRegistry, crate::semantic::SymbolTable) {
     let (driver, result) = test_utils::run_pipeline(source, CompilePhase::SemanticLowering);
     let out = match result {
         Ok(out) => out,
@@ -61,12 +61,12 @@ pub fn setup_analysis(source: &str) -> (Ast, TypeRegistry, crate::semantic::Symb
     (ast, registry, symbol_table)
 }
 
-pub fn find_layout<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::types::TypeLayout {
+pub(crate) fn find_layout<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::types::TypeLayout {
     let s_ty = find_record_type(registry, name);
     s_ty.layout.as_ref().expect("Layout not computed for S")
 }
 
-pub fn find_record_type<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::Type {
+pub(crate) fn find_record_type<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate::semantic::Type {
     registry
         .types
         .iter()
@@ -83,7 +83,7 @@ pub fn find_record_type<'a>(registry: &'a TypeRegistry, name: &str) -> &'a crate
         .unwrap_or_else(|| panic!("Record type '{}' not found in registry", name))
 }
 
-pub fn find_var_decl<'a>(ast: &'a Ast, name: &str) -> &'a crate::ast::VarDeclData {
+pub(crate) fn find_var_decl<'a>(ast: &'a Ast, name: &str) -> &'a crate::ast::VarDeclData {
     ast.kinds
         .iter()
         .find_map(|kind| {
@@ -98,7 +98,7 @@ pub fn find_var_decl<'a>(ast: &'a Ast, name: &str) -> &'a crate::ast::VarDeclDat
         .unwrap_or_else(|| panic!("Variable declaration '{}' not found in AST", name))
 }
 
-pub fn find_enum_constant(symbol_table: &crate::semantic::SymbolTable, name: &str) -> i64 {
+pub(crate) fn find_enum_constant(symbol_table: &crate::semantic::SymbolTable, name: &str) -> i64 {
     symbol_table
         .entries
         .iter()

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -60,30 +60,30 @@ pub(crate) fn sort_clif_ir(ir: &str) -> String {
     functions.join("\n\n")
 }
 
-pub fn run_pass(source: &str, phase: CompilePhase) {
+pub(crate) fn run_pass(source: &str, phase: CompilePhase) {
     let (driver, result) = run_pipeline(source, phase);
     if result.is_err() {
         panic!("Compilation failed unexpectedly: {:?}", driver.get_diagnostics());
     }
 }
 
-pub fn run_fail(source: &str, phase: CompilePhase) -> CompilerDriver {
+pub(crate) fn run_fail(source: &str, phase: CompilePhase) -> CompilerDriver {
     let (driver, result) = run_pipeline(source, phase);
     assert!(result.is_err(), "Compilation should have failed");
     driver
 }
 
-pub fn run_fail_with_message(source: &str, phase: CompilePhase, message: &str) {
+pub(crate) fn run_fail_with_message(source: &str, phase: CompilePhase, message: &str) {
     let driver = run_fail(source, phase);
     check_diagnostic_message_only(&driver, message);
 }
 
-pub fn run_fail_with_diagnostic(source: &str, phase: CompilePhase, message: &str, line: u32, col: u32) {
+pub(crate) fn run_fail_with_diagnostic(source: &str, phase: CompilePhase, message: &str, line: u32, col: u32) {
     let driver = run_fail(source, phase);
     check_diagnostic(&driver, message, line, col);
 }
 
-pub fn check_diagnostic(driver: &CompilerDriver, message: &str, line: u32, col: u32) {
+pub(crate) fn check_diagnostic(driver: &CompilerDriver, message: &str, line: u32, col: u32) {
     let diagnostics = driver.get_diagnostics();
     let found = diagnostics.iter().any(|d| {
         if d.message.contains(message)
@@ -102,7 +102,7 @@ pub fn check_diagnostic(driver: &CompilerDriver, message: &str, line: u32, col: 
     );
 }
 
-pub fn check_diagnostic_message_only(driver: &CompilerDriver, message: &str) {
+pub(crate) fn check_diagnostic_message_only(driver: &CompilerDriver, message: &str) {
     let diagnostics = driver.get_diagnostics();
     let found = diagnostics.iter().any(|d| d.message.contains(message));
     assert!(
@@ -112,7 +112,7 @@ pub fn check_diagnostic_message_only(driver: &CompilerDriver, message: &str) {
     );
 }
 
-pub fn setup_diagnostics_output(source: &str) -> String {
+pub(crate) fn setup_diagnostics_output(source: &str) -> String {
     let (driver, _) = run_pipeline(source, CompilePhase::Mir);
     let diagnostics = driver.get_diagnostics();
 
@@ -130,7 +130,7 @@ pub fn setup_diagnostics_output(source: &str) -> String {
     )
 }
 
-pub fn run_pass_with_diagnostic(source: &str, phase: CompilePhase, message: &str, line: u32, col: u32) {
+pub(crate) fn run_pass_with_diagnostic(source: &str, phase: CompilePhase, message: &str, line: u32, col: u32) {
     let (driver, result) = run_pipeline(source, phase);
     assert!(result.is_ok(), "Compilation should have succeeded");
     check_diagnostic(&driver, message, line, col);


### PR DESCRIPTION
Systematically cleaned up unused public APIs by downgrading visibility to `pub(crate)` or removing duplicated logic. Key internal components like `MirDumper`, `LinkGen`, and `ObjectGen` are now properly integrated into the compilation pipeline while remaining internal to the crate. Test utilities were also restricted to internal visibility.

---
*PR created automatically by Jules for task [5156088168380091349](https://jules.google.com/task/5156088168380091349) started by @bungcip*