### PR TITLE
refactor(ast): dedup type display logic in AstDumper

### DIFF
--- a/src/tests/ast_dumper_coverage.rs
+++ b/src/tests/ast_dumper_coverage.rs
@@ -472,12 +472,12 @@ fn test_type_registry_complex() {
     insta::assert_snapshot!(output, @r"
     === TypeRegistry (Used TypeRefs) ===
     TypeRef(8): int
-    TypeRef(24): <VLA>
+    TypeRef(24): int[*]
     TypeRef(22): void(int)
     TypeRef(25): void(int, ...)
     TypeRef(20): struct Point
     TypeRef(21): enum Color
-    TypeRef(23): _Complex
+    TypeRef(23): _Complex double
     ");
 }
 


### PR DESCRIPTION
Removed `AstDumper::format_type_kind_user_friendly` in favor of `TypeRegistry::display_type` to eliminate duplicated type formatting logic. Updated `src/tests/ast_dumper_coverage.rs` snapshots to match the new output format (e.g. `int[*]` instead of `<VLA>` and `_Complex double` instead of `_Complex`). Verified that tests pass.

---
*PR created automatically by Jules for task [563735629410837731](https://jules.google.com/task/563735629410837731) started by @bungcip*