### PR TITLE
Implement C11 Digraph Support

### DIFF
--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -384,6 +384,34 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    if self.peek_char() == Some(b'%') {
+                        let saved_pos = self.position;
+                        let saved_at_start = self.at_start_of_line;
+                        self.next_char();
+                        if self.peek_char() == Some(b':') {
+                            self.next_char();
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            self.position = saved_pos;
+                            self.at_start_of_line = saved_at_start;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -411,6 +439,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -470,7 +502,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -515,9 +553,19 @@ impl PPLexer {
             self.next_char();
             self.skip_whitespace_and_comments();
 
-            if let Some(b'#') = self.peek_char() {
-                // Found a directive! Stop skipping.
-                break;
+            match self.peek_char() {
+                Some(b'#') => break,
+                Some(b'%') => {
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    self.next_char();
+                    if self.peek_char() == Some(b':') {
+                        break;
+                    }
+                    self.position = saved_pos;
+                    self.at_start_of_line = saved_at_start;
+                }
+                _ => {}
             }
 
             // Not a directive, continue skipping from the current position.

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -1522,10 +1522,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             && let Some(len) = self.deduce_array_size_full(ie, et)
         {
             if len == 0 && self.lang_opts.c_standard >= crate::lang_options::CStandard::C23 {
-                self.report_error(
-                    span,
-                    SemanticErrorKind::ZeroOrNegativeSizeArray { name },
-                );
+                self.report_error(span, SemanticErrorKind::ZeroOrNegativeSizeArray { name });
             }
             qt = QualType::new(
                 self.registry.array_of(et, ArraySizeType::Constant(len)),

--- a/src/tests/pp_lexical.rs
+++ b/src/tests/pp_lexical.rs
@@ -280,6 +280,81 @@ fn test_char_literal_escapes() {
     );
 }
 
+// Digraphs
+#[test]
+fn test_all_digraph_tokens() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_edge_cases() {
+    let source = "%:% %:%: : :> < <: <%%";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("#", PPTokenKind::Hash),
+        ("%", PPTokenKind::Percent),
+        ("##", PPTokenKind::HashHash),
+        (":", PPTokenKind::Colon),
+        ("]", PPTokenKind::RightBracket),
+        ("<", PPTokenKind::Less),
+        ("[", PPTokenKind::LeftBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("%", PPTokenKind::Percent),
+    );
+}
+
+#[test]
+fn test_digraph_hash_starts_pp_line() {
+    let source = "%:define X 1\n%: ifdef X\nOK\n%: endif";
+    let tokens = setup_pp_snapshot(source);
+
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: OK
+    ");
+}
+
+#[test]
+fn test_digraph_hashhash_pasting() {
+    let source = r#"
+#define CONCAT(a, b) a %:%: b
+CONCAT(x, y)
+"#;
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: xy
+    ");
+}
+
+#[test]
+fn test_digraph_in_skipping_block() {
+    let source = r#"
+#if 0
+%: define X 1
+#endif
+OK
+"#;
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: OK
+    ");
+}
+
 // UCNs
 #[test]
 fn test_ucn_identifier() {


### PR DESCRIPTION
I have implemented support for C11/C23 digraphs in the preprocessor. 

Key changes:
- Modified `src/pp/pp_lexer.rs` to recognize `<:`, `:>`, `<%`, `%>`, `%:`, and `%:%:`.
- Digraphs are tokenized into their equivalent standard punctuator tokens (`[`, `]`, `{`, `}`, `#`, `##`).
- `%:` is correctly handled at the start of a line to initiate preprocessor directives, just like `#`.
- `%:%:` is tokenized as a single `##` token.
- Updated the preprocessor's fast skipping logic to recognize `%:` as a potential directive starter, ensuring correct handling of conditional blocks.
- Added comprehensive unit tests in `src/tests/pp_lexical.rs` verifying all digraphs and their interactions with macros and directives.
- Verified that all tests pass and that no regressions were introduced in the standard C test suite.
- Applied `cargo fmt` and ensured `cargo clippy` passes.

---
*PR created automatically by Jules for task [17220724086014736872](https://jules.google.com/task/17220724086014736872) started by @bungcip*