### PR TITLE
⚡ Bolt: Optimize token pasting in preprocessor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,7 @@
 ## 2026-11-28 - Optimized MacroInfo with Arc for Token Lists
 **Learning:** Cloning `MacroInfo` on every macro expansion and push/pop operation was a significant bottleneck due to `Vec<PPToken>` and `Vec<StringId>` causing repeated heap allocations and deep copies.
 **Action:** Use `Arc<[T]>` for immutable collections in frequently cloned data structures like `MacroInfo`. This turns (N)$ clones into (1)$ reference count increments while maintaining read-only performance.
+
+## 2026-02-17 - Optimizing Token Pasting Buffer Construction
+**Learning:** Using `format!` followed by `.clone().into_bytes()` for simple string concatenation in a hot path like token pasting introduces two unnecessary heap allocations and a redundant copy.
+**Action:** Build the byte buffer directly using `Vec::with_capacity(len1 + len2)` followed by `extend_from_slice`. This is more efficient and avoids the formatting overhead.

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -2080,10 +2080,10 @@ impl<'src> Preprocessor<'src> {
             return self.emit_error_loc(PPErrorKind::InvalidTokenPasting, right.location);
         };
 
-        let pasted_text = format!("{}{}", left_text, right_text);
-
-        // Create a virtual buffer containing the pasted text
-        let virtual_buffer = pasted_text.clone().into_bytes();
+        // ⚡ Bolt: Avoid redundant format! and clone by building the byte buffer directly.
+        let mut virtual_buffer = Vec::with_capacity(left_text.len() + right_text.len());
+        virtual_buffer.extend_from_slice(left_text.as_bytes());
+        virtual_buffer.extend_from_slice(right_text.as_bytes());
         let virtual_id = self
             .sm
             .add_virtual_buffer(virtual_buffer, "pasted-tokens", None, FileKind::PastedToken);


### PR DESCRIPTION
Optimized token pasting in the preprocessor by replacing redundant \`format!\` and \`clone()\` calls with direct byte buffer construction. This reduces heap allocations and formatting overhead in a hot path.

---
*PR created automatically by Jules for task [9837948266164834304](https://jules.google.com/task/9837948266164834304) started by @bungcip*