### PR TITLE
refactor: remove needless borrow in tests/parser_utils.rs

### DIFF
--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -1522,10 +1522,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             && let Some(len) = self.deduce_array_size_full(ie, et)
         {
             if len == 0 && self.lang_opts.c_standard >= crate::lang_options::CStandard::C23 {
-                self.report_error(
-                    span,
-                    SemanticErrorKind::ZeroOrNegativeSizeArray { name },
-                );
+                self.report_error(span, SemanticErrorKind::ZeroOrNegativeSizeArray { name });
             }
             qt = QualType::new(
                 self.registry.array_of(et, ArraySizeType::Constant(len)),

--- a/src/tests/parser_utils.rs
+++ b/src/tests/parser_utils.rs
@@ -115,7 +115,7 @@ fn resolve_specs(ast: &ParsedAst, specifiers: &[DeclSpec]) -> Vec<String> {
                     let mut s = format!("enum {}", tag_str);
                     if let Some(ut) = underlying_type {
                         s.push_str(" : ");
-                        s.push_str(&extract_type_kind(ast, &ut));
+                        s.push_str(&extract_type_kind(ast, ut));
                     }
                     if let Some(enums) = enumerators {
                         let enum_parts: Vec<String> = enums


### PR DESCRIPTION
This PR removes an unnecessary borrow in `src/tests/parser_utils.rs` that was flagged by Clippy as `clippy::needless_borrow`. `ut` was already a reference and creating a reference to it caused a double reference that the compiler immediately dereferenced.

---
*PR created automatically by Jules for task [7165937454350586234](https://jules.google.com/task/7165937454350586234) started by @bungcip*