### PR TITLE
Add tests for _Pragma operator in macros and conditionals

### DIFF
--- a/src/tests/pp_pragma.rs
+++ b/src/tests/pp_pragma.rs
@@ -69,3 +69,29 @@ OK
       text: OK
     ");
 }
+
+#[test]
+fn test_pragma_operator_inside_macro() {
+    let src = r#"
+#define M _Pragma("message(\"Inside Macro\")")
+M
+    "#;
+    let (tokens, diags) = setup_pp_snapshot_with_diags(src);
+    insta::assert_yaml_snapshot!((tokens, diags), @r#"
+    - []
+    - - "Note: Inside Macro"
+    "#);
+}
+
+#[test]
+fn test_pragma_operator_in_if() {
+    let src = r#"
+#if _Pragma("message(\"Inside If\")") 1
+#endif
+    "#;
+    let (tokens, diags) = setup_pp_snapshot_with_diags(src);
+    insta::assert_yaml_snapshot!((tokens, diags), @r#"
+    - []
+    - - "Note: Inside If"
+    "#);
+}


### PR DESCRIPTION
Added unit tests to cover `try_handle_pragma_operator` in `src/pp/preprocessor.rs`. This function handles `_Pragma` operators when encountered during token expansion (e.g., inside macros). The existing tests only covered top-level `_Pragma` usage which is handled by a different code path.

The new tests verify:
1. `_Pragma` inside a macro definition.
2. `_Pragma` inside an `#if` directive.

These tests confirm that the preprocessor correctly handles these cases and ensures the relevant code path is executed and covered.

---
*PR created automatically by Jules for task [17731820636219857868](https://jules.google.com/task/17731820636219857868) started by @bungcip*