### PR TITLE
🩺 Tuti: Add coverage for ParsedDeclarator::BitField in get_declarator_name

### DIFF
--- a/src/tests/parser_declarator_coverage.rs
+++ b/src/tests/parser_declarator_coverage.rs
@@ -214,3 +214,16 @@ fn test_pointer_qualifiers_coverage() {
           kind: pointer to pointer
     ");
 }
+
+#[test]
+fn test_get_declarator_name_bitfield_param() {
+    let resolved = setup_declaration("int f(int x : 5);");
+    insta::assert_yaml_snapshot!(&resolved, @"
+    Declaration:
+      specifiers:
+        - int
+      init_declarators:
+        - name: f
+          kind: function(bitfield identifier to int) -> int
+    ");
+}


### PR DESCRIPTION
This PR increases code coverage for `get_declarator_name()` by covering the `ParsedDeclarator::BitField` variant. It adds `test_get_declarator_name_bitfield_param` in `src/tests/parser_declarator_coverage.rs` to reach the uncovered lines.

---
*PR created automatically by Jules for task [12152560818008878891](https://jules.google.com/task/12152560818008878891) started by @bungcip*