### PR TITLE
Tuti: add test coverage for digit separators in float and hex parsing

### DIFF
--- a/src/ast/literal_parsing.rs
+++ b/src/ast/literal_parsing.rs
@@ -475,4 +475,16 @@ mod tests {
         // Empty hex escape -> \x
         assert_eq!(unescape(r"\xz"), r"\xz");
     }
+
+    #[test]
+    fn test_hex_float_edge_cases() {
+        // Covers line 123 (digit separator in decimal float)
+        assert_eq!(super::parse_float_literal("1'0.5"), Some((10.5, None)));
+
+        // Covers line 163 (digit separator in hex float mantissa)
+        assert_eq!(super::parse_hex_float_literal("0x1'A.5p2"), Some(105.25));
+
+        // Covers line 196, 197 (digit separator in hex float exponent)
+        assert_eq!(super::parse_hex_float_literal("0x1.0p1'0"), Some(1024.0));
+    }
 }


### PR DESCRIPTION
This commit adds a test to `src/ast/literal_parsing.rs` inside the existing test module to cover missing execution paths related to decimal digit separators in `parse_float_literal` and `parse_hex_float_literal`, improving coverage from 98.81% to 100.0%.

---
*PR created automatically by Jules for task [10995409042486269540](https://jules.google.com/task/10995409042486269540) started by @bungcip*