### PR TITLE
feat: implement support for C11/C23 digraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 * **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-* **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported. This compiler targets modern C and does not implement legacy digraph tokens.
 * **No K&R Function Declarations**: In compliance with C23, functions declared with an empty parameter list (e.g., `int foo()`) are treated as having no parameters (equivalent to `int foo(void)`).
 * **Limited Inline Assembly Support**: Inline assembly (using `asm` or `__asm__` keywords) has only limited support depending on the Cranelift backend capabilities.
 

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -384,6 +384,34 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    if self.peek_char() == Some(b'%') {
+                        let saved_pos = self.position;
+                        let saved_at_start = self.at_start_of_line;
+                        self.next_char(); // consume '%'
+                        if self.peek_char() == Some(b':') {
+                            self.next_char(); // consume ':'
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            self.position = saved_pos;
+                            self.at_start_of_line = saved_at_start;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -411,6 +439,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -470,7 +502,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,63 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::*;
+
+#[test]
+fn test_digraph_punctuators() {
+    let mut lexer = create_test_pp_lexer("<: :> <% %> %: %:%:");
+
+    // Digraphs should be tokenized as their standard equivalents.
+    // Note: token.get_text() for digraphs returns the standard punctuator string.
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive() {
+    let src = r#"
+%:define FOO 1
+int x = FOO;
+"#;
+    let tokens = setup_pp_snapshot(src);
+
+    // Should be expanded correctly if %: is recognized as #
+    assert_eq!(tokens.len(), 5); // int, x, =, 1, ;
+    assert_eq!(tokens[0].text, "int");
+    assert_eq!(tokens[3].text, "1");
+}
+
+#[test]
+fn test_digraph_pasting() {
+    let src = r#"
+#define PASTE(a, b) a %:%: b
+int xy = PASTE(x, y);
+"#;
+    let tokens = setup_pp_snapshot(src);
+
+    // Should be expanded correctly if %:%: is recognized as ##
+    assert_eq!(tokens.len(), 5); // int, xy, =, xy, ;
+    assert_eq!(tokens[0].text, "int");
+    assert_eq!(tokens[3].text, "xy");
+}
+
+#[test]
+fn test_digraph_stringification() {
+    let src = r#"
+#define STR(x) #x
+char* s = STR(<: :>);
+"#;
+    let tokens = setup_pp_snapshot(src);
+
+    // Stringification of digraphs.
+    // In C11 6.4.6p3: "the spelling of the preprocessing tokens [digraphs] is retained"
+    // during stringification.
+    assert_eq!(tokens.len(), 6); // char, *, s, =, "<: :>", ;
+    assert_eq!(tokens[4].text, "\"<: :>\"");
+}


### PR DESCRIPTION
This PR implements support for digraphs as defined in the C standard. Digraphs are two-character or four-character sequences that are treated as standard punctuators. This implementation maps them to their standard equivalents during tokenization and ensures they behave correctly in preprocessor directives and during macro expansion (including token pasting and stringification).

Key changes:
- Modified `src/pp/pp_lexer.rs` to recognize digraph sequences.
- Ensured `%:` at the start of a line correctly initiates preprocessor directives.
- Added `src/tests/pp_digraphs.rs` to verify correct behavior.
- Updated `README.md` documentation.

---
*PR created automatically by Jules for task [7301357192913545613](https://jules.google.com/task/7301357192913545613) started by @bungcip*