### PR TITLE
Cleanup Unused Public APIs and Restrict Visibility

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -220,7 +220,9 @@ impl<'a> SemanticAnalyzer<'a> {
         self.semantic_info.conversions[node.index()].push(conv);
     }
 
-    pub(crate) fn apply_lvalue_conversion(&mut self, node: NodeRef) {
+    /// Internal helper to apply lvalue-to-rvalue conversion to a node.
+    /// This is private because it is only used during the semantic analysis pass.
+    fn apply_lvalue_conversion(&mut self, node: NodeRef) {
         if self.semantic_info.value_categories[node.index()] == ValueCategory::LValue {
             self.semantic_info.value_categories[node.index()] = ValueCategory::RValue;
             self.push_conversion(node, Conversion::LValueToRValue);

--- a/src/semantic/type_registry.rs
+++ b/src/semantic/type_registry.rs
@@ -125,7 +125,9 @@ pub struct TypeRegistry {
 }
 
 impl TypeRegistry {
-    pub fn is_value_fitting(&self, val: u64, ty: TypeRef) -> bool {
+    /// Checks if a given u64 value can fit into the specified type.
+    /// This is used internally during semantic analysis and constant evaluation.
+    pub(crate) fn is_value_fitting(&self, val: u64, ty: TypeRef) -> bool {
         let layout = self.get_layout(ty);
         let size_bits = layout.size * 8;
         let is_unsigned = match &self.get(ty).kind {


### PR DESCRIPTION
I have systematically reviewed the public APIs in the `src/` directory.

Most items marked `pub` within internal modules (like `semantic`, `parser`, `mir`, etc.) are effectively private to the crate because those modules are not exported publicly from `src/lib.rs`.

However, I identified two functions that had unnecessarily broad visibility within the crate or were marked as fully public:

1. `apply_lvalue_conversion` in `src/semantic/analyzer.rs`: Changed from `pub(crate)` to private `fn`. It is only used within the `SemanticAnalyzer` implementation in the same file.
2. `is_value_fitting` in `src/semantic/type_registry.rs`: Changed from `pub` to `pub(crate)`. While used by other modules in the `semantic` sub-crate, it is not part of the public driver API and its module is not publicly exposed.

I have added reasoning comments to both functions and verified that all 1435 tests pass.

---
*PR created automatically by Jules for task [10979500857734909586](https://jules.google.com/task/10979500857734909586) started by @bungcip*