### PR TITLE
🛡️ Guardian: Implement C digraph support and address clippy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 * **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-* **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported. This compiler targets modern C and does not implement legacy digraph tokens.
 * **No K&R Function Declarations**: In compliance with C23, functions declared with an empty parameter list (e.g., `int foo()`) are treated as having no parameters (equivalent to `int foo(void)`).
 * **Limited Inline Assembly Support**: Inline assembly (using `asm` or `__asm__` keywords) has only limited support depending on the Cranelift backend capabilities.
 

--- a/src/ast/literal.rs
+++ b/src/ast/literal.rs
@@ -48,7 +48,7 @@ pub enum IntSuffix {
     LL = 2,
     U = 3,
     UL = 4,
-    ULL = 5,
+    Ull = 5,
 }
 
 impl IntSuffix {
@@ -58,7 +58,7 @@ impl IntSuffix {
             2 => Self::LL,
             3 => Self::U,
             4 => Self::UL,
-            5 => Self::ULL,
+            5 => Self::Ull,
             _ => Self::None,
         }
     }
@@ -104,7 +104,7 @@ impl IntSuffix {
                     SmallVec::from_slice(&[registry.type_long_long, registry.type_long_long_unsigned])
                 }
             }
-            IntSuffix::ULL => SmallVec::from_slice(&[registry.type_long_long_unsigned]),
+            IntSuffix::Ull => SmallVec::from_slice(&[registry.type_long_long_unsigned]),
         }
     }
 }
