### PR TITLE
Rendi: codebase cleanup by fixing clippy warnings

### DIFF
--- a/src/ast/literal.rs
+++ b/src/ast/literal.rs
@@ -48,7 +48,7 @@ pub enum IntSuffix {
     LL = 2,
     U = 3,
     UL = 4,
-    ULL = 5,
+    Ull = 5,
 }
 
 impl IntSuffix {
@@ -58,7 +58,7 @@ impl IntSuffix {
             2 => Self::LL,
             3 => Self::U,
             4 => Self::UL,
-            5 => Self::ULL,
+            5 => Self::Ull,
             _ => Self::None,
         }
     }
@@ -104,7 +104,7 @@ impl IntSuffix {
                     SmallVec::from_slice(&[registry.type_long_long, registry.type_long_long_unsigned])
                 }
             }
-            IntSuffix::ULL => SmallVec::from_slice(&[registry.type_long_long_unsigned]),
+            IntSuffix::Ull => SmallVec::from_slice(&[registry.type_long_long_unsigned]),
         }
     }
 }
@@ -271,7 +271,7 @@ impl LitRef {
     }
 
     pub fn from_int(value: i64, suffix: IntSuffix, radix: u8) -> Self {
-        if value >= INT_MIN_SMALL && value <= INT_MAX_SMALL {
+        if (INT_MIN_SMALL..=INT_MAX_SMALL).contains(&value) {
             let payload = ((value as u64) & INT_VALUE_MASK)
                 | ((suffix as u64) << INT_SUFFIX_SHIFT)
                 | (((radix as u64) & INT_RADIX_MASK) << INT_RADIX_SHIFT);

--- a/src/ast/literal_parsing.rs
+++ b/src/ast/literal_parsing.rs
@@ -4,8 +4,8 @@ use std::iter::Peekable;
 use std::str::Chars;
 
 const INTEGER_SUFFIXES: &[(&str, IntSuffix)] = &[
-    ("ull", IntSuffix::ULL),
-    ("llu", IntSuffix::ULL),
+    ("ull", IntSuffix::Ull),
+    ("llu", IntSuffix::Ull),
     ("ul", IntSuffix::UL),
     ("lu", IntSuffix::UL),
     ("ll", IntSuffix::LL),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -822,7 +822,7 @@ impl<'src> Lexer<'src> {
                 } else {
                     CharPrefix::None
                 };
-                let lit = LitRef::from_char(codepoint.into(), prefix);
+                let lit = LitRef::from_char(codepoint, prefix);
                 TokenKind::Literal(lit)
             }
             PPTokenKind::Number => {

--- a/src/pp/interpreter.rs
+++ b/src/pp/interpreter.rs
@@ -597,7 +597,7 @@ impl<'a> Interpreter<'a> {
             PPTokenKind::Number => {
                 let text = self.preprocessor.get_token_text(token);
                 let (val, suffix, _) = literal_parsing::parse_integer_literal(&text).ok_or_else(|| self.error())?;
-                let mut is_unsigned = matches!(suffix, Some(IntSuffix::U | IntSuffix::UL | IntSuffix::ULL));
+                let mut is_unsigned = matches!(suffix, Some(IntSuffix::U | IntSuffix::UL | IntSuffix::Ull));
                 if !is_unsigned && (val as u64) > i64::MAX as u64 {
                     is_unsigned = true;
                 }

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -1189,16 +1189,16 @@ impl PPLexer {
                 // Handle escape sequences, including line splicing
 
                 // Check for UCN first
-                if let Some(p_ch) = self.peek_char() {
-                    if p_ch == b'u' || p_ch == b'U' {
-                        if self.lex_ucn(true).is_some() {
-                            // Valid UCN.
-                            continue;
-                        } else {
-                            // Invalid UCN.
-                            *has_invalid_ucn = true;
-                            continue;
-                        }
+                if let Some(p_ch) = self.peek_char()
+                    && (p_ch == b'u' || p_ch == b'U')
+                {
+                    if self.lex_ucn(true).is_some() {
+                        // Valid UCN.
+                        continue;
+                    } else {
+                        // Invalid UCN.
+                        *has_invalid_ucn = true;
+                        continue;
                     }
                 }
 

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -1312,9 +1312,9 @@ impl<'a> SemanticAnalyzer<'a> {
             lhs
         } else if is_equality && rhs.is_pointer() {
             rhs
-        } else if is_equality && lhs.is_arithmetic() && rhs.is_arithmetic() {
-            self.check_uac(node, lhs, rhs)?
-        } else if !is_equality && lhs.is_real() && rhs.is_real() {
+        } else if (is_equality && lhs.is_arithmetic() && rhs.is_arithmetic())
+            || (!is_equality && lhs.is_real() && rhs.is_real())
+        {
             self.check_uac(node, lhs, rhs)?
         } else {
             self.report_error(

--- a/src/semantic/const_eval.rs
+++ b/src/semantic/const_eval.rs
@@ -114,7 +114,7 @@ impl<'a> ConstEvalCtx<'a> {
     }
 
     fn get_info(&self) -> Option<&'a SemanticInfo> {
-        self.semantic_info.or_else(|| self.ast.semantic_info.as_ref())
+        self.semantic_info.or(self.ast.semantic_info.as_ref())
     }
 
     fn get_literal_type(&self, literal: &LitVal) -> QualType {
@@ -133,7 +133,7 @@ impl<'a> ConstEvalCtx<'a> {
             LitVal::Char(_, prefix) => prefix.get_type(self.registry),
             LitVal::Float { suffix, .. } => suffix.get_type(self.registry),
             LitVal::String { value, prefix } => {
-                let parsed_str = lower_string_literal(&value, *prefix);
+                let parsed_str = lower_string_literal(value, *prefix);
                 let builtin_base = match parsed_str.builtin_type {
                     BuiltinType::Char => self.registry.type_char,
                     BuiltinType::Int => self.registry.type_int,

--- a/src/tests/mir_validation.rs
+++ b/src/tests/mir_validation.rs
@@ -379,7 +379,7 @@ fn test_call_void_with_dest() {
 fn test_operand_missing_constant() {
     let invalid_id = ConstValueId::new(999).unwrap();
     check_err(
-        ValidationError::IllegalOperation(format!("Constant 999 not found")),
+        ValidationError::IllegalOperation("Constant 999 not found".to_string()),
         |m| {
             let block_id = m.functions[m.module.functions[0].index()].blocks[0];
             m.blocks[block_id.index()].terminator = Terminator::Return(Some(Operand::Constant(invalid_id)));

--- a/src/tests/parser_lexical.rs
+++ b/src/tests/parser_lexical.rs
@@ -129,7 +129,7 @@ fn test_integer_literals() {
     check_lit!("42", LitVal::Int { value: 42, suffix: IntSuffix::None, radix: 10 });
     check_lit!("0x1A", LitVal::Int { value: 26, suffix: IntSuffix::None, radix: 16 });
     check_lit!("077u", LitVal::Int { value: 63, suffix: IntSuffix::U, radix: 8 });
-    check_lit!("123llu", LitVal::Int { value: 123, suffix: IntSuffix::ULL, radix: 10 });
+    check_lit!("123llu", LitVal::Int { value: 123, suffix: IntSuffix::Ull, radix: 10 });
     check_lit!("0b1010", LitVal::Int { value: 10, suffix: IntSuffix::None, radix: 2 });
     // C23 separators
     check_lit!("1'234", LitVal::Int { value: 1234, suffix: IntSuffix::None, radix: 10 });
@@ -140,6 +140,7 @@ fn test_integer_literals() {
 
 #[test]
 #[rustfmt::skip]
+#[allow(clippy::approx_constant)]
 fn test_float_literals() {
     check_lit!("3.14", LitVal::from_f64(3.14, FloatSuffix::None));
     check_lit!("1.0f", LitVal::from_f64(1.0, FloatSuffix::F));


### PR DESCRIPTION
This commit addresses multiple warnings reported by `cargo clippy`:

1. Fixed `clippy::upper_case_acronyms` in `src/ast/literal.rs` by renaming `IntSuffix::ULL` to `Ull`.
2. Fixed `clippy::manual_range_contains` in `src/ast/literal.rs`.
3. Fixed `clippy::useless_conversion` in `src/parser/lexer.rs`.
4. Fixed `clippy::collapsible_if` in `src/pp/pp_lexer.rs`.
5. Fixed `clippy::if_same_then_else` in `src/semantic/analyzer.rs` by combining branches.
6. Fixed `clippy::unnecessary_lazy_evaluations` in `src/semantic/const_eval.rs`.
7. Fixed `clippy::needless_borrow` in `src/semantic/const_eval.rs`.
8. Handled `clippy::approx_constant` via `#[allow(...)]` where appropriate.
9. Fixed `clippy::useless_format` in tests.

The code passes all tests, no coverage was lost, and no new features were added. This matches the objective to clean up redundant or over-engineered code and fix minor lints.

---
*PR created automatically by Jules for task [148588084201518233](https://jules.google.com/task/148588084201518233) started by @bungcip*