### PR TITLE
Add unit test for DirectiveKeywordTable::is_directive coverage

### DIFF
--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -2623,3 +2623,22 @@ impl<'a> SourceBufferCache<'a> {
         unsafe { std::str::from_utf8_unchecked(self.get_token_bytes(token)) }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::StringId;
+
+    #[test]
+    fn test_is_directive() {
+        let table = DirectiveKeywordTable::new();
+
+        // Test known directive
+        let define_sym = StringId::new("define");
+        assert_eq!(table.is_directive(define_sym), Some(DirectiveKind::Define));
+
+        // Test unknown directive (this covers the else { None } branch)
+        let unknown_sym = StringId::new("not_a_directive");
+        assert_eq!(table.is_directive(unknown_sym), None);
+    }
+}


### PR DESCRIPTION
Added a `#[cfg(test)]` module to `src/pp/preprocessor.rs` containing `test_is_directive`. This test verifies that `DirectiveKeywordTable::is_directive` returns `None` for symbols that are not directive keywords, addressing the uncovered code path identified in the codecov report.


---
*PR created automatically by Jules for task [3312768124893597420](https://jules.google.com/task/3312768124893597420) started by @bungcip*