### PR TITLE
⚡ Bolt: Optimize is_lvalue recursion in SemanticAnalyzer

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -238,12 +238,18 @@ impl<'a> SemanticAnalyzer<'a> {
             }
             NodeKind::UnaryOp(op, _) => matches!(*op, UnaryOp::Deref),
             NodeKind::IndexAccess(..) => true,
-            NodeKind::MemberAccess(obj_ref, _, is_arrow) => *is_arrow || self.is_lvalue(*obj_ref),
+            NodeKind::MemberAccess(obj_ref, _, is_arrow) => {
+                // ⚡ Bolt: Optimization - avoid O(N^2) recursive traversal for member access chains.
+                // Since child nodes are always visited before parents in `visit_node`,
+                // their value categories are already computed and stored in the side table.
+                *is_arrow || self.semantic_info.value_categories[obj_ref.index()] == ValueCategory::LValue
+            }
             NodeKind::Literal(literal::Literal::String(_)) => true,
             NodeKind::CompoundLiteral(..) => true,
             NodeKind::GenericSelection(_) => {
+                // ⚡ Bolt: Same optimization for generic selections.
                 if let Some(&selected) = self.semantic_info.generic_selections.get(&node_ref.index()) {
-                    self.is_lvalue(selected)
+                    self.semantic_info.value_categories[selected.index()] == ValueCategory::LValue
                 } else {
                     false
                 }


### PR DESCRIPTION
### 💡 What:
Optimized the `is_lvalue` function in `src/semantic/analyzer.rs` to be non-recursive for `MemberAccess` and `GenericSelection` nodes. It now uses the `value_categories` side table in `SemanticInfo` to look up the pre-computed value category of child nodes.

### 🎯 Why:
The original implementation was recursive, leading to $O(N)$ work per node in a chain of $N$ member accesses, resulting in $O(N^2)$ total work for the entire chain. Since the semantic analyzer already visits nodes in a bottom-up fashion, the results for child nodes are already available.

### 📊 Impact:
Reduces the algorithmic complexity of lvalue checking from $O(N^2)$ to $O(N)$ for deeply nested expressions. This leads to faster semantic analysis, especially in auto-generated code or complex header files.

### 🔬 Measurement:
Verified that child nodes are indeed visited and their value categories stored before the parent node's `is_lvalue` check is performed. All existing semantic and codegen tests passed, confirming correctness.

---
*PR created automatically by Jules for task [14029917151993121201](https://jules.google.com/task/14029917151993121201) started by @bungcip*