### PR TITLE
Fix global float initialization with integer constants

### DIFF
--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1414,7 +1414,27 @@ impl<'a> MirGen<'a> {
                     let inner_const = self.mir_builder.get_constants().get(&inner_const_id).unwrap().clone();
                     let mir_type = self.mir_builder.get_type(*ty);
                     let truncated_kind = match inner_const.kind {
-                        ConstValueKind::Int(val) => ConstValueKind::Int(mir_type.truncate_int(val)),
+                        ConstValueKind::Int(val) => {
+                            if mir_type.is_float() {
+                                ConstValueKind::Float(val as f64)
+                            } else {
+                                ConstValueKind::Int(mir_type.truncate_int(val))
+                            }
+                        }
+                        ConstValueKind::Float(val) => {
+                            if mir_type.is_int() {
+                                ConstValueKind::Int(mir_type.truncate_int(val as i64))
+                            } else {
+                                ConstValueKind::Float(val)
+                            }
+                        }
+                        ConstValueKind::Bool(val) => {
+                            if mir_type.is_float() {
+                                ConstValueKind::Float(if val { 1.0 } else { 0.0 })
+                            } else {
+                                ConstValueKind::Int(if val { 1 } else { 0 })
+                            }
+                        }
                         kind => kind,
                     };
                     // Create a new constant with the target type but same kind

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -27,6 +27,7 @@ pub mod semantic_builtins;
 pub mod semantic_control_flow;
 pub mod semantic_enums;
 pub mod semantic_expr;
+pub mod semantic_float_init;
 pub mod semantic_functions;
 pub mod semantic_init;
 pub mod semantic_scope;

--- a/src/tests/semantic_float_init.rs
+++ b/src/tests/semantic_float_init.rs
@@ -1,0 +1,83 @@
+use crate::tests::codegen_common::run_c_code_exit_status;
+
+#[test]
+fn test_double_init_with_int() {
+    let source = r#"
+        double x = 100;
+        int main() {
+            if (x != 100.0) return 1;
+            return 0;
+        }
+    "#;
+    assert_eq!(run_c_code_exit_status(source), 0);
+}
+
+#[test]
+fn test_float_init_with_int() {
+    let source = r#"
+        float x = 100;
+        int main() {
+            if (x != 100.0f) return 1;
+            return 0;
+        }
+    "#;
+    assert_eq!(run_c_code_exit_status(source), 0);
+}
+
+#[test]
+fn test_float_init_with_int_neg() {
+    let source = r#"
+        float x = -100;
+        int main() {
+            if (x != -100.0f) return 1;
+            return 0;
+        }
+    "#;
+    assert_eq!(run_c_code_exit_status(source), 0);
+}
+
+#[test]
+fn test_bool_init_float() {
+    // Tests implicit conversion from bool constant to float
+    let source = r#"
+        _Bool b = 1;
+        float x = (_Bool)1;
+        int main() {
+            if (x != 1.0f) return 1;
+            return 0;
+        }
+    "#;
+    assert_eq!(run_c_code_exit_status(source), 0);
+}
+
+#[test]
+fn test_int_init_float() {
+    let source = r#"
+        int x = 100.5;
+        int main() {
+            if (x != 100) return 1;
+            return 0;
+        }
+    "#;
+    assert_eq!(run_c_code_exit_status(source), 0);
+}
+
+#[test]
+fn test_int_init_float_overflow() {
+    // 300.0 fits in int, but truncating to char would overflow if not handled.
+    // However, global vars in C must be initialized with constant expressions.
+    // Conversion from float to int is allowed.
+    let source = r#"
+        char x = 300.0; // 300 does not fit in char. Implementation defined or modular.
+        // Usually (char)300 -> 44 (if char is signed/8bit) or similar.
+        // 300 = 0x12C. 0x2C = 44.
+        // If char is signed, 300 -> 44.
+
+        int main() {
+            // Check if it runs without crashing at least.
+            // Value depends on signedness of char.
+            return 0;
+        }
+    "#;
+    assert_eq!(run_c_code_exit_status(source), 0);
+}


### PR DESCRIPTION
Fix global float initialization with integer constants

Implicit casting of constant initializers (specifically from Integer to Float) was not handled during MIR generation, causing incorrect values (e.g., `double x = 100;` resulting in `x = 0.0`).

This change updates `src/codegen/mir_gen.rs` to correctly handle `ConstValueKind` conversions within `operand_to_const_id`. It handles Int<->Float and Bool->Float/Int conversions, including truncation when casting Float to Int.

New regression tests are added in `src/tests/semantic_float_init.rs`.

---
*PR created automatically by Jules for task [14316672062179520330](https://jules.google.com/task/14316672062179520330) started by @bungcip*