### PR TITLE
feat: Add support for GNU obsolete designated initializers

### DIFF
--- a/gnu_extensions_tests.md
+++ b/gnu_extensions_tests.md
@@ -73,13 +73,13 @@ int main(void) { int a[10] = { [0 ... 9] = 1 }; return a[0] - 1; }
 ❌ Fails with --pedantic-errors
 
 ## 8. GNU designated initializers (obsolete colons)
-**Description**: Allows initializing a struct field using `fieldname: value` instead of standard `.fieldname = value`. Cendol does not support this legacy syntax.
+**Description**: Allows initializing a struct field using `fieldname: value` instead of standard `.fieldname = value`.
 **C code snippet**:
 ```c
 struct S { int a; }; int main(void) { struct S s = { a: 1 }; return s.a - 1; }
 ```
 **Expected behavior**:
-❌ Fails with GNU extensions enabled (Unsupported)
+✅ Compiles with GNU extensions enabled
 ❌ Fails with --pedantic-errors
 
 ## 9. Case ranges

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -354,6 +354,7 @@ pub struct ParsedGenericAssociation {
 pub struct ParsedDesignatedInitializer {
     pub designation: Box<[ParsedDesignator]>,
     pub initializer: ParsedNodeRef,
+    pub is_gnu_obsolete: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -420,6 +420,17 @@ pub(super) fn parse_initializer(parser: &mut Parser) -> Result<ParsedNodeRef, Pa
         while !parser.at_eof() && !parser.is_token(TokenKind::RightBrace) {
             let initializer = if parser.matches(&[TokenKind::Dot, TokenKind::LeftBracket]) {
                 parse_designated_initializer(parser)?
+            } else if matches!(parser.current_token_kind(), Some(TokenKind::Identifier(_)))
+                && parser.peek_token(0).map(|t| t.kind) == Some(TokenKind::Colon)
+            {
+                let (field_name, _) = parser.expect_name()?;
+                parser.expect(TokenKind::Colon)?;
+                let inner = parse_initializer(parser)?;
+                ParsedDesignatedInitializer {
+                    designation: vec![ParsedDesignator::FieldName(field_name)].into_boxed_slice(),
+                    initializer: inner,
+                    is_gnu_obsolete: true,
+                }
             } else {
                 let inner = if parser.is_token(TokenKind::LeftBrace) {
                     parse_initializer(parser)?
@@ -430,6 +441,7 @@ pub(super) fn parse_initializer(parser: &mut Parser) -> Result<ParsedNodeRef, Pa
                 ParsedDesignatedInitializer {
                     designation: Vec::new().into_boxed_slice(),
                     initializer: inner,
+                    is_gnu_obsolete: false,
                 }
             };
 
@@ -461,6 +473,7 @@ fn parse_designated_initializer(parser: &mut Parser) -> Result<ParsedDesignatedI
     Ok(ParsedDesignatedInitializer {
         designation,
         initializer,
+        is_gnu_obsolete: false,
     })
 }
 

--- a/src/semantic/errors.rs
+++ b/src/semantic/errors.rs
@@ -37,6 +37,7 @@ impl SemanticError {
             | SemanticErrorKind::GnuStatementExpression
             | SemanticErrorKind::GnuTypeof
             | SemanticErrorKind::GnuDesignatedInitializerRange
+            | SemanticErrorKind::GnuObsoleteDesignatedInitializer
             | SemanticErrorKind::GnuCaseRange
             | SemanticErrorKind::InlineAsmIgnored
             | SemanticErrorKind::ExcessElements { .. } => DiagnosticLevel::Warning,
@@ -407,6 +408,7 @@ pub enum SemanticErrorKind {
     GnuStatementExpression,
     GnuTypeof,
     GnuDesignatedInitializerRange,
+    GnuObsoleteDesignatedInitializer,
     GnuCaseRange,
     GnuZeroLengthArray,
     InlineAsmIgnored,
@@ -436,6 +438,7 @@ impl SemanticErrorKind {
             SemanticErrorKind::GnuStatementExpression => Some("gnu-statement-expression"),
             SemanticErrorKind::GnuTypeof => Some("gnu-typeof-expression"),
             SemanticErrorKind::GnuDesignatedInitializerRange => Some("gnu-designated-init"),
+            SemanticErrorKind::GnuObsoleteDesignatedInitializer => Some("gnu-obsolete-designated-init"),
             SemanticErrorKind::GnuCaseRange => Some("gnu-case-range"),
             SemanticErrorKind::GnuZeroLengthArray => Some("gnu-zero-length-array"),
             SemanticErrorKind::InlineAsmIgnored => Some("inline-asm"),
@@ -852,6 +855,9 @@ impl SemanticErrorKind {
             SemanticErrorKind::GnuTypeof => "use of GNU typeof extension".to_string(),
             SemanticErrorKind::GnuDesignatedInitializerRange => {
                 "use of GNU designated initializer range extension".to_string()
+            }
+            SemanticErrorKind::GnuObsoleteDesignatedInitializer => {
+                "use of GNU obsolete designated initializer extension".to_string()
             }
             SemanticErrorKind::GnuCaseRange => "use of GNU case range extension".to_string(),
             SemanticErrorKind::GnuZeroLengthArray => "use of GNU zero-length array extension".to_string(),

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -1945,7 +1945,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
         let declarator = parsed_type.declarator;
         let qualifiers = parsed_type.qualifiers;
 
-        let base = self.convert_to_qual_type(&base_type_node, span)?;
+        let base = self.convert_to_qual_type(base_type_node, span)?;
         let qbase = self.merge_qualifiers_with_check(base, qualifiers, span);
 
         let final_type = self.apply_declarator(qbase, declarator, span, None, DeclaratorContext { in_parameter });
@@ -2091,6 +2091,9 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
         }
 
         for (i, init) in inits.iter().enumerate() {
+            if init.is_gnu_obsolete {
+                self.report_warning(span, SemanticErrorKind::GnuObsoleteDesignatedInitializer);
+            }
             let expr = self.visit_expression(init.initializer);
             let designator_count = init.designation.len() as u16;
             let mut designator_dummies = Vec::with_capacity(designator_count as usize);

--- a/src/tests/driver_ast_dumper.rs
+++ b/src/tests/driver_ast_dumper.rs
@@ -61,7 +61,7 @@ fn test_dump_parsed_ast_with_structs() {
     4: Declaration(ParsedDecl { specifiers: [TypeSpec(Int)], init_declarators: [ParsedInitDeclarator { declarator: 2, initializer: None, span: SourceSpan(2199040032794) }] })
     5: LiteralInt(1, None, base=10)
     6: LiteralInt(2, None, base=10)
-    7: InitializerList([ParsedDesignatedInitializer { designation: [], initializer: 5 }, ParsedDesignatedInitializer { designation: [], initializer: 6 }])
+    7: InitializerList([ParsedDesignatedInitializer { designation: [], initializer: 5, is_gnu_obsolete: false }, ParsedDesignatedInitializer { designation: [], initializer: 6, is_gnu_obsolete: false }])
     "#
     );
 }
@@ -135,7 +135,7 @@ fn test_dump_parsed_ast_with_pointers() {
 #[test]
 fn test_dump_parsed_ast_with_arrays() {
     let output = dump_parsed_ast("int arr[5] = {1, 2, 3, 4, 5}; int* ptr_arr[3];");
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     1: TranslationUnit(decls=[2, 10])
     2: Declaration(ParsedDecl { specifiers: [TypeSpec(Int)], init_declarators: [ParsedInitDeclarator { declarator: 2, initializer: Some(9), span: SourceSpan(2199308468235) }] })
     3: LiteralInt(5, None, base=10)
@@ -144,7 +144,7 @@ fn test_dump_parsed_ast_with_arrays() {
     6: LiteralInt(3, None, base=10)
     7: LiteralInt(4, None, base=10)
     8: LiteralInt(5, None, base=10)
-    9: InitializerList([ParsedDesignatedInitializer { designation: [], initializer: 4 }, ParsedDesignatedInitializer { designation: [], initializer: 5 }, ParsedDesignatedInitializer { designation: [], initializer: 6 }, ParsedDesignatedInitializer { designation: [], initializer: 7 }, ParsedDesignatedInitializer { designation: [], initializer: 8 }])
+    9: InitializerList([ParsedDesignatedInitializer { designation: [], initializer: 4, is_gnu_obsolete: false }, ParsedDesignatedInitializer { designation: [], initializer: 5, is_gnu_obsolete: false }, ParsedDesignatedInitializer { designation: [], initializer: 6, is_gnu_obsolete: false }, ParsedDesignatedInitializer { designation: [], initializer: 7, is_gnu_obsolete: false }, ParsedDesignatedInitializer { designation: [], initializer: 8, is_gnu_obsolete: false }])
     10: Declaration(ParsedDecl { specifiers: [TypeSpec(Int)], init_declarators: [ParsedInitDeclarator { declarator: 5, initializer: None, span: SourceSpan(2199056810028) }] })
     11: LiteralInt(3, None, base=10)
     ");
@@ -474,7 +474,7 @@ fn test_parsed_ast_compound_literal() {
     5: FunctionDef(ParsedFunctionDef { specifiers: [TypeSpec(Int)], declarator: 3, body: 6 })
     6: CompoundStmt(stmts=[11])
     7: LiteralInt(1, None, base=10)
-    8: InitializerList([ParsedDesignatedInitializer { designation: [], initializer: 7 }])
+    8: InitializerList([ParsedDesignatedInitializer { designation: [], initializer: 7, is_gnu_obsolete: false }])
     9: CompoundLiteral(ParsedType { base: 1, declarator: 4, qualifiers: TypeQualifiers(0x0) }, 8)
     10: MemberAccess(9, a, .)
     11: Return(10)

--- a/src/tests/parser_gcc_extensions.rs
+++ b/src/tests/parser_gcc_extensions.rs
@@ -143,3 +143,18 @@ fn test_gnu_statement_expression_empty() {
       - Empty
     ");
 }
+
+#[test]
+fn test_gnu_obsolete_designated_initializer() {
+    let resolved = setup_declaration("struct S s = { a: 1 };");
+    insta::assert_yaml_snapshot!(&resolved, @"
+    Declaration:
+      specifiers:
+        - struct S
+      init_declarators:
+        - name: s
+          initializer:
+            InitializerList:
+              - LiteralInt: 1
+    ");
+}


### PR DESCRIPTION
Adds support for the GNU legacy obsolete designated initializer syntax (`fieldname: value`), ensuring it is properly parsed, flagged, warned, and covered with standard tests under `src/tests/parser_gcc_extensions.rs`.

---
*PR created automatically by Jules for task [10719147617147946795](https://jules.google.com/task/10719147617147946795) started by @bungcip*