### PR TITLE
test(source_manager): add test for reserved source id panic

### DIFF
--- a/src/tests/driver_source_manager.rs
+++ b/src/tests/driver_source_manager.rs
@@ -542,3 +542,11 @@ fn test_source_manager_get_buffer_arc_invalid_id() {
     let invalid_id = SourceId::new(999);
     sm.get_buffer_arc(invalid_id);
 }
+
+#[test]
+#[should_panic(expected = "invalid source_id SourceId(1)")]
+fn test_source_manager_get_buffer_reserved_id() {
+    let sm = SourceManager::new();
+    let reserved_id = SourceId::new(1);
+    sm.get_buffer(reserved_id);
+}


### PR DESCRIPTION
This PR adds a unit test to `src/tests/driver_source_manager.rs` which exercises the panic path in `SourceManager::get_buffer` when a reserved `SourceId` (value 1) is used. This covers the previously uncovered `if id < 2` branch in `get_buffer`.

Coverage analysis confirms an increase in coverage for `src/source_manager.rs`.

---
*PR created automatically by Jules for task [4512495400351489452](https://jules.google.com/task/4512495400351489452) started by @bungcip*