### PR TITLE
🛡️ Guardian: [correct function return type compatibility]

### DIFF
--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -279,7 +279,7 @@ impl<'a> MirGen<'a> {
                 }
 
                 if let Some((return_type, parameters, is_variadic)) = fn_data {
-                    let return_mir_type = self.lower_type(return_type);
+                    let return_mir_type = self.lower_type(return_type.ty());
                     let param_mir_types = parameters.into_iter().map(|p| self.lower_qual_type(p)).collect();
 
                     self.define_or_declare_function(
@@ -1139,7 +1139,7 @@ impl<'a> MirGen<'a> {
             Builtin(BuiltinType),
             Pointer(QualType),
             Array(TypeRef, ArraySizeType),
-            Function(TypeRef, Vec<FunctionParameter>, bool),
+            Function(QualType, Vec<FunctionParameter>, bool),
             Complex(TypeRef),
             Default,
         }
@@ -1368,11 +1368,11 @@ impl<'a> MirGen<'a> {
 
     fn lower_function_type(
         &mut self,
-        return_type: TypeRef,
+        return_type: QualType,
         parameters: &[FunctionParameter],
         is_variadic: bool,
     ) -> MirType {
-        let return_type = self.lower_type(return_type);
+        let return_type = self.lower_type(return_type.ty());
         let mut params = Vec::new();
         for p in parameters {
             let param_ty_id = self.lower_qual_type(p.param_type);

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -45,7 +45,7 @@ enum TypeAnalysisTask {
     Record(Arc<[StructMember]>, bool),
     Array(TypeRef, ArraySizeType),
     Function {
-        return_type: TypeRef,
+        return_type: QualType,
         parameters: Arc<[FunctionParameter]>,
         is_variadic: bool,
     },
@@ -340,7 +340,7 @@ impl<'a> SemanticAnalyzer<'a> {
         enum Task {
             Array(TypeRef, Option<NodeRef>),
             Pointer(QualType),
-            Function(TypeRef, Arc<[FunctionParameter]>),
+            Function(QualType, Arc<[FunctionParameter]>),
             Complex(TypeRef),
             Typeof(NodeRef, bool), // bool is true for unqual
             Alias(TypeRef),
@@ -383,7 +383,7 @@ impl<'a> SemanticAnalyzer<'a> {
                 self.visit_type_exprs(pointee);
             }
             Task::Function(return_type, parameters) => {
-                self.visit_type_exprs(QualType::unqualified(return_type));
+                self.visit_type_exprs(return_type);
                 for param in parameters.iter() {
                     self.visit_type_exprs(param.param_type);
                 }
@@ -2196,7 +2196,7 @@ impl<'a> SemanticAnalyzer<'a> {
                         }
                     }
                 }
-                Some(QualType::unqualified(return_type))
+                Some(return_type)
             }
             _ => {
                 // This is not a function or function pointer, report an error.
@@ -2403,8 +2403,8 @@ impl<'a> SemanticAnalyzer<'a> {
 
                 if let Some(return_type) = return_type_to_check {
                     // Bolt ⚡: Extension: allow incomplete enums in declarations (per GCC/Clang).
-                    if !self.registry.is_complete(return_type)
-                        && return_type != self.registry.type_void
+                    if !self.registry.is_complete(return_type.ty())
+                        && return_type.ty() != self.registry.type_void
                         && !return_type.is_enum()
                     {
                         self.report_error(node, SemanticError::IncompleteReturnType);
@@ -2427,10 +2427,10 @@ impl<'a> SemanticAnalyzer<'a> {
         let ret_type = if let TypeAnalysisTask::Function { return_type, .. } = self.get_analysis_task(func_ty) {
             return_type
         } else {
-            self.registry.type_error
+            QualType::unqualified(self.registry.type_error)
         };
 
-        if !self.registry.is_complete(ret_type) && ret_type != self.registry.type_void {
+        if !self.registry.is_complete(ret_type.ty()) && ret_type.ty() != self.registry.type_void {
             self.report_error(node, SemanticError::IncompleteReturnType);
         }
 
@@ -2446,7 +2446,7 @@ impl<'a> SemanticAnalyzer<'a> {
 
         let prev_ctx = self.current_function.take();
         self.current_function = Some(FunctionCtx {
-            ret_type: QualType::unqualified(ret_type),
+            ret_type,
             name: symbol.name,
             is_noreturn,
         });

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -950,27 +950,14 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
 
     fn check_function_redeclaration(
         &mut self,
-        name: NameId,
-        new_ty: QualType,
-        span: SourceSpan,
-        first_def: SourceSpan,
-        existing_ty: QualType,
+        _name: NameId,
+        _new_ty: QualType,
+        _span: SourceSpan,
+        _first_def: SourceSpan,
+        _existing_ty: QualType,
     ) {
-        // Check for _Noreturn mismatch
-        let get_noreturn = |qt: QualType, registry: &TypeRegistry| {
-            if let TypeKind::Function { is_noreturn, .. } = &registry.get(qt.ty()).kind {
-                *is_noreturn
-            } else {
-                false
-            }
-        };
-
-        let existing_is_noreturn = get_noreturn(existing_ty, self.registry);
-        let new_is_noreturn = get_noreturn(new_ty, self.registry);
-
-        if existing_is_noreturn != new_is_noreturn {
-            self.report_error(span, SemanticError::ConflictingTypes { name, first_def });
-        }
+        // GCC and Clang allow _Noreturn to be present on only some declarations of a function.
+        // We allow this and merge the property in composite_type.
     }
 
     fn visit_function_definition(&mut self, func_def: &ParsedFunctionDef, node: NodeRef, span: SourceSpan) {
@@ -2336,7 +2323,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
     }
 
     fn handle_builtin_implicit_decl(&mut self, name: NameId, span: SourceSpan) -> Option<SymbolRef> {
-        let (params, ret_ty) = if name == self.keywords.builtin_nanf || name == self.keywords.builtin_nan {
+        let (params, ret_qt) = if name == self.keywords.builtin_nanf || name == self.keywords.builtin_nan {
             let char_const = QualType::new(self.registry.type_char, TypeQualifiers::CONST);
             let char_ptr = QualType::unqualified(self.registry.pointer_to(char_const));
             let params = vec![FunctionParameter {
@@ -2345,9 +2332,9 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                 storage: None,
             }];
             let ret = if name == self.keywords.builtin_nanf {
-                self.registry.type_float
+                QualType::unqualified(self.registry.type_float)
             } else {
-                self.registry.type_double
+                QualType::unqualified(self.registry.type_double)
             };
             (params, ret)
         } else if name == self.keywords.builtin_inff
@@ -2356,16 +2343,16 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             || name == self.keywords.builtin_huge_valf
         {
             let ret = if name == self.keywords.builtin_inff || name == self.keywords.builtin_huge_valf {
-                self.registry.type_float
+                QualType::unqualified(self.registry.type_float)
             } else {
-                self.registry.type_double
+                QualType::unqualified(self.registry.type_double)
             };
             (vec![], ret)
         } else {
             return None;
         };
 
-        let func_ty = self.registry.function_type(ret_ty, params, false, false);
+        let func_ty = self.registry.function_type(ret_qt, params, false, false);
 
         // Save current scope and switch to global for implicit decl
         let old_scope = self.symbol_table.current_scope();
@@ -2485,7 +2472,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                     func_ty = self.registry.get_pointee(func_ty)?.ty();
                 }
                 if let TypeKind::Function { return_type, .. } = &self.registry.get(func_ty).kind {
-                    Some(QualType::unqualified(*return_type))
+                    Some(*return_type)
                 } else {
                     None
                 }
@@ -2876,7 +2863,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                 let is_noreturn = spec_info.map(|s| s.is_noreturn).unwrap_or(false);
                 let function_type =
                     self.registry
-                        .function_type(current_type.ty(), processed_params, flags.is_variadic, is_noreturn);
+                        .function_type(current_type, processed_params, flags.is_variadic, is_noreturn);
                 self.apply_declarator(QualType::unqualified(function_type), *inner, span, spec_info, ctx)
             }
             ParsedDeclarator::BitField { inner, .. } => {

--- a/src/semantic/type_registry.rs
+++ b/src/semantic/type_registry.rs
@@ -649,7 +649,7 @@ impl TypeRegistry {
 
     pub(crate) fn function_type(
         &mut self,
-        return_type: TypeRef,
+        return_type: QualType,
         params: Vec<FunctionParameter>,
         is_variadic: bool,
         is_noreturn: bool,
@@ -1573,7 +1573,7 @@ impl TypeRegistry {
                 if var_a != var_b {
                     return false;
                 }
-                if !self.is_compatible(QualType::unqualified(*ret_a), QualType::unqualified(*ret_b)) {
+                if !self.is_compatible(*ret_a, *ret_b) {
                     return false;
                 }
                 if params_a.len() != params_b.len() {
@@ -1701,7 +1701,7 @@ impl TypeRegistry {
                 drop(type_a);
                 drop(type_b);
 
-                let composite_ret = self.composite_type(QualType::unqualified(ret_a), QualType::unqualified(ret_b))?;
+                let composite_ret = self.composite_type(ret_a, ret_b)?;
                 if params_a.len() != params_b.len() {
                     return None;
                 }
@@ -1719,7 +1719,7 @@ impl TypeRegistry {
                         storage: p_b.storage.or(p_a.storage),
                     });
                 }
-                let res_ty = self.function_type(composite_ret.ty(), composite_params, var_a, noreturn_a || noreturn_b);
+                let res_ty = self.function_type(composite_ret, composite_params, var_a, noreturn_a || noreturn_b);
                 Some(QualType::new(res_ty, a.qualifiers()))
             }
             _ => {
@@ -1836,7 +1836,7 @@ impl TypeRegistry {
                     parameters,
                     ..
                 } => {
-                    if self.is_variably_modified(*return_type) {
+                if self.is_variably_modified(return_type.ty()) {
                         return true;
                     }
                     return parameters.iter().any(|p| self.is_variably_modified(p.param_type.ty()));
@@ -1908,7 +1908,7 @@ impl TypeRegistry {
                 is_variadic,
                 ..
             } => {
-                let ret_str = self.display_type(*return_type);
+                let ret_str = self.display_qual_type(*return_type);
                 let params_str = parameters
                     .iter()
                     .map(|p| self.display_qual_type(p.param_type))
@@ -1946,7 +1946,7 @@ enum LayoutTask {
 /// Most C functions have <= 8 parameters, allowing the key to remain on the stack.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct FnSigKey {
-    return_type: TypeRef,
+    return_type: QualType,
     params: SmallVec<[QualType; 8]>,
     is_variadic: bool,
     is_noreturn: bool,

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -841,7 +841,7 @@ pub enum TypeKind {
         size: ArraySizeType,
     },
     Function {
-        return_type: TypeRef,
+        return_type: QualType,
         parameters: Arc<[FunctionParameter]>,
         is_variadic: bool,
         is_noreturn: bool,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -85,6 +85,7 @@ pub mod guardian_cast_constraints;
 pub mod guardian_compound_literal_constraints;
 pub mod guardian_const_eval_builtins;
 pub mod guardian_fam_union_constraints;
+pub mod guardian_function_type_compatibility;
 pub mod guardian_generic;
 pub mod guardian_generic_multiple_matches;
 pub mod guardian_index_completeness;

--- a/src/tests/guardian_function_type_compatibility.rs
+++ b/src/tests/guardian_function_type_compatibility.rs
@@ -1,0 +1,81 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_pass, run_fail_with_message};
+
+#[test]
+fn test_generic_distinguishes_qualified_return_types() {
+    // C11 6.7.6.3p15: "...and the return type is a compatible type."
+    // 6.7.3p10: "...both shall have the identically qualified version of a compatible type."
+    // Thus, int(*)(void) and const int(*)(void) are NOT compatible because their
+    // return types (int and const int) are not identically qualified.
+
+    run_pass(
+        r#"
+        int f(void);
+        const int g(void);
+        int main() {
+            // This should match both associations correctly if they are distinct (incompatible).
+            _Static_assert(_Generic(&f, int(*)(void): 1, const int(*)(void): 0) == 1, "Match f");
+            _Static_assert(_Generic(&g, int(*)(void): 0, const int(*)(void): 1) == 1, "Match g");
+            return 0;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}
+
+#[test]
+fn test_rejects_assignment_of_incompatible_return_qualifiers() {
+    run_fail_with_message(
+        r#"
+        int f(void);
+        int main() {
+            const int (*p)(void) = &f;
+            return 0;
+        }
+        "#,
+        "type mismatch: expected const int()*, found int()*",
+    );
+}
+
+#[test]
+fn test_rejects_compatible_typedef_redefinition_with_different_return_qualifiers() {
+    run_fail_with_message(
+        r#"
+        typedef int F(void);
+        typedef const int F(void);
+        "#,
+        "redefinition of 'F' with a different type",
+    );
+}
+
+#[test]
+fn test_preserves_noreturn_in_composite_type() {
+    // GCC and Clang allow _Noreturn to be added in redeclarations.
+    // The resulting composite type should be _Noreturn.
+    run_pass(
+        r#"
+        _Noreturn void f(void);
+        void f(void);
+        void g(void) {
+            f();
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}
+
+#[test]
+fn test_generic_distinguishes_atomic_return_types() {
+    run_pass(
+        r#"
+        int f(void);
+        _Atomic int h(void);
+        int main() {
+            _Static_assert(_Generic(&f, int(*)(void): 1, _Atomic int(*)(void): 0) == 1, "Match f");
+            _Static_assert(_Generic(&h, int(*)(void): 0, _Atomic int(*)(void): 1) == 1, "Match h");
+            return 0;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}

--- a/src/tests/semantic_functions.rs
+++ b/src/tests/semantic_functions.rs
@@ -264,9 +264,11 @@ fn test_noreturn_declaration_mismatch() {
     let code = r#"
     _Noreturn void foo();
     void foo() {
+        while(1);
     }
     "#;
-    run_fail_with_message(code, "conflicting types for 'foo'");
+    // GCC and Clang allow this mismatch.
+    run_pass(code, CompilePhase::Mir);
 }
 
 #[test]


### PR DESCRIPTION
🧪 **What**: This PR refactors the internal representation of function types to use `QualType` for return types. It updates `TypeRegistry::is_compatible` and `composite_type` to respect return type qualifiers. It also relaxes redeclaration rules for `_Noreturn` to align with GCC/Clang.

🎯 **Why**: C11 requires that function types are compatible only if their return types are compatible. Previously, Cendol ignored return type qualifiers during this check, leading to incorrect `_Generic` selection and silent acceptance of incompatible function pointer assignments.

🛠️ **Phase**: Semantic Analysis / Type System

🔬 **Verify**: Run `cargo test guardian_function_type_compatibility`.

---
*PR created automatically by Jules for task [2246426263614681975](https://jules.google.com/task/2246426263614681975) started by @bungcip*