### PR TITLE
Support C23 empty initializer validation for unknown size arrays

### DIFF
--- a/src/semantic/errors.rs
+++ b/src/semantic/errors.rs
@@ -153,6 +153,9 @@ pub enum SemanticErrorKind {
         feature: &'static str,
     },
     InvalidArraySize,
+    ZeroOrNegativeSizeArray {
+        name: NameId,
+    },
     ArraySizeNotInteger,
     InvalidBitfieldWidth,
     NonConstantBitfieldWidth,
@@ -499,6 +502,9 @@ impl SemanticErrorKind {
             SemanticErrorKind::ExcessElements { kind } => format!("excess elements in {} initializer", kind),
             SemanticErrorKind::UnsupportedFeature { feature } => format!("Unsupported feature: {}", feature),
             SemanticErrorKind::InvalidArraySize => "size of array is negative".to_string(),
+            SemanticErrorKind::ZeroOrNegativeSizeArray { name } => {
+                format!("zero or negative size array '{}'", name)
+            }
             SemanticErrorKind::ArraySizeNotInteger => "size of array has non-integer type".to_string(),
             SemanticErrorKind::InvalidBitfieldWidth => "invalid bit-field width".to_string(),
             SemanticErrorKind::NonConstantBitfieldWidth => "bit-field width is not a constant expression".to_string(),

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -1521,6 +1521,12 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             && let Some(et) = element_type
             && let Some(len) = self.deduce_array_size_full(ie, et)
         {
+            if len == 0 && self.lang_opts.c_standard >= crate::lang_options::CStandard::C23 {
+                self.report_error(
+                    span,
+                    SemanticErrorKind::ZeroOrNegativeSizeArray { name },
+                );
+            }
             qt = QualType::new(
                 self.registry.array_of(et, ArraySizeType::Constant(len)),
                 qt.qualifiers(),

--- a/src/tests/semantic_c23.rs
+++ b/src/tests/semantic_c23.rs
@@ -292,3 +292,23 @@ fn test_c23_enum_constant_type() {
         CStandard::C23,
     );
 }
+
+#[test]
+fn test_empty_initializer_array_of_unknown_size() {
+    // Array of unknown size initialized with empty initializer is invalid in C23.
+    crate::tests::test_utils::run_fail_with_message_and_std(
+        "int arr[] = {};",
+        "zero or negative size array 'arr'",
+        crate::lang_options::CStandard::C23,
+    );
+}
+
+#[test]
+fn test_empty_initializer_array_of_known_size() {
+    // Empty initializer is allowed for known size array in C23.
+    crate::tests::test_utils::run_pass_with_std(
+        "int arr[5] = {};",
+        crate::driver::artifact::CompilePhase::SemanticLowering,
+        crate::lang_options::CStandard::C23,
+    );
+}


### PR DESCRIPTION
Implemented C23 standard validation to prevent using empty initializers (`{}`) for arrays of an unknown size, mimicking GCC behavior.

---
*PR created automatically by Jules for task [5148985750324852077](https://jules.google.com/task/5148985750324852077) started by @bungcip*