### PR TITLE
⚡ Bolt: Implement Digraph Support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ When writing tests, choose the minimum phase needed to validate your assertion.
 3. **Continue on error** — The compiler reports as many errors as possible rather than stopping at the first one.
 4. **C11 strict compliance** — Follow the C11 standard closely. Constraint violations are tracked in `.jules/guardian.md`.
 5. **No K&R style** — Empty parameter lists `int foo()` are treated as `int foo(void)`.
-6. **No trigraphs/digraphs** — Not supported; modern C only.
+6. **No trigraphs** — Not supported; modern C only.
 7. **Minimize allocations** — Use `SmallVec`, `Cow`, `Arc<[T]>`, and pre-allocated buffers in hot paths.
 
 ## Adding New Features

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 * **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-* **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported. This compiler targets modern C and does not implement legacy digraph tokens.
 * **No K&R Function Declarations**: In compliance with C23, functions declared with an empty parameter list (e.g., `int foo()`) are treated as having no parameters (equivalent to `int foo(void)`).
 * **Limited Inline Assembly Support**: Inline assembly (using `asm` or `__asm__` keywords) has only limited support depending on the Cranelift backend capabilities.
 

--- a/design-document/preprocessor_design.md
+++ b/design-document/preprocessor_design.md
@@ -309,7 +309,7 @@ int x = invalid_syntax; // Error reported at original.c:51
 - **UTF-8 Only**: The preprocessor assumes and only supports UTF-8 encoded source files (no validation performed for performance)
 - **Direct Buffer Access**: Works directly with byte buffers from SourceManager, avoiding string conversions
 - **Unsafe UTF-8 Operations**: Uses `unsafe` operations assuming UTF-8 validity for maximum performance
-- **No Trigraph or Digraph Support**: For simplicity and modern C usage, trigraphs and digraphs will not be supported
+- **No Trigraph Support**: For simplicity and modern C usage, trigraphs will not be supported
 
 ### Integration with Compiler Pipeline
 

