### PR TITLE
⚡ Bolt: optimize MacroInfo with Arc for token lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2026-11-25 - Reducing Allocations for HashMap Keys
 **Learning:** Using `Vec<T>` as a key in a `HashMap` (or as part of a composite key) causes a heap allocation on every lookup, even for cache hits. This is especially costly in hot paths like type canonicalization.
 **Action:** Use `SmallVec<[T; N]>` for collection fields in composite keys. This allows the key to be stack-allocated during lookup for the common case where the collection is small, significantly reducing heap pressure and improving cache locality.
+
+## 2026-11-28 - Optimized MacroInfo with Arc for Token Lists
+**Learning:** Cloning `MacroInfo` on every macro expansion and push/pop operation was a significant bottleneck due to `Vec<PPToken>` and `Vec<StringId>` causing repeated heap allocations and deep copies.
+**Action:** Use `Arc<[T]>` for immutable collections in frequently cloned data structures like `MacroInfo`. This turns (N)$ clones into (1)$ reference count increments while maintaining read-only performance.

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Datelike, Timelike, Utc};
 use hashbrown::HashMap;
 use std::borrow::Cow;
 use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
 
 use super::pp_lexer::PPLexer;
 use crate::pp::interpreter::Interpreter;
@@ -150,8 +151,8 @@ bitflags::bitflags! {
 pub(crate) struct MacroInfo {
     pub(crate) location: SourceLoc,
     pub(crate) flags: MacroFlags, // Packed boolean flags
-    pub(crate) tokens: Vec<PPToken>,
-    pub(crate) parameter_list: Vec<StringId>,
+    pub(crate) tokens: Arc<[PPToken]>,
+    pub(crate) parameter_list: Arc<[StringId]>,
     pub(crate) variadic_arg: Option<StringId>,
 }
 
@@ -594,8 +595,8 @@ impl<'src> Preprocessor<'src> {
         let macro_info = MacroInfo {
             location: SourceLoc::builtin(),
             flags: MacroFlags::BUILTIN,
-            tokens,
-            parameter_list: Vec::new(),
+            tokens: Arc::from(tokens),
+            parameter_list: Arc::from([]),
             variadic_arg: None,
         };
         self.macros.insert(symbol, macro_info);
@@ -1166,8 +1167,8 @@ impl<'src> Preprocessor<'src> {
         let macro_info = MacroInfo {
             location: name_token.location,
             flags,
-            tokens,
-            parameter_list: params,
+            tokens: Arc::from(tokens),
+            parameter_list: Arc::from(params),
             variadic_arg: variadic,
         };
 


### PR DESCRIPTION
Identified that \`MacroInfo\` was being cloned on every macro expansion and stack operation (push/pop). Since macro definitions are immutable once created, changed the \`tokens\` and \`parameter_list\` fields to use \`Arc<[T]>\` to avoid expensive heap allocations and deep copies during these clones. updated creation sites in \`handle_define\` and \`define_builtin_macro\` to use \`Arc::from()\`. Verified with full test suite.

---
*PR created automatically by Jules for task [349026563234864198](https://jules.google.com/task/349026563234864198) started by @bungcip*