### PR TITLE
Feature: Add C Digraph Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 * **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-* **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported. This compiler targets modern C and does not implement legacy digraph tokens.
 * **No K&R Function Declarations**: In compliance with C23, functions declared with an empty parameter list (e.g., `int foo()`) are treated as having no parameters (equivalent to `int foo(void)`).
 * **Limited Inline Assembly Support**: Inline assembly (using `asm` or `__asm__` keywords) has only limited support depending on the Cranelift backend capabilities.
 

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,36 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    // Check for %:%:
+                    let mut is_hashhash = false;
+
+                    let saved_position = self.position;
+                    let saved_at_start = self.at_start_of_line;
+
+                    if self.peek_char() == Some(b'%') {
+                        self.next_char();
+                        if self.peek_char() == Some(b':') {
+                            self.next_char();
+                            is_hashhash = true;
+                        }
+                    }
+
+                    if is_hashhash {
+                        token!(PPTokenKind::HashHash, 4)
+                    } else {
+                        self.position = saved_position;
+                        self.at_start_of_line = saved_at_start;
+
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +519,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +582,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -596,6 +636,21 @@ impl PPLexer {
             if let Some(b'#') = self.peek_char() {
                 // Found a directive! Stop skipping.
                 break;
+            }
+
+            if self.peek_char() == Some(b'%') {
+                let saved_position = self.position;
+                let saved_at_start = self.at_start_of_line;
+
+                self.next_char();
+                if self.peek_char() == Some(b':') {
+                    self.position = saved_position;
+                    self.at_start_of_line = saved_at_start;
+                    break;
+                } else {
+                    self.position = saved_position;
+                    self.at_start_of_line = saved_at_start;
+                }
             }
 
             // Not a directive, continue skipping from the current position.
@@ -1189,16 +1244,16 @@ impl PPLexer {
                 // Handle escape sequences, including line splicing
 
                 // Check for UCN first
-                if let Some(p_ch) = self.peek_char() {
-                    if p_ch == b'u' || p_ch == b'U' {
-                        if self.lex_ucn(true).is_some() {
-                            // Valid UCN.
-                            continue;
-                        } else {
-                            // Invalid UCN.
-                            *has_invalid_ucn = true;
-                            continue;
-                        }
+                if let Some(p_ch) = self.peek_char()
+                    && (p_ch == b'u' || p_ch == b'U')
+                {
+                    if self.lex_ucn(true).is_some() {
+                        // Valid UCN.
+                        continue;
+                    } else {
+                        // Invalid UCN.
+                        *has_invalid_ucn = true;
+                        continue;
                     }
                 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,6 +20,7 @@ pub mod pp_conditionals;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;
+pub mod pp_digraphs;
 pub mod pp_internal;
 pub mod pp_lexical;
 pub mod pp_macros;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,90 @@
+use crate::tests::pp_common::setup_pp_snapshot;
+
+#[test]
+fn test_digraph_bracket() {
+    let src = r#"
+<: 1, 2 :>
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_brace() {
+    let src = r#"
+<% 1; 2; %>
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_hash() {
+    let src = r#"
+%:define FOO 1
+FOO
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_hashhash() {
+    let src = r#"
+#define CONCAT(a, b) a %:%: b
+CONCAT(1, 2)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_hashhash_with_digraph_hash() {
+    let src = r#"
+%:define CONCAT(a, b) a %:%: b
+CONCAT(1, 2)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_skipping() {
+    let src = r#"
+%:if 0
+  this is skipped;
+  <: %> %:%:
+%:else
+  this is not skipped
+%:endif
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_mixed() {
+    let src = r#"
+%:define M(a, b) a %:%: b
+int x <: 1 :> = <% M(1, 2) %>;
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_line_splice() {
+    let src = r#"
+%\
+:define FOO 1
+FOO
+
+#define CONCAT(a, b) a %\
+:\
+%\
+: b
+CONCAT(1, 2)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_brace.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_brace.snap
@@ -1,0 +1,16 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: LeftBrace
+  text: "{"
+- kind: Number
+  text: "1"
+- kind: Semicolon
+  text: ;
+- kind: Number
+  text: "2"
+- kind: Semicolon
+  text: ;
+- kind: RightBrace
+  text: "}"

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_bracket.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_bracket.snap
@@ -1,0 +1,14 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: LeftBracket
+  text: "["
+- kind: Number
+  text: "1"
+- kind: Comma
+  text: ","
+- kind: Number
+  text: "2"
+- kind: RightBracket
+  text: "]"

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_hash.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_hash.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Number
+  text: "1"

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_hashhash.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_hashhash.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Number
+  text: "12"

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_hashhash_with_digraph_hash.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_hashhash_with_digraph_hash.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Number
+  text: "12"

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_line_splice.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_line_splice.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Number
+  text: "1"
+- kind: Number
+  text: "12"

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_mixed.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_mixed.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Identifier
+  text: int
+- kind: Identifier
+  text: x
+- kind: LeftBracket
+  text: "["
+- kind: Number
+  text: "1"
+- kind: RightBracket
+  text: "]"
+- kind: Assign
+  text: "="
+- kind: LeftBrace
+  text: "{"
+- kind: Number
+  text: "12"
+- kind: RightBrace
+  text: "}"
+- kind: Semicolon
+  text: ;

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_skipping.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_skipping.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Identifier
+  text: this
+- kind: Identifier
+  text: is
+- kind: Identifier
+  text: not
+- kind: Identifier
+  text: skipped


### PR DESCRIPTION
Implement C digraph support (`<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`).

---
*PR created automatically by Jules for task [7409045033620950831](https://jules.google.com/task/7409045033620950831) started by @bungcip*