### PR TITLE
Implement C digraph support in preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,38 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let saved_pos = self.position;
+                    let saved_has_splice = self.has_splice;
+                    let saved_at_start = self.at_start_of_line;
+
+                    if self.peek_char() == Some(b'%') {
+                        self.next_char();
+                        if self.peek_char() == Some(b':') {
+                            self.next_char();
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            self.position = saved_pos;
+                            self.has_splice = saved_has_splice;
+                            self.at_start_of_line = saved_at_start;
+
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +521,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +584,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -2474,10 +2474,10 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             }
             NodeKind::InitializerList(list) => {
                 for item in list.init_start.range(list.init_len) {
-                    if let NodeKind::InitializerItem(ii) = self.ast.get_kind(item) {
-                        if !self.is_constant_expr(ii.initializer) {
-                            return false;
-                        }
+                    if let NodeKind::InitializerItem(ii) = self.ast.get_kind(item)
+                        && !self.is_constant_expr(ii.initializer)
+                    {
+                        return false;
                     }
                 }
                 true
@@ -2488,10 +2488,10 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                 }
                 if let NodeKind::InitializerList(list) = self.ast.get_kind(*init_list) {
                     for item in list.init_start.range(list.init_len) {
-                        if let NodeKind::InitializerItem(ii) = self.ast.get_kind(item) {
-                            if !self.is_constant_expr(ii.initializer) {
-                                return false;
-                            }
+                        if let NodeKind::InitializerItem(ii) = self.ast.get_kind(item)
+                            && !self.is_constant_expr(ii.initializer)
+                        {
+                            return false;
                         }
                     }
                 }
@@ -2527,10 +2527,10 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
 
             NodeKind::GenericSelection(gs) => {
                 for assoc_node in gs.assoc_start.range(gs.assoc_len) {
-                    if let NodeKind::GenericAssociation(assoc) = self.ast.get_kind(assoc_node) {
-                        if !self.is_constant_expr(assoc.result_expr) {
-                            return false;
-                        }
+                    if let NodeKind::GenericAssociation(assoc) = self.ast.get_kind(assoc_node)
+                        && !self.is_constant_expr(assoc.result_expr)
+                    {
+                        return false;
                     }
                 }
                 true

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,101 @@
+use crate::pp::PPTokenKind;
+use crate::tests::pp_common::create_test_pp_lexer;
+
+#[macro_export]
+macro_rules! test_digraph_tokens {
+    ($lexer:expr, $( ($input:expr, $expected:pat) ),* $(,)?) => {
+        $(
+            let token = $lexer.next_token().unwrap();
+            match token.kind {
+                $expected => {
+                    // Digraphs are tokenized as their standard equivalents.
+                    // We don't check for literal source text here because get_text_from_buffer
+                    // (and hence get_text_with_sm) returns the fixed text for punctuators.
+                },
+                _ => panic!("Expected {:?}, got {:?}", stringify!($expected), token.kind),
+            }
+        )*
+    };
+}
+
+#[test]
+fn test_digraphs() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_digraph_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_hash_starts_line() {
+    let source = "%:define FOO 1";
+    let mut lexer = create_test_pp_lexer(source);
+
+    let t1 = lexer.next_token().unwrap();
+    assert_eq!(t1.kind, PPTokenKind::Hash);
+    assert!(t1.flags.contains(crate::pp::PPTokenFlags::STARTS_PP_LINE));
+
+    test_digraph_tokens!(
+        lexer,
+        ("define", PPTokenKind::Identifier(_)),
+        ("FOO", PPTokenKind::Identifier(_)),
+        ("1", PPTokenKind::Number),
+        ("", PPTokenKind::Eod),
+    );
+}
+
+#[test]
+fn test_digraph_splices() {
+    let source = "<\\\n: :\\\n> <\\\n% %\\\n> %\\\n: %\\\n:%\\\n:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_digraph_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_not_digraphs() {
+    let source = "% : % % : : % : % :";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_digraph_tokens!(
+        lexer,
+        ("%", PPTokenKind::Percent),
+        (":", PPTokenKind::Colon),
+        ("%", PPTokenKind::Percent),
+        ("%", PPTokenKind::Percent),
+        (":", PPTokenKind::Colon),
+        (":", PPTokenKind::Colon),
+        ("%", PPTokenKind::Percent),
+        (":", PPTokenKind::Colon),
+        ("%", PPTokenKind::Percent),
+        (":", PPTokenKind::Colon),
+    );
+}
+
+#[test]
+fn test_percent_colon_percent_not_hash_hash() {
+    let source = "%:%";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_digraph_tokens!(
+        lexer,
+        ("#", PPTokenKind::Hash),
+        ("%", PPTokenKind::Percent),
+    );
+}


### PR DESCRIPTION
I have implemented full support for C digraphs in the Cendol preprocessor. Digraphs are two-character sequences that represent standard C punctuators (e.g., `<:` for `[`). 

Key improvements:
- Updated the preprocessor lexer to recognize `<:`, `:>`, `<%`, `%>`, `%:`, and `%:%:`.
- Ensured `%:` correctly triggers preprocessor directives at the start of a line.
- Digraphs preserve their original source length while being treated as standard tokens, ensuring correct diagnostic reporting.
- Added a comprehensive suite of unit tests in `src/tests/pp_digraphs.rs`.
- Cleaned up clippy warnings in `src/semantic/lowering.rs` using modern Rust 'let chains'.
- Updated documentation to reflect the new capability.

---
*PR created automatically by Jules for task [11317012757180762000](https://jules.google.com/task/11317012757180762000) started by @bungcip*