### PR TITLE
🛡️ Guardian: [logical NOT scalar constraint enforced]

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -214,3 +214,8 @@ Action: Implement recursive property checks for 'has_flexible_array_member' in t
 
 Learning: C11 6.5.1.1p2 mandates that the controlling expression of a `_Generic` selection shall be compatible with at most one generic association. Picking only the first match is insufficient as it silently accepts ambiguous code. Furthermore, associations like `int(*)[10]` and `int(*)[20]` are NOT compatible with each other, but both can be compatible with a controlling expression of type `int(*)[]` (pointer to incomplete array).
 Action: Ensure that `_Generic` selection continues checking all associations even after a match is found, to detect and report ambiguity errors when multiple associations are compatible with the controlling expression.
+
+2026-04-15 - [Logical NOT Scalar Constraint and Decay]
+
+Learning: C11 6.5.3.3p1 requires the operand of the unary ! operator to have a scalar type. While aggregates like structures and unions must be rejected, arrays and functions are permitted because they undergo implicit decay to pointers (which are scalar) in this context. Enforcing the scalar constraint before decay leads to false negatives for valid C code.
+Action: Always ensure that implicit conversions (like lvalue conversion and decay) are applied before enforcing type category constraints (like scalar or arithmetic) on operator operands, unless the operator specifically suppresses them (like sizeof or &).

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -1108,8 +1108,13 @@ impl<'a> SemanticAnalyzer<'a> {
             }
             UnaryOp::LogicNot => {
                 self.apply_lvalue_conversion(expr);
-                // Logical NOT always returns int type (C11 6.5.3.3)
-                Some(QualType::unqualified(self.registry.type_int))
+                let decayed_qt = self.decay(expr, operand_qt);
+                if self.require_scalar(node, decayed_qt) {
+                    // Logical NOT always returns int type (C11 6.5.3.3)
+                    Some(QualType::unqualified(self.registry.type_int))
+                } else {
+                    None
+                }
             }
             UnaryOp::BitNot => {
                 self.apply_lvalue_conversion(expr);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -88,6 +88,7 @@ pub mod guardian_fam_union_constraints;
 pub mod guardian_generic;
 pub mod guardian_generic_multiple_matches;
 pub mod guardian_index_completeness;
+pub mod guardian_logic_not_constraints;
 pub mod guardian_noreturn_switch;
 pub mod guardian_npc_propagation;
 pub mod guardian_offsetof;

--- a/src/tests/guardian_logic_not_constraints.rs
+++ b/src/tests/guardian_logic_not_constraints.rs
@@ -1,0 +1,59 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+
+#[test]
+fn test_logic_not_on_struct_prohibited() {
+    // C11 6.5.3.3p1: The operand of the unary ! operator shall have scalar type.
+    run_fail_with_message(
+        r#"
+        struct S { int x; };
+        int main() {
+            struct S s = {0};
+            return !s;
+        }
+        "#,
+        "expected scalar type",
+    );
+}
+
+#[test]
+fn test_logic_not_on_union_prohibited() {
+    run_fail_with_message(
+        r#"
+        union U { int x; };
+        int main() {
+            union U u = {0};
+            return !u;
+        }
+        "#,
+        "expected scalar type",
+    );
+}
+
+#[test]
+fn test_logic_not_on_array_allowed() {
+    // Array decays to pointer, which is scalar.
+    run_pass(
+        r#"
+        int main() {
+            int a[10];
+            return !a;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}
+
+#[test]
+fn test_logic_not_on_function_allowed() {
+    // Function decays to pointer, which is scalar.
+    run_pass(
+        r#"
+        void f() {}
+        int main() {
+            return !f;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
Enforce C11 scalar type constraint for logical NOT operator and add comprehensive regression tests.

---
*PR created automatically by Jules for task [12839994736063871585](https://jules.google.com/task/12839994736063871585) started by @bungcip*