### PR TITLE
Refactor codebase: Remove redundant code and optimize lookups

### DIFF
--- a/src/ast/literal_parsing.rs
+++ b/src/ast/literal_parsing.rs
@@ -175,7 +175,7 @@ pub(crate) fn unescape_string(s: &str) -> String {
 }
 
 /// Unescape C11 string literal content into a buffer
-pub(crate) fn unescape_string_into(s: &str, result: &mut String) {
+fn unescape_string_into(s: &str, result: &mut String) {
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\\' {

--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -10,7 +10,6 @@ use crate::mir::{
 use crate::semantic::ArraySizeType;
 use crate::semantic::BuiltinType;
 use crate::semantic::QualType;
-use crate::semantic::StructMember;
 use crate::semantic::SymbolKind;
 use crate::semantic::SymbolRef;
 use crate::semantic::SymbolTable;
@@ -778,10 +777,10 @@ impl<'a> MirGen<'a> {
         match ast_type_kind {
             TypeKind::Record {
                 tag,
-                members,
                 is_union,
                 is_complete,
-            } => self.lower_recursive_record_pattern(type_ref, tag, members, is_union, is_complete),
+                ..
+            } => self.lower_recursive_record_pattern(type_ref, tag, is_union, is_complete),
             TypeKind::Builtin(b) => {
                 let mir_type = if matches!(b, BuiltinType::VaList) {
                     self.lower_valist_type()
@@ -822,7 +821,6 @@ impl<'a> MirGen<'a> {
         &mut self,
         type_ref: TypeRef,
         tag: Option<NameId>,
-        members: Vec<StructMember>,
         is_union: bool,
         is_complete: bool,
     ) -> TypeId {
@@ -843,7 +841,7 @@ impl<'a> MirGen<'a> {
         let placeholder_id = self.mir_builder.add_type(placeholder_type);
         self.type_cache.insert(type_ref, placeholder_id);
 
-        let mir_type = self.lower_record_type(type_ref, &tag, &members, is_union, is_complete);
+        let mir_type = self.lower_record_type(type_ref, &tag, is_union, is_complete);
 
         // Remove from in-progress set
         self.type_conversion_in_progress.remove(&type_ref);
@@ -1028,7 +1026,6 @@ impl<'a> MirGen<'a> {
         &mut self,
         type_ref: TypeRef,
         tag: &Option<NameId>,
-        _members: &[StructMember],
         is_union: bool,
         is_complete: bool,
     ) -> MirType {

--- a/src/source_manager.rs
+++ b/src/source_manager.rs
@@ -483,10 +483,9 @@ impl SourceManager {
     /// Get the presumed location (logical line and file) for a source location
     pub(crate) fn get_presumed_location(&self, loc: SourceLoc) -> Option<(u32, u32, Option<&str>)> {
         let file_info = self.get_file_info(loc.source_id())?;
-        let physical_line = self.get_line_column(loc)?.0;
+        let (physical_line, column) = self.get_line_column(loc)?;
 
         let (logical_line, logical_file) = file_info.line_map.presumed_location(physical_line);
-        let column = self.get_line_column(loc)?.1;
 
         // If no logical file specified, use the physical filename
         let filename = logical_file.or_else(|| file_info.path.to_str());


### PR DESCRIPTION
This PR cleans up the codebase by removing unused function parameters in MIR generation, restricting visibility of a helper function in literal parsing, and optimizing source location lookup.

**Changes:**
- `src/codegen/mir_gen.rs`: Removed `members` parameter from `lower_record_type` and `lower_recursive_record_pattern` as the member information is retrieved from the registry. Removed unused `StructMember` import.
- `src/ast/literal_parsing.rs`: Changed `unescape_string_into` visibility to private.
- `src/source_manager.rs`: Updated `get_presumed_location` to call `get_line_column` only once.

---
*PR created automatically by Jules for task [4916246074728478002](https://jules.google.com/task/4916246074728478002) started by @bungcip*