### PR TITLE
Add support for -fuse-ld option

### DIFF
--- a/src/codegen/link_gen.rs
+++ b/src/codegen/link_gen.rs
@@ -21,6 +21,8 @@ pub(crate) struct LinkConfig {
     pub debug_info: bool,
     /// Verbose output
     pub verbose: bool,
+    /// Use a specific linker
+    pub fuse_ld: Option<String>,
 }
 
 /// Error type for linking operations.
@@ -86,6 +88,10 @@ impl LinkGen {
         // Add debug info if requested
         if config.debug_info {
             clang_cmd.arg("-g");
+        }
+
+        if let Some(linker) = &config.fuse_ld {
+            clang_cmd.arg(format!("-fuse-ld={}", linker));
         }
 
         // Default to linking math library

--- a/src/driver/cli.rs
+++ b/src/driver/cli.rs
@@ -103,6 +103,10 @@ pub struct Cli {
     /// Generate debug information
     #[clap(short = 'g')]
     pub debug_info: bool,
+
+    /// Use a specific linker
+    #[clap(long = "fuse-ld", value_name = "LINKER")]
+    pub fuse_ld: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -139,6 +143,7 @@ pub struct CompileConfig {
     pub library_paths: Vec<PathBuf>,
     pub compile_only: bool,
     pub debug_info: bool,
+    pub fuse_ld: Option<String>,
 }
 
 impl Default for CompileConfig {
@@ -159,6 +164,7 @@ impl Default for CompileConfig {
             library_paths: Vec::new(),
             compile_only: false,
             debug_info: false,
+            fuse_ld: None,
         }
     }
 }
@@ -311,6 +317,7 @@ impl Cli {
             library_paths: self.library_paths,
             compile_only: self.compile_only,
             debug_info: self.debug_info,
+            fuse_ld: self.fuse_ld,
         })
     }
 }
@@ -346,10 +353,12 @@ mod tests {
             library_paths: vec![PathBuf::from("/lib")],
             compile_only: true,
             debug_info: true,
+            fuse_ld: Some("lld".to_string()),
         };
 
         let config = cli.into_config().expect("Failed to create config");
 
+        assert_eq!(config.fuse_ld, Some("lld".to_string()));
         assert_eq!(config.stop_after, CompilePhase::Mir);
         assert!(config.verbose);
         assert!(config.suppress_line_markers);
@@ -384,6 +393,7 @@ mod tests {
             library_paths: vec![],
             compile_only: false,
             debug_info: false,
+            fuse_ld: None,
         };
 
         let err = cli_error.into_config().unwrap_err();

--- a/src/driver/compiler.rs
+++ b/src/driver/compiler.rs
@@ -419,6 +419,7 @@ impl CompilerDriver {
                         optimization: self.config.optimization.clone(),
                         debug_info: self.config.debug_info,
                         verbose: self.config.verbose,
+                        fuse_ld: self.config.fuse_ld.clone(),
                     };
 
                     // Link using LinkGen

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     // Clap does not strictly support single-dash long options (e.g. -std=c99), so we manually
     // map them to double-dash options (e.g. --std=c99) before parsing.
     let args = std::env::args().map(|arg| {
-        if arg.starts_with("-std=") || arg.starts_with("-target=") {
+        if arg.starts_with("-std=") || arg.starts_with("-target=") || arg.starts_with("-fuse-ld=") {
             format!("-{}", arg)
         } else if arg == "-pedantic" {
             "--pedantic".to_string()


### PR DESCRIPTION
Implemented support for specifying a custom linker via the `-fuse-ld` option, mirroring Clang's behavior. This involved updating the CLI argument parsing, configuration structures, and the linker invocation logic to pass the flag to the underlying Clang driver. Verified with unit tests.

---
*PR created automatically by Jules for task [8349806297208782507](https://jules.google.com/task/8349806297208782507) started by @bungcip*