### PR TITLE
Add unit test for preprocessor #warning directive coverage

### DIFF
--- a/src/tests/pp_directives.rs
+++ b/src/tests/pp_directives.rs
@@ -13,6 +13,20 @@ fn test_error_directive_produces_failure() {
 }
 
 #[test]
+fn test_warning_directive() {
+    let src = r#"
+#warning "this is a warning"
+OK
+"#;
+    let (tokens, diags) = setup_pp_snapshot_with_diags(src);
+    insta::assert_yaml_snapshot!((tokens, diags), @r#"
+    - - kind: Identifier
+        text: OK
+    - - "Warning: \"this is a warning\""
+    "#);
+}
+
+#[test]
 fn test_line_directive_presumed_location() {
     let src = r#"
 // This is line 2


### PR DESCRIPTION
Added a new test case `test_warning_directive` in `src/tests/pp_directives.rs` which compiles a source string containing `#warning` and asserts that the resulting diagnostic matches the expected warning message. This ensures `handle_warning` is covered by tests.

---
*PR created automatically by Jules for task [15643440655719557419](https://jules.google.com/task/15643440655719557419) started by @bungcip*