### PR TITLE
Add test for undefining built-in macros

### DIFF
--- a/src/tests/pp_macros.rs
+++ b/src/tests/pp_macros.rs
@@ -480,3 +480,14 @@ FOO
     - - "Warning: Redefinition of macro 'FOO'"
     "#);
 }
+
+#[test]
+fn test_undef_builtin_macro_should_warn() {
+    let src = r#"
+#undef __DATE__
+"#;
+    let (_, diags) = setup_pp_snapshot_with_diags(src);
+    insta::assert_yaml_snapshot!(diags, @r#"
+    - "Warning: Undefining built-in macro '__DATE__'"
+    "#);
+}


### PR DESCRIPTION
Added a unit test to cover the `handle_undef` branch where a built-in macro is undefined. The test asserts that a warning is produced, ensuring the logic is exercised.

---
*PR created automatically by Jules for task [14135850935769425010](https://jules.google.com/task/14135850935769425010) started by @bungcip*