### PR TITLE
⚡ Bolt: Optimize semantic analysis hot-paths

### DIFF
--- a/benches/compiler_benches.rs
+++ b/benches/compiler_benches.rs
@@ -49,6 +49,7 @@ fn bench_compiler_stages(c: &mut Criterion) {
 
     group.bench_function("preprocess_sqlite", |b| run_stage(b, CompilePhase::Preprocess));
     group.bench_function("parse_sqlite", |b| run_stage(b, CompilePhase::Parse));
+    group.bench_function("analyze_sqlite", |b| run_stage(b, CompilePhase::Mir));
 
     group.finish();
 }

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -444,12 +444,12 @@ impl<'a> SemanticAnalyzer<'a> {
             NodeKind::FunctionCall(call) => {
                 if let Some(callee_type) = self.semantic_info.types[call.callee.index()] {
                     let mut ty = callee_type.ty();
-                    while let TypeKind::Pointer { pointee } = &self.registry.get(ty).kind {
+                    // Bolt ⚡: Optimization: use registry.get_pointee() and is_noreturn_function helper.
+                    // This avoids redundant Cow<Type> allocations for pointers in the hot path.
+                    while let Some(pointee) = self.registry.get_pointee(ty) {
                         ty = pointee.ty();
                     }
-                    if let TypeKind::Function { is_noreturn, .. } = &self.registry.get(ty).kind {
-                        return *is_noreturn;
-                    }
+                    return self.registry.is_noreturn_function(ty);
                 }
                 false
             }
@@ -3658,8 +3658,8 @@ impl<'a> SemanticAnalyzer<'a> {
 
             // C11 6.5.1.1p2: The type name in a generic association shall specify a complete object type
             // other than a variably modified type.
-            let assoc_ty_kind = &self.registry.get(assoc_qt.ty()).kind;
-            if matches!(assoc_ty_kind, TypeKind::Function { .. }) {
+            // Bolt ⚡: Optimization: use assoc_qt.is_function() instead of registry lookup.
+            if assoc_qt.is_function() {
                 self.report_error(
                     assoc_node,
                     SemanticErrorKind::GenericFunctionAssociation { ty: assoc_qt },

--- a/src/semantic/conversions.rs
+++ b/src/semantic/conversions.rs
@@ -1,17 +1,16 @@
 //! Implements C11 semantic conversions, such as usual arithmetic conversions
 //! and integer promotions.
 
-use crate::semantic::{BuiltinType, QualType, TypeKind, TypeRegistry};
+use crate::semantic::{BuiltinType, QualType, TypeRegistry};
 
 /// Performs the "usual arithmetic conversions" as specified in C11 6.3.1.8.
 pub(super) fn usual_arithmetic_conversions(ctx: &TypeRegistry, lhs: QualType, rhs: QualType) -> Option<QualType> {
     if lhs.is_floating() || rhs.is_floating() {
         let get_real = |qt: QualType| {
             if qt.is_complex() {
-                match &ctx.get(qt.ty()).kind {
-                    TypeKind::Complex { base_type } => Some(*base_type),
-                    _ => unreachable!("ICE: Complex type has non-complex kind"),
-                }
+                // Bolt ⚡: Optimization: use registry.get_complex_base() helper.
+                // This avoids redundant Cow<Type> allocations for complex types.
+                ctx.get_complex_base(qt.ty())
             } else {
                 Some(qt.ty())
             }

--- a/src/semantic/type_registry.rs
+++ b/src/semantic/type_registry.rs
@@ -126,11 +126,13 @@ pub struct TypeRegistry {
 
 impl TypeRegistry {
     pub(crate) fn is_value_fitting(&self, val: i64, ty_ref: TypeRef) -> bool {
-        let ty = self.get(ty_ref);
-        if !ty.is_int() {
+        // Bolt ⚡: Optimization: use ty_ref property checks before calling get().
+        // This avoids Cow<Type> allocations for non-integer types (like pointers).
+        if !ty_ref.is_integer() {
             return false;
         }
 
+        let ty = self.get(ty_ref);
         let width = ty.width();
         if ty.is_signed() {
             let max = if width >= 64 {
@@ -528,6 +530,40 @@ impl TypeRegistry {
             match &self.types[ty.index()].kind {
                 TypeKind::Alias(inner) => ty = *inner,
                 TypeKind::Array { element_type, .. } => return Some(*element_type),
+                _ => return None,
+            }
+        }
+    }
+
+    pub(crate) fn is_noreturn_function(&self, mut ty: TypeRef) -> bool {
+        loop {
+            // Bolt ⚡: Fast path to avoid registry lookup for non-function types.
+            let class = ty.class();
+            if class != TypeClass::Function && class != TypeClass::Alias {
+                return false;
+            }
+
+            // Bolt ⚡: Direct registry access avoids Cow<Type> allocations.
+            match &self.types[ty.index()].kind {
+                TypeKind::Alias(inner) => ty = *inner,
+                TypeKind::Function { is_noreturn, .. } => return *is_noreturn,
+                _ => return false,
+            }
+        }
+    }
+
+    pub(crate) fn get_complex_base(&self, mut ty: TypeRef) -> Option<TypeRef> {
+        loop {
+            // Bolt ⚡: Fast path to avoid registry lookup for non-complex types.
+            let class = ty.class();
+            if class != TypeClass::Complex && class != TypeClass::Alias {
+                return None;
+            }
+
+            // Bolt ⚡: Direct registry access avoids Cow<Type> allocations.
+            match &self.types[ty.index()].kind {
+                TypeKind::Alias(inner) => ty = *inner,
+                TypeKind::Complex { base_type } => return Some(*base_type),
                 _ => return None,
             }
         }


### PR DESCRIPTION
💡 What: This PR optimizes hot paths in the semantic analyzer and type registry. It introduces specialized helper methods to extract type properties directly from `TypeRef` or registry indices, bypassing the expensive `registry.get()` method which frequently triggers `Cow::Owned(Type)` heap allocations for inline types (pointers and arrays).

🎯 Why: Semantic analysis is a significant portion of total compilation time. Profiling identified `TypeRegistry::get()` and matching on the large `TypeKind` enum as major contributors to heap pressure and branching overhead in recursive property checks like `is_noreturn` or `_Generic` selection.

📊 Impact: Reduces heap allocations in hot semantic paths. Initial benchmarks on SQLite show stable performance with reduced micro-overhead in expression resolution.

🔬 Measurement: Verified with `cargo bench --bench compiler_benches` and the full `cargo test` suite. All 1400+ unit tests pass. Confirmed that real-world SQLite compilation failures are pre-existing and unrelated to these changes.

---
*PR created automatically by Jules for task [3446499862898662528](https://jules.google.com/task/3446499862898662528) started by @bungcip*