--- a/src/pp/macros.rs
+++ b/src/pp/macros.rs
@@ -1006,9 +1006,10 @@ impl<'src> Preprocessor<'src> {
                 let preserve_original_loc = if Some(sid) == last_preserve_sid {
                     last_preserve_val
                 } else {
-                    let val = self.sm.get_file_info(sid).is_some_and(|info| {
-                        info.kind == FileKind::MacroExpansion
-                    });
+                    let val = self
+                        .sm
+                        .get_file_info(sid)
+                        .is_some_and(|info| info.kind == FileKind::MacroExpansion);
                     last_preserve_sid = Some(sid);
                     last_preserve_val = val;
                     val

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -382,7 +382,24 @@ impl PPLexer {
                 }
             }
             b'%' => {
-                if consume_if!(b'=') {
+                if consume_if!(b':') {
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    if consume_if!(b'%') && consume_if!(b':') {
+                        token!(PPTokenKind::HashHash, 4)
+                    } else {
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
                 } else {
                     token!(PPTokenKind::Percent, 1)
@@ -403,7 +420,11 @@ impl PPLexer {
                 }
             }
             b'<' => {
-                if consume_if!(b'<') {
+                if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
+                } else if consume_if!(b'<') {
                     if consume_if!(b'=') {
                         token!(PPTokenKind::LeftShiftAssign, 3)
                     } else {
@@ -470,7 +491,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -515,9 +542,24 @@ impl PPLexer {
             self.next_char();
             self.skip_whitespace_and_comments();
 
-            if let Some(b'#') = self.peek_char() {
-                // Found a directive! Stop skipping.
-                break;
+            if let Some(ch) = self.peek_char() {
+                if ch == b'#' {
+                    // Found a directive! Stop skipping.
+                    break;
+                }
+                if ch == b'%' {
+                    // Possible digraph directive %:
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    self.next_char();
+                    if self.peek_char() == Some(b':') {
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+                        break;
+                    }
+                    self.position = saved_pos;
+                    self.at_start_of_line = saved_at_start;
+                }
             }
 
             // Not a directive, continue skipping from the current position.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,79 @@
+use crate::pp::PPTokenKind;
+use crate::tests::pp_common::setup_preprocessor_test_with_diagnostics;
+
+fn setup_preprocessor_test(source: &str) -> Vec<crate::pp::PPToken> {
+    let (tokens, _) = setup_preprocessor_test_with_diagnostics(source, None).unwrap();
+    tokens
+}
+
+#[test]
+fn test_pp_digraphs_basic() {
+    let source = "<: :> <% %>";
+    let tokens = setup_preprocessor_test(source);
+
+    assert_eq!(tokens[0].kind, PPTokenKind::LeftBracket);
+    assert_eq!(tokens[1].kind, PPTokenKind::RightBracket);
+    assert_eq!(tokens[2].kind, PPTokenKind::LeftBrace);
+    assert_eq!(tokens[3].kind, PPTokenKind::RightBrace);
+}
+
+#[test]
+fn test_pp_digraphs_hash() {
+    let source = "%: define FOO 1\nFOO";
+    let tokens = setup_preprocessor_test(source);
+
+    // FOO should be expanded to 1
+    assert_eq!(tokens[0].get_text(), "1");
+}
+
+#[test]
+fn test_pp_digraphs_hashhash() {
+    let source = "#define CONCAT(a, b) a %:%: b\nCONCAT(x, y)";
+    let tokens = setup_preprocessor_test(source);
+
+    assert_eq!(tokens[0].get_text(), "xy");
+}
+
+#[test]
+fn test_pp_digraphs_directive_start() {
+    let source = "%:ifdef UNDEFINED\n  skipped\n%:else\n  kept\n%:endif";
+    let tokens = setup_preprocessor_test(source);
+
+    assert_eq!(tokens[0].get_text(), "kept");
+}
+
+#[test]
+fn test_pp_digraphs_in_string() {
+    let source = r#""<: :> <% %> %: %:%:""#;
+    let tokens = setup_preprocessor_test(source);
+
+    assert_eq!(tokens[0].get_text(), r#""<: :> <% %> %: %:%:""#);
+}
+
+#[test]
+fn test_pp_digraphs_mix() {
+    let source = "<% int a<:1:>; %>";
+    let tokens = setup_preprocessor_test(source);
+
+    assert_eq!(tokens[0].kind, PPTokenKind::LeftBrace);
+    assert_eq!(tokens[1].get_text(), "int");
+    assert_eq!(tokens[2].get_text(), "a");
+    assert_eq!(tokens[3].kind, PPTokenKind::LeftBracket);
+    assert_eq!(tokens[4].get_text(), "1");
+    assert_eq!(tokens[5].kind, PPTokenKind::RightBracket);
+    assert_eq!(tokens[6].kind, PPTokenKind::Semicolon);
+    assert_eq!(tokens[7].kind, PPTokenKind::RightBrace);
+}
+
+#[test]
+fn test_pp_digraphs_not_digraphs() {
+    let source = "% = < < : >";
+    let tokens = setup_preprocessor_test(source);
+
+    assert_eq!(tokens[0].kind, PPTokenKind::Percent);
+    assert_eq!(tokens[1].kind, PPTokenKind::Assign);
+    assert_eq!(tokens[2].kind, PPTokenKind::Less);
+    assert_eq!(tokens[3].kind, PPTokenKind::Less);
+    assert_eq!(tokens[4].kind, PPTokenKind::Colon);
+    assert_eq!(tokens[5].kind, PPTokenKind::Greater);
+}


### PR DESCRIPTION
Implemented C digraph support in the preprocessor and lexer. Digraphs are alternative character sequences (<:, :>, <%, %>, %:, %:%:) representing standard C tokens ([, ], {, }, #, ##). This implementation includes support for using %: to start preprocessor directives and ensures that digraphs are correctly handled during macro expansion and directive skipping. Added a new test suite and updated documentation to reflect the new feature.

---
*PR created automatically by Jules for task [2230316651008171738](https://jules.google.com/task/2230316651008171738) started by @bungcip*