### PR TITLE
test: increase coverage for `is_value_fitting`

### DIFF
--- a/src/tests/semantic_types.rs
+++ b/src/tests/semantic_types.rs
@@ -685,3 +685,32 @@ fn test_pedantic_enum_forward_decl() {
     // Should fail with --pedantic-errors
     run_pedantic_fail_with_message(source, "ISO C forbids forward references");
 }
+
+#[test]
+fn test_is_value_fitting_coverage() {
+    use crate::semantic::type_registry::TypeRegistry;
+    let registry = TypeRegistry::new(target_lexicon::Triple::host());
+
+    // Unsigned 64-bit type
+    let ty_unsigned_long_long = registry.type_long_long_unsigned;
+    assert!(registry.is_value_fitting(12345, ty_unsigned_long_long));
+    assert!(registry.is_value_fitting(u64::MAX, ty_unsigned_long_long));
+
+    // Signed 64-bit type
+    let ty_signed_long_long = registry.type_long_long;
+    assert!(registry.is_value_fitting(12345, ty_signed_long_long));
+    assert!(registry.is_value_fitting(i64::MAX as u64, ty_signed_long_long));
+    assert!(!registry.is_value_fitting(u64::MAX, ty_signed_long_long));
+
+    // Unsigned 32-bit type
+    let ty_unsigned_int = registry.type_int_unsigned;
+    assert!(registry.is_value_fitting(12345, ty_unsigned_int));
+    assert!(registry.is_value_fitting(u32::MAX as u64, ty_unsigned_int));
+    assert!(!registry.is_value_fitting(u64::MAX, ty_unsigned_int));
+
+    // Signed 32-bit type
+    let ty_signed_int = registry.type_int;
+    assert!(registry.is_value_fitting(12345, ty_signed_int));
+    assert!(registry.is_value_fitting(i32::MAX as u64, ty_signed_int));
+    assert!(!registry.is_value_fitting(u32::MAX as u64, ty_signed_int));
+}


### PR DESCRIPTION
Coverage Increased for TypeRegistry::is_value_fitting

---
*PR created automatically by Jules for task [6056416825589043476](https://jules.google.com/task/6056416825589043476) started by @bungcip*