### PR TITLE
Add parser test for __builtin_alloca

### DIFF
--- a/src/tests/parser_expr.rs
+++ b/src/tests/parser_expr.rs
@@ -468,3 +468,9 @@ fn test_sizeof_compound_literal_postfix() {
         - LiteralInt: 1
     ");
 }
+
+#[test]
+fn test_builtin_alloca() {
+    let resolved = setup_expr("__builtin_alloca(42)");
+    insta::assert_yaml_snapshot!(&resolved);
+}

--- a/src/tests/parser_utils.rs
+++ b/src/tests/parser_utils.rs
@@ -47,7 +47,8 @@ pub(crate) enum ResolvedNodeKind {
     Return(Option<Box<ResolvedNodeKind>>),  // Return statement
     Break,                                  // Break statement
     Continue,                               // Continue statement
-    Switch(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>), // Switch statement
+    Switch(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>),
+    BuiltinAlloca(Box<ResolvedNodeKind>),
     Case(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>), // Case statement
     CaseRange(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>, Box<ResolvedNodeKind>), // GNU Case range statement
     Default(Box<ResolvedNodeKind>),         // Default statement
@@ -360,6 +361,7 @@ pub(crate) fn resolve_node(ast: &ParsedAst, node: ParsedNodeRef) -> ResolvedNode
         }
         ParsedNodeKind::EmptyStmt | ParsedNodeKind::Dummy => ResolvedNodeKind::Empty,
         // Add more cases as needed for other ParsedNodeKind variants used in tests
+        ParsedNodeKind::BuiltinAlloca(expr) => ResolvedNodeKind::BuiltinAlloca(Box::new(resolve_node(ast, *expr))),
         _ => panic!("Unsupported ParsedNodeKind for resolution: {:?}", node.kind),
     }
 }

--- a/src/tests/parser_utils.rs
+++ b/src/tests/parser_utils.rs
@@ -51,7 +51,7 @@ pub(crate) enum ResolvedNodeKind {
     BuiltinAlloca(Box<ResolvedNodeKind>),
     Case(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>), // Case statement
     CaseRange(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>, Box<ResolvedNodeKind>), // GNU Case range statement
-    Default(Box<ResolvedNodeKind>),         // Default statement
+    Default(Box<ResolvedNodeKind>),                     // Default statement
     If(
         Box<ResolvedNodeKind>,
         Box<ResolvedNodeKind>,

--- a/src/tests/snapshots/cendol__tests__parser_expr__builtin_alloca.snap
+++ b/src/tests/snapshots/cendol__tests__parser_expr__builtin_alloca.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/parser_expr.rs
+expression: "&resolved"
+---
+BuiltinAlloca:
+  LiteralInt: 42


### PR DESCRIPTION
This change increases code coverage in `src/parser/expressions.rs` by adding a snapshot test for parsing `__builtin_alloca`. 

The `parse_builtin_alloca` function (lines 490-496) was previously uncovered.

I added a `test_builtin_alloca` test to `src/tests/parser_expr.rs` and updated the `resolve_node` function in `src/tests/parser_utils.rs` to support the `BuiltinAlloca` AST node to allow the test to generate the snapshot correctly. 

This successfully increases statement coverage in `src/parser/expressions.rs`.

---
*PR created automatically by Jules for task [7941460620949633840](https://jules.google.com/task/7941460620949633840) started by @bungcip*