### PR TITLE
Increase coverage for semantic type display

### DIFF
--- a/src/tests/semantic_types.rs
+++ b/src/tests/semantic_types.rs
@@ -561,3 +561,39 @@ fn test_struct_copy_init() {
     }
     ");
 }
+
+#[test]
+fn test_type_registry_display_builtins() {
+    use crate::semantic::type_registry::TypeRegistry;
+    use crate::semantic::types::BuiltinType;
+    use target_lexicon::Triple;
+
+    let reg = TypeRegistry::new(Triple::host());
+
+    let cases = [
+        (BuiltinType::Void, "void"),
+        (BuiltinType::Bool, "_Bool"),
+        (BuiltinType::Char, "char"),
+        (BuiltinType::SChar, "signed char"),
+        (BuiltinType::UChar, "unsigned char"),
+        (BuiltinType::Short, "short"),
+        (BuiltinType::UShort, "unsigned short"),
+        (BuiltinType::Int, "int"),
+        (BuiltinType::UInt, "unsigned int"),
+        (BuiltinType::Long, "long"),
+        (BuiltinType::ULong, "unsigned long"),
+        (BuiltinType::LongLong, "long long"),
+        (BuiltinType::ULongLong, "unsigned long long"),
+        (BuiltinType::Float, "float"),
+        (BuiltinType::Double, "double"),
+        (BuiltinType::LongDouble, "long double"),
+        (BuiltinType::Signed, "signed"),
+        (BuiltinType::VaList, "__builtin_va_list"),
+        (BuiltinType::Complex, "_Complex (marker)"),
+    ];
+
+    for (builtin, expected) in cases {
+        let ty = reg.get_builtin_type(builtin);
+        assert_eq!(reg.display_type(ty), expected, "Failed for {:?}", builtin);
+    }
+}


### PR DESCRIPTION
Added a new unit test to `src/tests/semantic_types.rs` that verifies `TypeRegistry::display_type` correctly formats all builtin types. This addresses uncovered code paths in `src/semantic/type_registry.rs`.

---
*PR created automatically by Jules for task [11536322690027250623](https://jules.google.com/task/11536322690027250623) started by @bungcip*