### PR TITLE
Clean up unused internal APIs and visibility downgrades

### DIFF
--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1164,7 +1164,7 @@ impl<'a> MirGen<'a> {
         }
     }
 
-    pub(crate) fn get_place_type(&mut self, place: &Place) -> TypeId {
+    fn get_place_type(&mut self, place: &Place) -> TypeId {
         match place {
             Place::Local(local_id) => self.mir_builder.get_locals().get(local_id).unwrap().type_id,
             Place::Global(global_id) => self.get_global_type(*global_id),

--- a/src/codegen/mir_gen_initializer.rs
+++ b/src/codegen/mir_gen_initializer.rs
@@ -522,7 +522,7 @@ impl<'a> MirGen<'a> {
         }
     }
 
-    pub(crate) fn create_array_const_from_string(
+    fn create_array_const_from_string(
         &mut self,
         val: &ast::NameId,
         fixed_size: Option<usize>,

--- a/src/tests/mir_validation.rs
+++ b/src/tests/mir_validation.rs
@@ -317,7 +317,7 @@ fn test_call_arg_type_mismatch() {
     let res = validator.validate();
 
     let expected_err = ValidationError::FunctionCallArgTypeMismatch {
-        func_name: func_name,
+        func_name,
         arg_index: 0,
         expected_type: i32_ty,
         actual_type: f32_ty,


### PR DESCRIPTION
Systematically identified and cleaned up internal functions that were unnecessarily exposed with `pub(crate)` visibility. Restricted these functions to private `fn` within their respective files to maintain a smaller and more maintainable internal API. Also addressed Clippy warnings and ensured compatibility with stable Rust by avoiding unstable syntax. Core architectural constructors were retained with `pub(crate)` visibility to support cross-module coordination.

---
*PR created automatically by Jules for task [3366103763202315853](https://jules.google.com/task/3366103763202315853) started by @bungcip*