### PR TITLE
🛡️ Guardian: enforce register aggregate member address constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -214,3 +214,8 @@ Action: Implement recursive property checks for 'has_flexible_array_member' in t
 
 Learning: C11 6.5.1.1p2 mandates that the controlling expression of a `_Generic` selection shall be compatible with at most one generic association. Picking only the first match is insufficient as it silently accepts ambiguous code. Furthermore, associations like `int(*)[10]` and `int(*)[20]` are NOT compatible with each other, but both can be compatible with a controlling expression of type `int(*)[]` (pointer to incomplete array).
 Action: Ensure that `_Generic` selection continues checking all associations even after a match is found, to detect and report ambiguity errors when multiple associations are compatible with the controlling expression.
+
+2026-04-15 - [Register Aggregate Member Address Constraints]
+
+Learning: C11 6.7.1p6 prohibits taking the address of any part of an object declared with the 'register' storage class. This includes not only the object itself but also its members (for structs/unions) and elements (for arrays). Crucially, this prohibition extends to implicit address-of operations, such as array-to-pointer decay. Enforcing this requires 'is_register_variable' to be recursive for 'MemberAccess' and 'IndexAccess', and 'decay' to explicitly check for the 'register' property on its operand.
+Action: Always verify that storage-class-specific constraints are propagated and checked through aggregate access and implicit conversions.

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -515,6 +515,10 @@ impl<'a> SemanticAnalyzer<'a> {
 
     fn decay(&mut self, node: NodeRef, qt: QualType) -> QualType {
         if qt.is_array() || qt.is_function() {
+            if qt.is_array() && self.is_register_variable(node) {
+                self.report_error(node, SemanticErrorKind::AddressOfRegister);
+            }
+
             let decayed = self.registry.decay(qt, TypeQualifiers::empty());
             self.push_conversion(node, Conversion::PointerDecay { to: decayed.ty() });
             decayed
@@ -522,7 +526,6 @@ impl<'a> SemanticAnalyzer<'a> {
             qt
         }
     }
-
     fn get_bitfield_width(&self, node: NodeRef) -> Option<u16> {
         match self.ast.get_kind(node) {
             NodeKind::MemberAccess(obj, field_name, is_arrow) => {
@@ -584,6 +587,13 @@ impl<'a> SemanticAnalyzer<'a> {
                 } else {
                     false
                 }
+            }
+            NodeKind::MemberAccess(obj, _, is_arrow) => {
+                !is_arrow && self.is_register_variable(*obj)
+            }
+            NodeKind::IndexAccess(arr, _) => {
+                let arr_ty = self.semantic_info.types.get(arr.index()).and_then(|t| *t);
+                arr_ty.is_some_and(|t| t.is_array()) && self.is_register_variable(*arr)
             }
             NodeKind::BuiltinChooseExpr(..) => {
                 if let Some(&selected) = self.semantic_info.choose_expressions.get(&node.index()) {
@@ -1523,8 +1533,7 @@ impl<'a> SemanticAnalyzer<'a> {
 
         // 2. Array/Function-to-pointer decay
         if lhs_qt.is_pointer() && (rhs_qt.is_array() || rhs_qt.is_function()) {
-            rhs_qt = self.registry.decay(rhs_qt, TypeQualifiers::empty());
-            self.push_conversion(rhs, Conversion::PointerDecay { to: rhs_qt.ty() });
+            rhs_qt = self.decay(rhs, rhs_qt);
         }
 
         // 3. Qualifier adjustment
@@ -2723,8 +2732,7 @@ impl<'a> SemanticAnalyzer<'a> {
                     if let Some(t) = ty
                         && (t.is_array() || t.is_function())
                     {
-                        let decayed = self.registry.decay(t, TypeQualifiers::empty());
-                        self.push_conversion(*result_expr, Conversion::PointerDecay { to: decayed.ty() });
+                        let decayed = self.decay(*result_expr, t);
                         ty = Some(decayed);
                     }
                     ty
@@ -3181,8 +3189,7 @@ impl<'a> SemanticAnalyzer<'a> {
         self.apply_lvalue_conversion(node);
         let mut qt = qt;
         if qt.is_array() || qt.is_function() {
-            let decayed = self.registry.decay(qt, TypeQualifiers::empty());
-            self.push_conversion(node, Conversion::PointerDecay { to: decayed.ty() });
+            let decayed = self.decay(node, qt);
             qt = decayed;
         } else if !qt.qualifiers().is_empty() {
             self.push_conversion(
@@ -3560,7 +3567,7 @@ impl<'a> SemanticAnalyzer<'a> {
         // association. Before comparison, array and function types decay to pointers.
         let decayed_ctrl = if ctrl.is_array() || ctrl.is_function() {
             // Qualifiers on the array/function type itself are discarded during decay.
-            self.registry.decay(ctrl, TypeQualifiers::empty())
+            self.decay(gs.control, ctrl)
         } else {
             ctrl
         };

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -588,9 +588,7 @@ impl<'a> SemanticAnalyzer<'a> {
                     false
                 }
             }
-            NodeKind::MemberAccess(obj, _, is_arrow) => {
-                !is_arrow && self.is_register_variable(*obj)
-            }
+            NodeKind::MemberAccess(obj, _, is_arrow) => !is_arrow && self.is_register_variable(*obj),
             NodeKind::IndexAccess(arr, _) => {
                 let arr_ty = self.semantic_info.types.get(arr.index()).and_then(|t| *t);
                 arr_ty.is_some_and(|t| t.is_array()) && self.is_register_variable(*arr)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -92,6 +92,7 @@ pub mod guardian_noreturn_switch;
 pub mod guardian_npc_propagation;
 pub mod guardian_offsetof;
 pub mod guardian_parameter_completeness;
+pub mod guardian_register_constraints;
 pub mod guardian_relational_pointer_constraints;
 pub mod guardian_sizeof_alignof;
 pub mod guardian_ternary_pointer_constraints;

--- a/src/tests/guardian_register_constraints.rs
+++ b/src/tests/guardian_register_constraints.rs
@@ -1,0 +1,131 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+
+#[test]
+fn test_register_struct_member_address_prohibited() {
+    // C11 6.7.1p6: "If an object... is declared with the register storage-class specifier...
+    // any part of the object... shall not have its address taken"
+    run_fail_with_message(
+        r#"
+        struct S { int x; };
+        int main() {
+            register struct S s;
+            int *p = &s.x;
+        }
+        "#,
+        "cannot take address of 'register' variable",
+    );
+}
+
+#[test]
+fn test_register_union_member_address_prohibited() {
+    run_fail_with_message(
+        r#"
+        union U { int x; float y; };
+        int main() {
+            register union U u;
+            int *p = &u.x;
+        }
+        "#,
+        "cannot take address of 'register' variable",
+    );
+}
+
+#[test]
+fn test_register_array_decay_prohibited() {
+    // Implicit decay of a register array is effectively taking the address of its first element.
+    run_fail_with_message(
+        r#"
+        int main() {
+            register int a[10];
+            int *p = a;
+        }
+        "#,
+        "cannot take address of 'register' variable",
+    );
+}
+
+#[test]
+fn test_register_array_index_address_prohibited() {
+    run_fail_with_message(
+        r#"
+        int main() {
+            register int a[10];
+            int *p = &a[0];
+        }
+        "#,
+        "cannot take address of 'register' variable",
+    );
+}
+
+#[test]
+fn test_register_nested_member_address_prohibited() {
+    run_fail_with_message(
+        r#"
+        struct Inner { int x; };
+        struct Outer { struct Inner inner; };
+        int main() {
+            register struct Outer o;
+            int *p = &o.inner.x;
+        }
+        "#,
+        "cannot take address of 'register' variable",
+    );
+}
+
+#[test]
+fn test_register_selection_expression_member_address_prohibited() {
+    // _Generic
+    run_fail_with_message(
+        r#"
+        struct S { int x; };
+        int main() {
+            register struct S s;
+            int *p = &_Generic(0, int: s.x);
+        }
+        "#,
+        "cannot take address of 'register' variable",
+    );
+
+    // __builtin_choose_expr
+    run_fail_with_message(
+        r#"
+        struct S { int x; };
+        int main() {
+            register struct S s;
+            int *p = &__builtin_choose_expr(1, s.x, s.x);
+        }
+        "#,
+        "cannot take address of 'register' variable",
+    );
+}
+
+#[test]
+fn test_register_selection_expression_array_decay_prohibited() {
+    run_fail_with_message(
+        r#"
+        int main() {
+            register int a[10];
+            int *p = _Generic(0, int: a);
+        }
+        "#,
+        "cannot take address of 'register' variable",
+    );
+}
+
+#[test]
+fn test_non_register_aggregate_address_allowed() {
+    run_pass(
+        r#"
+        struct S { int x; };
+        int main() {
+            struct S s;
+            int *p = &s.x;
+            int a[10];
+            int *pa = a;
+            return 0;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
This PR ensures compliance with C11 6.7.1p6, which states that any part of an object declared with the `register` storage-class specifier shall not have its address taken.

Previously, the compiler only checked this for the object itself (e.g., `&reg_var`). This change extends the check to:
1. Members of a `register` struct or union (`&reg_struct.member`).
2. Elements of a `register` array (`&reg_array[0]`).
3. Implicit decay of a `register` array to a pointer (`int *p = reg_array;`).
4. Preservation of these constraints through selection expressions (`_Generic` and `__builtin_choose_expr`).

The implementation makes `is_register_variable` recursive and centralizes array/function decay logic in the `SemanticAnalyzer` to consistently enforce the constraint during implicit conversions.

---
*PR created automatically by Jules for task [18377371691265955784](https://jules.google.com/task/18377371691265955784) started by @bungcip*