### PR TITLE
Increase parser code coverage for sizeof with compound literal postfix

### DIFF
--- a/src/tests/parser_expr.rs
+++ b/src/tests/parser_expr.rs
@@ -452,3 +452,19 @@ fn test_ternary_with_comma_in_middle() {
       - Ident: d
     ");
 }
+
+#[test]
+fn test_sizeof_compound_literal_postfix() {
+    let resolved = setup_expr("sizeof(int[]){1, 2, 3}[1]");
+    insta::assert_yaml_snapshot!(&resolved, @"
+    SizeOfExpr:
+      IndexAccess:
+        - CompoundLiteral:
+            - parsed_type_1
+            - InitializerList:
+                - LiteralInt: 1
+                - LiteralInt: 2
+                - LiteralInt: 3
+        - LiteralInt: 1
+    ");
+}


### PR DESCRIPTION
A. Coverage increased

The uncovered code path was the `expr = parse_postfix_tail(parser, expr)?` branch in `src/parser/expressions.rs` during the parsing of a `sizeof` expression that operates on a compound literal with trailing postfix operators (e.g., array index).

I added a new unit test, `test_sizeof_compound_literal_postfix`, in `src/tests/parser_expr.rs` which uses the existing `setup_expr` helper to test `sizeof(int[]){1, 2, 3}[1]` and assert the AST snapshot using `insta::assert_yaml_snapshot!`.

This change successfully increased the line coverage in `src/parser/expressions.rs`.

---
*PR created automatically by Jules for task [445255023724887747](https://jules.google.com/task/445255023724887747) started by @bungcip*