### PR TITLE
🛡️ Guardian: Enforce C11 Structure and Union Member Constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -59,3 +59,8 @@ Action: Centralize function specifier validation in semantic lowering to ensure 
 
 Learning: `can_fall_through` analysis for `_Noreturn` compliance must distinguish between truly infinite loops and those that can exit via `break`. A loop without a condition (like `for(;;)`) or with a constant true condition (like `while(1)`) only satisfies `_Noreturn` if it contains no `break` statements targeting it. Shallow scanning for `NodeKind::Break` (avoiding nested loops) combined with `const_eval` for loop conditions provides a robust safeguard against miscompilation of divergent control flow.
 Action: Always combine condition analysis with internal control-flow jump detection (like `break`) when validating divergent or non-returning constructs.
+
+2025-05-26 - [Structure and Union Member Constraints]
+
+Learning: C11 6.7.2.1p3 requires that structure/union members must not have incomplete or function types (with the exception of FAM in structs). Incomplete type layout computation must be robust against recursion and errors to prevent "leaked" state in tracking sets like `layout_in_progress`, which could otherwise cause false "recursive type definition" errors for subsequent valid types. Mapping general layout errors (like `SizeOfIncompleteType`) to member-specific diagnostics (like `IncompleteType` or `MemberHasFunctionType`) with correct spans significantly improves compiler quality.
+Action: Implement robust internal/external function splits for stateful semantic checks (like layout) and prioritize context-specific re-mapping of lower-level errors to provide precise diagnostics.

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -210,7 +210,7 @@ impl<'a> MirGen<'a> {
     fn visit_type_query(&mut self, ty: semantic::TypeRef, is_size: bool) -> Operand {
         let layout = self.registry.get_layout(ty);
         let val = if is_size { layout.size } else { layout.alignment };
-        self.create_size_t_operand(val as u64)
+        self.create_size_t_operand(val)
     }
 
     fn visit_generic_selection(

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -294,6 +294,8 @@ pub enum SemanticError {
     },
     #[error("member reference base type '{ty}' is not a structure or union")]
     MemberAccessOnNonRecord { ty: String, span: SourceSpan },
+    #[error("member '{name}' has function type")]
+    MemberHasFunctionType { name: NameId, span: SourceSpan },
     #[error("no member named '{name}' in '{ty}'")]
     MemberNotFound { name: NameId, ty: String, span: SourceSpan },
     #[error("expected a typedef name, found {found}")]
@@ -472,6 +474,7 @@ impl SemanticError {
             SemanticError::InvalidFunctionSpecifier { span, .. } => *span,
             SemanticError::DuplicateMember { span, .. } => *span,
             SemanticError::MemberAccessOnNonRecord { span, .. } => *span,
+            SemanticError::MemberHasFunctionType { span, .. } => *span,
             SemanticError::MemberNotFound { span, .. } => *span,
             SemanticError::ExpectedTypedefName { span, .. } => *span,
             SemanticError::MissingTypeSpecifier { span } => *span,

--- a/src/lang_options.rs
+++ b/src/lang_options.rs
@@ -1,15 +1,10 @@
 /// supported C standards
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum CStandard {
     C89,
     C99,
+    #[default]
     C11,
-}
-
-impl Default for CStandard {
-    fn default() -> Self {
-        Self::C11
-    }
 }
 
 impl CStandard {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -71,6 +71,7 @@ pub mod guardian_noreturn_break;
 pub mod guardian_parameter_storage;
 pub mod guardian_pointer_arithmetic;
 pub mod guardian_restrict_constraints;
+pub mod guardian_struct_member_constraints;
 pub mod guardian_tentative_definitions;
 pub mod guardian_typedef_constraints;
 pub mod mir_dumper_coverage;

--- a/src/tests/guardian_struct_member_constraints.rs
+++ b/src/tests/guardian_struct_member_constraints.rs
@@ -1,0 +1,113 @@
+use crate::tests::test_utils::run_fail_with_message;
+
+#[test]
+fn test_void_member_prohibited() {
+    // C11 6.7.2.1p3: "A structure or union shall not contain a member with incomplete or function type"
+    run_fail_with_message(
+        r#"
+        struct S {
+            void v;
+        };
+        "#,
+        "incomplete type",
+    );
+}
+
+#[test]
+fn test_incomplete_struct_member_prohibited() {
+    // C11 6.7.2.1p3: "A structure or union shall not contain a member with incomplete or function type"
+    run_fail_with_message(
+        r#"
+        struct Incomplete;
+        struct T {
+            struct Incomplete s;
+        };
+        "#,
+        "incomplete type",
+    );
+}
+
+#[test]
+fn test_function_member_prohibited() {
+    // C11 6.7.2.1p3: "A structure or union shall not contain a member with incomplete or function type"
+    run_fail_with_message(
+        r#"
+        struct S {
+            void f(void);
+        };
+        "#,
+        "member 'f' has function type",
+    );
+}
+
+#[test]
+fn test_vla_member_prohibited() {
+    // C11 6.7.2.1p3: "A structure or union shall not contain a member with [...] variably modified type"
+    run_fail_with_message(
+        r#"
+        void f(int n) {
+            struct S {
+                int a[n];
+            };
+        }
+        "#,
+        "variably modified type",
+    );
+}
+
+#[test]
+fn test_vla_member_in_middle_prohibited() {
+    run_fail_with_message(
+        r#"
+        void f(int n) {
+            struct S {
+                int a[n];
+                int x;
+            };
+        }
+        "#,
+        "variably modified type",
+    );
+}
+
+#[test]
+fn test_fam_in_union_prohibited() {
+    // C11 6.7.2.1p18: FAM is a special case for structures, not mentioned for unions.
+    // Also 6.7.2.1p3 says unions shall not contain incomplete types.
+    run_fail_with_message(
+        r#"
+        union U {
+            int x;
+            int a[];
+        };
+        "#,
+        "incomplete/VLA array in union",
+    );
+}
+
+#[test]
+fn test_fam_not_last_prohibited() {
+    // C11 6.7.2.1p18: "the last element of a structure ... may have an incomplete array type"
+    run_fail_with_message(
+        r#"
+        struct S {
+            int a[];
+            int x;
+        };
+        "#,
+        "flexible array member must be the last member of a structure",
+    );
+}
+
+#[test]
+fn test_fam_in_otherwise_empty_struct_prohibited() {
+    // C11 6.7.2.1p18: "the last element of a structure with more than one named member ..."
+    run_fail_with_message(
+        r#"
+        struct S {
+            int a[];
+        };
+        "#,
+        "flexible array member in otherwise empty structure",
+    );
+}


### PR DESCRIPTION
Implemented C11 structure and union member constraints validation. Rejects invalid members like void, function types, and VLAs. Added comprehensive tests and improved internal layout computation robustness in TypeRegistry.

---
*PR created automatically by Jules for task [1848685396755253099](https://jules.google.com/task/1848685396755253099) started by @bungcip*