### PR TITLE
Add test coverage for popping undefined macros

### DIFF
--- a/src/tests/pp_pragma.rs
+++ b/src/tests/pp_pragma.rs
@@ -95,3 +95,18 @@ fn test_pragma_operator_in_if() {
     - - "Note: Inside If"
     "#);
 }
+
+#[test]
+fn test_push_pop_undefined_macro() {
+    let src = r#"
+#pragma push_macro("M")
+#define M 1
+#pragma pop_macro("M")
+M
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @r"
+    - kind: Identifier
+      text: M
+    ");
+}


### PR DESCRIPTION
This PR adds a test case to cover the `else` branch in `handle_pop_macro`, ensuring that macros pushed while undefined are correctly removed from the macro table when popped.


---
*PR created automatically by Jules for task [3019390664124876618](https://jules.google.com/task/3019390664124876618) started by @bungcip*