### PR TITLE
Implement constant evaluation for __builtin_complex

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -2852,10 +2852,10 @@ impl<'a> SemanticAnalyzer<'a> {
                 ty
             }
             NodeKind::BuiltinComplex(real, imag) => {
-                self.apply_lvalue_conversion(*real);
-                self.apply_lvalue_conversion(*imag);
                 let real_ty = self.visit_node(*real)?;
                 let imag_ty = self.visit_node(*imag)?;
+                self.apply_lvalue_conversion(*real);
+                self.apply_lvalue_conversion(*imag);
 
                 if !real_ty.is_real() {
                     self.report_error(*real, SemanticErrorKind::InvalidUnaryOperand { ty: real_ty });

--- a/src/semantic/const_eval.rs
+++ b/src/semantic/const_eval.rs
@@ -180,6 +180,13 @@ impl<'a> ConstEvalCtx<'a> {
                 }
             }
             NodeKind::Cast(_, expr) => self.eval_complex_part(*expr, is_real),
+            NodeKind::BuiltinComplex(real, imag) => {
+                if is_real {
+                    self.eval_float(*real)
+                } else {
+                    self.eval_float(*imag)
+                }
+            }
             _ => {
                 if is_real {
                     self.eval_float(node)
@@ -294,6 +301,7 @@ impl<'a> ConstEvalCtx<'a> {
             NodeKind::BuiltinFabs(exp) | NodeKind::BuiltinFabsf(exp) | NodeKind::BuiltinFabsl(exp) => {
                 self.eval_float(*exp).map(|v| v.abs() as i64)
             }
+            NodeKind::BuiltinComplex(real, _) => self.eval_int(*real),
             _ => None,
         }
     }
@@ -365,6 +373,7 @@ impl<'a> ConstEvalCtx<'a> {
             NodeKind::BuiltinFabs(exp) | NodeKind::BuiltinFabsf(exp) | NodeKind::BuiltinFabsl(exp) => {
                 self.eval_float(*exp).map(|v| v.abs())
             }
+            NodeKind::BuiltinComplex(real, _) => self.eval_float(*real),
             NodeKind::FunctionCall(call) => {
                 let callee_kind = self.ast.get_kind(call.callee);
                 let name_id = match callee_kind {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -80,6 +80,7 @@ pub mod guardian_alignof_bitfield;
 pub mod guardian_array_init_bounds;
 pub mod guardian_array_init_string;
 pub mod guardian_bitfield_constraints;
+pub mod guardian_builtin_complex_const;
 pub mod guardian_cast_constraints;
 pub mod guardian_compound_literal_constraints;
 pub mod guardian_const_eval_builtins;

--- a/src/tests/guardian_builtin_complex_const.rs
+++ b/src/tests/guardian_builtin_complex_const.rs
@@ -1,0 +1,37 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_pass;
+
+#[test]
+fn test_builtin_complex_constant_evaluation() {
+    // C11 6.6p6: "...floating constants are ONLY allowed as the immediate operands of casts."
+    // However, __builtin_complex is an intrinsic that constructs a complex number.
+    // If its operands are constant, the result should be treatable as a constant expression
+    // when accessed via __real__ or __imag__.
+
+    run_pass(
+        r#"
+        _Static_assert(__real__ __builtin_complex(1.0, 2.0) == 1.0, "real part constant eval");
+        _Static_assert(__imag__ __builtin_complex(1.0, 2.0) == 2.0, "imag part constant eval");
+
+        _Static_assert(__real__ __builtin_complex(1.0f + 1.0f, 2.0f) == 2.0, "real part with expr");
+
+        int main() { return 0; }
+        "#,
+        CompilePhase::Mir,
+    );
+}
+
+#[test]
+fn test_builtin_complex_global_init() {
+    run_pass(
+        r#"
+        _Complex double cd = __builtin_complex(3.0, 4.0);
+        int main() {
+            if (__real__ cd != 3.0) return 1;
+            if (__imag__ cd != 4.0) return 2;
+            return 0;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
### Problem
The `__builtin_complex` intrinsic was not supported in the compiler's constant evaluator, preventing its use in `_Static_assert` and global initializers even when its arguments were constant. Furthermore, a phase-ordering bug in the semantic analyzer caused lvalue conversions for its operands to be applied prematurely.

### Solution
1.  **Constant Evaluation**: Updated `src/semantic/const_eval.rs` to handle `NodeKind::BuiltinComplex`. The `eval_complex_part` helper now correctly extracts the real or imaginary part from a constant `__builtin_complex` call.
2.  **Phase Ordering**: Fixed `visit_builtin_complex` in `src/semantic/analyzer.rs` to call `visit_node` on operands before `apply_lvalue_conversion`.
3.  **Testing**: Added `src/tests/guardian_builtin_complex_const.rs` with test cases for static assertions and global initialization using `__builtin_complex`.

### Verification
- Ran `cargo test guardian_builtin_complex_const` (Passed)
- Ran related tests in `semantic_builtin_complex`, `semantic_regr_real_imag`, and `semantic_static_assert` (All Passed)
- Verified fix for lvalue conversion ordering with manual analysis.

---
*PR created automatically by Jules for task [13389395576103566347](https://jules.google.com/task/13389395576103566347) started by @bungcip*