### PR TITLE
test(source_manager): increase coverage for reserved SourceId behavior

### DIFF
--- a/src/tests/driver_source_manager.rs
+++ b/src/tests/driver_source_manager.rs
@@ -550,3 +550,22 @@ fn test_source_manager_get_buffer_reserved_id() {
     let reserved_id = SourceId::new(1);
     sm.get_buffer(reserved_id);
 }
+
+#[test]
+fn test_reserved_source_id_behavior() {
+    let mut sm = SourceManager::new();
+    let reserved_id = SourceId::new(1);
+
+    // get_line_map_mut should return None for reserved ID
+    assert!(sm.get_line_map_mut(reserved_id).is_none());
+
+    // set_line_starts should do nothing (no panic) for reserved ID
+    sm.set_line_starts(reserved_id, vec![0, 10]);
+
+    // calculate_line_starts should do nothing (no panic) for reserved ID
+    sm.calculate_line_starts(reserved_id);
+
+    // Explicitly check that get_file_info and get_buffer_safe handle reserved ID gracefully
+    assert!(sm.get_file_info(reserved_id).is_none());
+    assert!(sm.get_buffer_safe(reserved_id).is_none());
+}


### PR DESCRIPTION
This PR adds a new unit test `test_reserved_source_id_behavior` to `src/tests/driver_source_manager.rs`.

The test targets the following methods in `SourceManager`:
- `set_line_starts`
- `calculate_line_starts`
- `get_line_map_mut`

These methods have checks for `id < 2` (reserved/built-in IDs) which were previously uncovered. The new test calls these methods with a reserved ID (`SourceId::new(1)`) to ensure they handle it gracefully (noop or return `None`) and to trigger the coverage for these branches.

This change adheres to the "add AT MOST ONE new unit test" rule and focuses on increasing coverage for error/edge case paths.

---
*PR created automatically by Jules for task [10117391529390515863](https://jules.google.com/task/10117391529390515863) started by @bungcip*