### PR TITLE
⚡ Bolt: Optimize vector allocations in hot paths

### DIFF
--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -843,7 +843,10 @@ impl<'src> Preprocessor<'src> {
         self.lexer_stack.push(PPLexer::new(source_id, buffer));
         self.sm.calculate_line_starts(source_id);
 
-        let mut result_tokens = Vec::new();
+        // ⚡ Bolt: Pre-allocate the result_tokens vector using a capacity hint based on buffer size.
+        // A common estimate for C code is around 8 bytes per token.
+        // This avoids multiple costly reallocations for large source files.
+        let mut result_tokens = Vec::with_capacity(buffer_len as usize / 8);
 
         while let Some(token) = self.lex_token() {
             match token.kind {

--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -142,9 +142,11 @@ pub struct SymbolTable {
 
 impl SymbolTable {
     pub(crate) fn new() -> Self {
+        // ⚡ Bolt: Pre-allocate space for symbols and scopes to avoid multiple reallocations.
+        // A medium-sized C translation unit can easily have hundreds of symbols and multiple scopes.
         let mut table = SymbolTable {
-            entries: Vec::new(),
-            scopes: Vec::new(),
+            entries: Vec::with_capacity(512),
+            scopes: Vec::with_capacity(32),
             current_scope_id: ScopeId::GLOBAL,
             next_scope_id: 2, // Start after GLOBAL
         };


### PR DESCRIPTION
💡 What: Optimized performance by pre-allocating `Vec` capacities in the Preprocessor and SymbolTable.
🎯 Why: Reducing heap reallocations in hot paths improves overall compilation speed, especially for large translation units.
📊 Impact: Decreases the number of costly `realloc` calls during preprocessing and symbol resolution.
🔬 Measurement: Verified with `cargo test` and manual build. Pre-allocation uses safe heuristics based on buffer size or common C program structures.

---
*PR created automatically by Jules for task [17081961085354286785](https://jules.google.com/task/17081961085354286785) started by @bungcip*