### PR TITLE
Add test coverage for skipped preprocessor directives

### DIFF
--- a/src/tests/pp_directives.rs
+++ b/src/tests/pp_directives.rs
@@ -81,3 +81,28 @@ OK
     - []
     ");
 }
+
+#[test]
+fn test_skipped_directives_coverage() {
+    let src = r#"
+#if 0
+#define FOO 1
+#undef FOO
+#include "non_existent.h"
+#line 100 "bad_file.c"
+#pragma unknown
+#error "should not error"
+#warning "should not warn"
+#if 1
+  #error "should not error nested"
+#endif
+#endif
+OK
+"#;
+    let (tokens, diags) = setup_pp_snapshot_with_diags(src);
+    insta::assert_yaml_snapshot!((tokens, diags), @r#"
+    - - kind: Identifier
+        text: OK
+    - []
+    "#);
+}


### PR DESCRIPTION
Added a unit test to cover `skip_directive` in `src/pp/preprocessor.rs`. The test ensures that directives inside skipped conditional blocks are correctly ignored.

---
*PR created automatically by Jules for task [15643907358988929350](https://jules.google.com/task/15643907358988929350) started by @bungcip*