@@ -271,7 +271,7 @@ impl LitRef {
     }
 
     pub fn from_int(value: i64, suffix: IntSuffix, radix: u8) -> Self {
-        if value >= INT_MIN_SMALL && value <= INT_MAX_SMALL {
+        if (INT_MIN_SMALL..=INT_MAX_SMALL).contains(&value) {
             let payload = ((value as u64) & INT_VALUE_MASK)
                 | ((suffix as u64) << INT_SUFFIX_SHIFT)
                 | (((radix as u64) & INT_RADIX_MASK) << INT_RADIX_SHIFT);

--- a/src/ast/literal_parsing.rs
+++ b/src/ast/literal_parsing.rs
@@ -4,8 +4,8 @@ use std::iter::Peekable;
 use std::str::Chars;
 
 const INTEGER_SUFFIXES: &[(&str, IntSuffix)] = &[
-    ("ull", IntSuffix::ULL),
-    ("llu", IntSuffix::ULL),
+    ("ull", IntSuffix::Ull),
+    ("llu", IntSuffix::Ull),
     ("ul", IntSuffix::UL),
     ("lu", IntSuffix::UL),
     ("ll", IntSuffix::LL),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -822,7 +822,7 @@ impl<'src> Lexer<'src> {
                 } else {
                     CharPrefix::None
                 };
-                let lit = LitRef::from_char(codepoint.into(), prefix);
+                let lit = LitRef::from_char(codepoint, prefix);
                 TokenKind::Literal(lit)
             }
             PPTokenKind::Number => {

--- a/src/pp/interpreter.rs
+++ b/src/pp/interpreter.rs
@@ -597,7 +597,7 @@ impl<'a> Interpreter<'a> {
             PPTokenKind::Number => {
                 let text = self.preprocessor.get_token_text(token);
                 let (val, suffix, _) = literal_parsing::parse_integer_literal(&text).ok_or_else(|| self.error())?;
-                let mut is_unsigned = matches!(suffix, Some(IntSuffix::U | IntSuffix::UL | IntSuffix::ULL));
+                let mut is_unsigned = matches!(suffix, Some(IntSuffix::U | IntSuffix::UL | IntSuffix::Ull));
                 if !is_unsigned && (val as u64) > i64::MAX as u64 {
                     is_unsigned = true;
                 }

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,33 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let pos_after_first = self.position;
+                    let has_splice_after_first = self.has_splice;
+                    if consume_if!(b'%') {
+                        if consume_if!(b':') {
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            // Backtrack to handle as %: then %
+                            self.position = pos_after_first;
+                            self.has_splice = has_splice_after_first;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +516,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +579,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -1189,16 +1226,16 @@ impl PPLexer {
                 // Handle escape sequences, including line splicing
 
                 // Check for UCN first
-                if let Some(p_ch) = self.peek_char() {
-                    if p_ch == b'u' || p_ch == b'U' {
-                        if self.lex_ucn(true).is_some() {
-                            // Valid UCN.
-                            continue;
-                        } else {
-                            // Invalid UCN.
-                            *has_invalid_ucn = true;
-                            continue;
-                        }
+                if let Some(p_ch) = self.peek_char()
+                    && (p_ch == b'u' || p_ch == b'U')
+                {
+                    if self.lex_ucn(true).is_some() {
+                        // Valid UCN.
+                        continue;
+                    } else {
+                        // Invalid UCN.
+                        *has_invalid_ucn = true;
+                        continue;
                     }
                 }
 

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -1308,9 +1308,9 @@ impl<'a> SemanticAnalyzer<'a> {
             lhs
         } else if is_equality && rhs.is_pointer() {
             rhs
-        } else if is_equality && lhs.is_arithmetic() && rhs.is_arithmetic() {
-            self.check_uac(node, lhs, rhs)?
-        } else if !is_equality && lhs.is_real() && rhs.is_real() {
+        } else if (is_equality && lhs.is_arithmetic() && rhs.is_arithmetic())
+            || (!is_equality && lhs.is_real() && rhs.is_real())
+        {
             self.check_uac(node, lhs, rhs)?
         } else {
             self.report_error(

--- a/src/semantic/const_eval.rs
+++ b/src/semantic/const_eval.rs
@@ -114,7 +114,7 @@ impl<'a> ConstEvalCtx<'a> {
     }
 
     fn get_info(&self) -> Option<&'a SemanticInfo> {
-        self.semantic_info.or_else(|| self.ast.semantic_info.as_ref())
+        self.semantic_info.or(self.ast.semantic_info.as_ref())
     }
 
     fn get_literal_type(&self, literal: &LitVal) -> QualType {
@@ -133,7 +133,7 @@ impl<'a> ConstEvalCtx<'a> {
             LitVal::Char(_, prefix) => prefix.get_type(self.registry),
             LitVal::Float { suffix, .. } => suffix.get_type(self.registry),
             LitVal::String { value, prefix } => {
-                let parsed_str = lower_string_literal(&value, *prefix);
+                let parsed_str = lower_string_literal(value, *prefix);
                 let builtin_base = match parsed_str.builtin_type {
                     BuiltinType::Char => self.registry.type_char,
                     BuiltinType::Int => self.registry.type_int,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/parser_decl.rs
+++ b/src/tests/parser_decl.rs
@@ -607,7 +607,7 @@ fn test_designated_initializer_struct_with_range() {
 #[test]
 fn test_static_assert() {
     let resolved = setup_declaration("_Static_assert(1, \"ok\");");
-    insta::assert_yaml_snapshot!(&resolved, @r"
+    insta::assert_yaml_snapshot!(&resolved, @"
     StaticAssert:
       - LiteralInt: 1
       - ok

--- a/src/tests/parser_expr.rs
+++ b/src/tests/parser_expr.rs
@@ -474,6 +474,6 @@ fn test_builtin_alloca() {
     let resolved = setup_expr("__builtin_alloca(42)");
     insta::assert_yaml_snapshot!(&resolved, @"
     BuiltinAlloca:
-      LiteralInt: 42    
+      LiteralInt: 42
     ");
 }

--- a/src/tests/parser_lexical.rs
+++ b/src/tests/parser_lexical.rs
@@ -129,7 +129,7 @@ fn test_integer_literals() {
     check_lit!("42", LitVal::Int { value: 42, suffix: IntSuffix::None, radix: 10 });
     check_lit!("0x1A", LitVal::Int { value: 26, suffix: IntSuffix::None, radix: 16 });
     check_lit!("077u", LitVal::Int { value: 63, suffix: IntSuffix::U, radix: 8 });
-    check_lit!("123llu", LitVal::Int { value: 123, suffix: IntSuffix::ULL, radix: 10 });
+    check_lit!("123llu", LitVal::Int { value: 123, suffix: IntSuffix::Ull, radix: 10 });
     check_lit!("0b1010", LitVal::Int { value: 10, suffix: IntSuffix::None, radix: 2 });
     // C23 separators
     check_lit!("1'234", LitVal::Int { value: 1234, suffix: IntSuffix::None, radix: 10 });

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,96 @@
+use crate::pp::{PPTokenFlags, PPTokenKind};
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_digraph_basic() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive() {
+    let source = "%:define FOO 1\nFOO";
+    let mut lexer = create_test_pp_lexer(source);
+
+    // Test that %: has the STARTS_PP_LINE flag.
+    let t1 = lexer.next_token().unwrap();
+    assert_eq!(t1.kind, PPTokenKind::Hash);
+    assert!(t1.flags.contains(PPTokenFlags::STARTS_PP_LINE));
+
+    let t2 = lexer.next_token().unwrap();
+    assert!(matches!(t2.kind, PPTokenKind::Identifier(_)));
+    assert_eq!(lexer.get_token_text(&t2), "define");
+}
+
+#[test]
+fn test_digraph_in_macro() {
+    let source = r#"
+#define GLUE(a, b) a %:%: b
+GLUE(1, 2)
+"#;
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: Number
+      text: "12"
+    "#);
+}
+
+#[test]
+fn test_digraph_with_splices() {
+    // Digraphs should be recognized if they are split by a splice because splices are removed in phase 2.
+    let source = "<\\\n: %\\\n>";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(lexer, ("[", PPTokenKind::LeftBracket), ("}", PPTokenKind::RightBrace),);
+}
+
+#[test]
+fn test_percent_colon_not_hash_hash() {
+    // %: followed by % should be Hash then Percent
+    let source = "%:%";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(lexer, ("#", PPTokenKind::Hash), ("%", PPTokenKind::Percent),);
+}
+
+#[test]
+fn test_complex_digraph_usage() {
+    let source = r#"
+%:define STR(x) %:x
+STR(hello)
+"#;
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: StringLiteral
+      text: "\"hello\""
+    "#);
+}
+
+#[test]
+fn test_digraph_in_expression() {
+    // Test that digraphs are correctly handled in a more complex context.
+    let source = r#"
+int main() <%
+    int arr<:5:>;
+    arr<:0:> = 1;
+    return arr<:0:>;
+%>
+"#;
+    let tokens = setup_pp_snapshot(source);
+    // Just verify it doesn't crash and generates expected tokens
+    assert!(tokens.iter().any(|t| t.text == "{"));
+    assert!(tokens.iter().any(|t| t.text == "}"));
+    assert!(tokens.iter().any(|t| t.text == "["));
+    assert!(tokens.iter().any(|t| t.text == "]"));
+}

--- a/src/tests/semantic_expr.rs
+++ b/src/tests/semantic_expr.rs
@@ -689,24 +689,24 @@ fn test_long_long_literal_suffix() {
         "#;
     let mir = setup_mir(source);
     insta::assert_snapshot!(mir, @"
-        type %t0 = i32
-        type %t1 = i64
+    type %t0 = i32
+    type %t1 = i64
 
-        fn main() -> i32
-        {
-          locals {
-            %a: i64
-            %b: i64
-            %c: i64
-          }
+    fn main() -> i32
+    {
+      locals {
+        %a: i64
+        %b: i64
+        %c: i64
+      }
 
-          bb1:
-            %a = const -2147483648
-            %b = const 2147483648
-            %c = const 2147483648
-            return const 0
-        }
-        ");
+      bb1:
+        %a = const -2147483648
+        %b = const 2147483648
+        %c = const 2147483648
+        return const 0
+    }
+    ");
 }
 
 #[test]

--- a/src/tests/semantic_mir.rs
+++ b/src/tests/semantic_mir.rs
@@ -554,7 +554,7 @@ fn test_function_with_many_return_types() {
         "#;
 
     let mir_dump = setup_mir(source);
-    insta::assert_snapshot!(mir_dump, @r"
+    insta::assert_snapshot!(mir_dump, @"
     type %t0 = i32
     type %t1 = f64
     type %t2 = i8


### PR DESCRIPTION
This PR implements support for C digraphs (`<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) in the Cendol compiler, addressing one of the stated limitations in the `README.md`.

Digraphs are now recognized by the preprocessor lexer and correctly mapped to their equivalent punctuators. Special handling was added for `%:`, which can initiate a preprocessor directive if it appears at the beginning of a line, and `%:%:`, which is tokenized as a single `##` punctuator.

Additionally, this PR addresses several Clippy warnings to maintain high code standards, including logic simplifications and style improvements.

Comprehensive unit tests were added in `src/tests/pp_digraphs.rs` to verify correct behavior across basic lexing, directives, macro expansion, and line splicing.

---
*PR created automatically by Jules for task [17205518441104368313](https://jules.google.com/task/17205518441104368313) started by @bungcip*