### PR TITLE
Add tests for preprocessor unary operators

### DIFF
--- a/src/tests/pp_expressions.rs
+++ b/src/tests/pp_expressions.rs
@@ -156,3 +156,55 @@ SIGNED
       text: SIGNED
     "#);
 }
+
+// Unary Operators
+#[test]
+fn test_pp_unary_ops() {
+    let src = r#"
+/* Unary Plus */
+#if +1 == 1
+PLUS_OK
+#else
+PLUS_FAIL
+#endif
+
+/* Unary BitNot */
+#if ~0 == -1
+BITNOT_SIGNED_OK
+#else
+BITNOT_SIGNED_FAIL
+#endif
+
+#if ~0U == 0xFFFFFFFFFFFFFFFFU
+BITNOT_UNSIGNED_OK
+#else
+BITNOT_UNSIGNED_FAIL
+#endif
+
+/* Unary LogicNot */
+#if !0
+LOGICNOT_0_OK
+#else
+LOGICNOT_0_FAIL
+#endif
+
+#if !1
+LOGICNOT_1_FAIL
+#else
+LOGICNOT_1_OK
+#endif
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @r"
+    - kind: Identifier
+      text: PLUS_OK
+    - kind: Identifier
+      text: BITNOT_SIGNED_OK
+    - kind: Identifier
+      text: BITNOT_UNSIGNED_OK
+    - kind: Identifier
+      text: LOGICNOT_0_OK
+    - kind: Identifier
+      text: LOGICNOT_1_OK
+    ");
+}


### PR DESCRIPTION
Added unit tests for preprocessor unary operators (+, ~, !) to improve code coverage for `eval_unary` in `src/pp/interpreter.rs`. The new test `test_pp_unary_ops` verifies the behavior of these operators in preprocessor conditional expressions.

---
*PR created automatically by Jules for task [14902219265561644745](https://jules.google.com/task/14902219265561644745) started by @bungcip*