### PR TITLE
Implement C digraph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 * **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-* **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported. This compiler targets modern C and does not implement legacy digraph tokens.
 * **No K&R Function Declarations**: In compliance with C23, functions declared with an empty parameter list (e.g., `int foo()`) are treated as having no parameters (equivalent to `int foo(void)`).
 * **Limited Inline Assembly Support**: Inline assembly (using `asm` or `__asm__` keywords) has only limited support depending on the Cranelift backend capabilities.
 

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -384,6 +384,26 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    // Check for %:%:
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    if consume_if!(b'%') && consume_if!(b':') {
+                        token!(PPTokenKind::HashHash, 4)
+                    } else {
+                        // Backtrack if not %:%:
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -411,6 +431,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -470,7 +494,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests/pp_lexical.rs
+++ b/src/tests/pp_lexical.rs
@@ -64,6 +64,66 @@ fn test_all_punctuation_tokens() {
 }
 
 #[test]
+fn test_digraph_in_macro() {
+    let src = r#"
+#define LBRACKET <:
+#define RBRACKET :>
+int a LBRACKET 5 RBRACKET;
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_tokens() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    // Digraphs should be lexed as their equivalent punctuators, but with length of 2 (or 4 for %:%:)
+    // and token text matching the punctuator they represent.
+    // wait, get_text() for LeftBracket returns "[".
+    // test_tokens! macro compares t.get_text() with the first argument.
+
+    let t1 = lexer.next_token().unwrap();
+    assert_eq!(t1.kind, PPTokenKind::LeftBracket);
+    assert_eq!(t1.length, 2);
+
+    let t2 = lexer.next_token().unwrap();
+    assert_eq!(t2.kind, PPTokenKind::RightBracket);
+    assert_eq!(t2.length, 2);
+
+    let t3 = lexer.next_token().unwrap();
+    assert_eq!(t3.kind, PPTokenKind::LeftBrace);
+    assert_eq!(t3.length, 2);
+
+    let t4 = lexer.next_token().unwrap();
+    assert_eq!(t4.kind, PPTokenKind::RightBrace);
+    assert_eq!(t4.length, 2);
+
+    let t5 = lexer.next_token().unwrap();
+    assert_eq!(t5.kind, PPTokenKind::Hash);
+    assert_eq!(t5.length, 2);
+
+    let t6 = lexer.next_token().unwrap();
+    assert_eq!(t6.kind, PPTokenKind::HashHash);
+    assert_eq!(t6.length, 4);
+}
+
+#[test]
+fn test_digraph_hash_starts_pp_line() {
+    let source = "%:define X 1";
+    let mut lexer = create_test_pp_lexer(source);
+
+    let t1 = lexer.next_token().unwrap();
+    assert_eq!(t1.kind, PPTokenKind::Hash);
+    assert_eq!(t1.length, 2);
+    assert!(t1.flags.contains(PPTokenFlags::STARTS_PP_LINE));
+
+    let t2 = lexer.next_token().unwrap();
+    assert_eq!(t2.get_text(), "define");
+}
+
+#[test]
 fn test_all_keyword_tokens() {
     let source = "if ifdef ifndef elif else endif define undef include line pragma error warning";
     let mut lexer = create_test_pp_lexer(source);

--- a/src/tests/snapshots/cendol__tests__pp_lexical__digraph_in_macro.snap
+++ b/src/tests/snapshots/cendol__tests__pp_lexical__digraph_in_macro.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/pp_lexical.rs
+assertion_line: 74
+expression: tokens
+---
+- kind: Identifier
+  text: int
+- kind: Identifier
+  text: a
+- kind: LeftBracket
+  text: "["
+- kind: Number
+  text: "5"
+- kind: RightBracket
+  text: "]"
+- kind: Semicolon
+  text: ;

--- a/test_digraphs.c
+++ b/test_digraphs.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() <%
+    int arr<:5:>;
+    return 0;
+%>


### PR DESCRIPTION
Implemented support for C digraphs in the preprocessor lexer. This includes handling of `<:`, `:>`, `<%`, `%>`, `%:`, and `%:%:`. The `%:` digraph is correctly recognized as a `#` for the purposes of initiating preprocessor directives. Comprehensive unit tests were added to ensure correct behavior in various contexts, including macro expansion. Documentation was updated to remove the previous limitation.

---
*PR created automatically by Jules for task [6129170857632859308](https://jules.google.com/task/6129170857632859308) started by @bungcip*