### PR TITLE
Add test for include_next fallback to built-in headers

### DIFF
--- a/src/tests/pp_include_next.rs
+++ b/src/tests/pp_include_next.rs
@@ -103,3 +103,46 @@ fn test_include_next_angled() {
     assert!(pp.is_macro_defined(&crate::ast::StringId::new("FOO_1")));
     assert!(pp.is_macro_defined(&crate::ast::StringId::new("FOO_2")));
 }
+
+#[test]
+fn test_include_next_builtin() {
+    // Create temporary directory
+    let dir = TempDir::new().unwrap();
+
+    // Create a user stddef.h that includes the next stddef.h (which should be the builtin one)
+    let stddef_path = dir.path().join("stddef.h");
+    {
+        let mut file = File::create(&stddef_path).unwrap();
+        writeln!(file, "#define MY_STDDEF_WRAPPER 1").unwrap();
+        // This should find the built-in stddef.h
+        writeln!(file, "#include_next <stddef.h>").unwrap();
+    }
+
+    // main.c
+    let main_path = dir.path().join("main.c");
+    {
+        let mut file = File::create(&main_path).unwrap();
+        writeln!(file, "#include <stddef.h>").unwrap();
+    }
+
+    // Setup configuration
+    let mut config = PPConfig::default();
+    // Add our directory to angled include paths
+    config.angled_include_paths.push(dir.path().to_path_buf());
+
+    let (mut sm, mut diag) = setup_sm_and_diag();
+
+    // Add main file
+    let source_id = sm.add_file_from_path(&main_path, None).unwrap();
+
+    let mut pp = Preprocessor::new(&mut sm, &mut diag, &config);
+
+    // Process
+    let _ = pp.process(source_id, &config).unwrap();
+
+    // Verify macros
+    // MY_STDDEF_WRAPPER should be defined
+    assert!(pp.is_macro_defined(&crate::ast::StringId::new("MY_STDDEF_WRAPPER")));
+    // NULL should be defined from the built-in stddef.h
+    assert!(pp.is_macro_defined(&crate::ast::StringId::new("NULL")));
+}


### PR DESCRIPTION
Added a unit test to cover the fallback logic in `resolve_next_include_path` for built-in headers.
The test creates a user-defined `stddef.h` which includes the next `stddef.h`, verifying that the preprocessor correctly resolves to the compiler's built-in `stddef.h` when no other file is found on disk.


---
*PR created automatically by Jules for task [13300203638731630506](https://jules.google.com/task/13300203638731630506) started by @bungcip*