### PR TITLE
Implement Digraph Support

### DIFF
--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -384,6 +384,34 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    if self.peek_char() == Some(b'%') {
+                        let saved_pos = self.position;
+                        let saved_at_start = self.at_start_of_line;
+                        self.next_char(); // consume second '%'
+                        if self.peek_char() == Some(b':') {
+                            self.next_char(); // consume second ':'
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            self.position = saved_pos;
+                            self.at_start_of_line = saved_at_start;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -411,6 +439,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -470,7 +502,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests/pp_lexical.rs
+++ b/src/tests/pp_lexical.rs
@@ -518,3 +518,44 @@ fn test_invalid_ucn() {
     let (_, diags) = setup_preprocessor_test_with_diagnostics(src, None).unwrap();
     assert!(!diags.is_empty(), "Expected diagnostics for invalid UCN");
 }
+
+#[test]
+fn test_digraphs() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+
+    // Verify token lengths
+    let mut lexer = create_test_pp_lexer(source);
+    let t1 = lexer.next_token().unwrap(); // <:
+    assert_eq!(t1.length, 2);
+    let t2 = lexer.next_token().unwrap(); // :>
+    assert_eq!(t2.length, 2);
+    let t3 = lexer.next_token().unwrap(); // <%
+    assert_eq!(t3.length, 2);
+    let t4 = lexer.next_token().unwrap(); // %>
+    assert_eq!(t4.length, 2);
+    let t5 = lexer.next_token().unwrap(); // %:
+    assert_eq!(t5.length, 2);
+    let t6 = lexer.next_token().unwrap(); // %:%:
+    assert_eq!(t6.length, 4);
+}
+
+#[test]
+fn test_digraph_hash_starts_pp_line() {
+    let source = "%:define X 1";
+    let mut lexer = create_test_pp_lexer(source);
+    let token = lexer.next_token().unwrap();
+    assert_eq!(token.kind, PPTokenKind::Hash);
+    assert_eq!(token.length, 2);
+    assert!(token.flags.contains(PPTokenFlags::STARTS_PP_LINE));
+}


### PR DESCRIPTION
Implemented all C11/C23 digraphs in the preprocessor lexer. They are correctly tokenized into their standard punctuator equivalents with accurate source lengths. Special preprocessor behavior for `%:` (directive initiation) and `%:%:` (token pasting) is also correctly handled. Verified with new unit tests and by running the full test suite.

---
*PR created automatically by Jules for task [12430250955364721135](https://jules.google.com/task/12430250955364721135) started by @bungcip*