### PR TITLE
🛡️ Guardian: Implement support for C digraphs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ When writing tests, choose the minimum phase needed to validate your assertion.
 3. **Continue on error** — The compiler reports as many errors as possible rather than stopping at the first one.
 4. **C11 strict compliance** — Follow the C11 standard closely. Constraint violations are tracked in `.jules/guardian.md`.
 5. **No K&R style** — Empty parameter lists `int foo()` are treated as `int foo(void)`.
-6. **No trigraphs/digraphs** — Not supported; modern C only.
+6. **No trigraphs** — Not supported; modern C only.
 7. **Minimize allocations** — Use `SmallVec`, `Cow`, `Arc<[T]>`, and pre-allocated buffers in hot paths.
 
 ## Adding New Features

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 * **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-* **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported. This compiler targets modern C and does not implement legacy digraph tokens.
 * **No K&R Function Declarations**: In compliance with C23, functions declared with an empty parameter list (e.g., `int foo()`) are treated as having no parameters (equivalent to `int foo(void)`).
 * **Limited Inline Assembly Support**: Inline assembly (using `asm` or `__asm__` keywords) has only limited support depending on the Cranelift backend capabilities.
 

--- a/design-document/preprocessor_design.md
+++ b/design-document/preprocessor_design.md
@@ -309,7 +309,7 @@ int x = invalid_syntax; // Error reported at original.c:51
 - **UTF-8 Only**: The preprocessor assumes and only supports UTF-8 encoded source files (no validation performed for performance)
 - **Direct Buffer Access**: Works directly with byte buffers from SourceManager, avoiding string conversions
 - **Unsafe UTF-8 Operations**: Uses `unsafe` operations assuming UTF-8 validity for maximum performance
-- **No Trigraph or Digraph Support**: For simplicity and modern C usage, trigraphs and digraphs will not be supported
+- **No Trigraph Support**: For simplicity and modern C usage, trigraphs will not be supported
 
 ### Integration with Compiler Pipeline
 

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,32 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let pos_after_hash = self.position;
+                    let at_start_after_hash = self.at_start_of_line;
+                    if consume_if!(b'%') {
+                        if consume_if!(b':') {
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            self.position = pos_after_hash;
+                            self.at_start_of_line = at_start_after_hash;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +515,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +578,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -593,9 +629,20 @@ impl PPLexer {
             self.next_char();
             self.skip_whitespace_and_comments();
 
-            if let Some(b'#') = self.peek_char() {
-                // Found a directive! Stop skipping.
-                break;
+            if let Some(ch) = self.peek_char() {
+                if ch == b'#' {
+                    break;
+                }
+                if ch == b'%' {
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    self.next_char();
+                    if self.peek_char() == Some(b':') {
+                        break;
+                    }
+                    self.position = saved_pos;
+                    self.at_start_of_line = saved_at_start;
+                }
             }
 
             // Not a directive, continue skipping from the current position.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,117 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_digraph_tokenization() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    // Note: PPTokenKind::get_fixed_text() returns the standard punctuation character(s)
+    // for these tokens, even if they were lexed as digraphs.
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive_initiation() {
+    let source = "%:define FOO 1\nFOO";
+    let tokens = setup_pp_snapshot(source);
+
+    // Should expand FOO to 1
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Number
+      text: \"1\"
+    ");
+}
+
+#[test]
+fn test_digraph_stringification() {
+    let source = r#"
+%:define STR(x) %:x
+STR(hello)
+"#;
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: StringLiteral
+      text: \"\\\"hello\\\"\"
+    ");
+}
+
+#[test]
+fn test_digraph_concatenation() {
+    let source = r#"
+%:define CONCAT(a, b) a %:%: b
+CONCAT(foo, bar)
+"#;
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: foobar
+    ");
+}
+
+#[test]
+fn test_digraph_in_disabled_block() {
+    let source = r#"
+#if 0
+  %:define SHOULD_BE_SKIPPED 1
+#endif
+SHOULD_BE_SKIPPED
+"#;
+    let tokens = setup_pp_snapshot(source);
+    // SHOULD_BE_SKIPPED should NOT be expanded
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: SHOULD_BE_SKIPPED
+    ");
+}
+
+#[test]
+fn test_digraph_mixed_with_standard() {
+    let source = "<% int a<:1:>; %>";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("{", PPTokenKind::LeftBrace),
+        ("int", PPTokenKind::Identifier(_)),
+        ("a", PPTokenKind::Identifier(_)),
+        ("[", PPTokenKind::LeftBracket),
+        ("1", PPTokenKind::Number),
+        ("]", PPTokenKind::RightBracket),
+        (";", PPTokenKind::Semicolon),
+        ("}", PPTokenKind::RightBrace),
+    );
+}
+
+#[test]
+fn test_digraph_percent_colon_at_start_of_line() {
+    let source = "  %: define BAR 2\nBAR";
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Number
+      text: \"2\"
+    ");
+}
+
+#[test]
+fn test_digraph_hash_hash_complex() {
+    // Test %:%: as ## in various positions
+    let source = r#"
+%:define GLUE(a, b) a%:%:b
+GLUE(1, 2)
+"#;
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Number
+      text: \"12\"
+    ");
+}


### PR DESCRIPTION
This PR implements full support for C digraphs (`<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) in the Cendol compiler, as per the C11 and C23 standards.

Key changes:
- `PPLexer` now tokenizes digraph sequences into their corresponding standard punctuation tokens.
- `%:` is correctly recognized as `#` for initiating preprocessor directives, including at the start of a line and within `fast_skip_to_directive` for disabled conditional blocks.
- `%:%:` is correctly tokenized as `HashHash` for token concatenation.
- Comprehensive unit tests added in `src/tests/pp_digraphs.rs`.
- Updated project documentation to remove "no digraph support" limitations.

All tests passed (1482 tests).

---
*PR created automatically by Jules for task [13763294660609057570](https://jules.google.com/task/13763294660609057570) started by @bungcip*