### PR TITLE
🛡️ Guardian: [modifiable lvalue completeness protected]

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -219,3 +219,8 @@ Action: Ensure that `_Generic` selection continues checking all associations eve
 
 Learning: C11 prohibits 'static' storage class for function declarations in block scope. Furthermore, 'extern' function declarations in block scope can be missed by a global 'pre-declare' pass that only scans top-level symbols. If these block-scope declarations are referenced, the MIR generator must handle them lazily by declaring the function on-the-fly using symbol table metadata, otherwise it may encounter unexpected 'None' values when resolving identifiers to function addresses.
 Action: Enforce storage class constraints for block-scope functions in semantic lowering and implement lazy, metadata-driven function declaration in the MIR generator to ensure robust handling of all valid C scope-linkage combinations.
+
+2026-04-15 - [Modifiable LValue Completeness Constraint]
+
+Learning: C11 6.3.2.1p1 requires the left operand of an assignment to be a modifiable lvalue, which specifically prohibits objects with incomplete types. While incomplete arrays decay to pointers (making them complete), other incomplete types like 'void' (via dereference) or forward-declared structures remain incomplete and must be rejected during semantic analysis of assignments.
+Action: Enforce completeness checks in 'check_lvalue_and_modifiable' for all lvalues to ensure standard compliance for assignments and other mutating operations.

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -778,6 +778,9 @@ impl<'a> SemanticAnalyzer<'a> {
         if !self.is_lvalue(node) || qt.is_array() || qt.is_function() {
             self.report_error(node, SemanticError::NotAnLvalue);
             false
+        } else if !self.registry.is_complete(qt.ty()) {
+            self.report_error(node, SemanticError::IncompleteType { ty: qt });
+            false
         } else if self.registry.is_const_recursive(qt) {
             self.report_error(node, SemanticError::AssignmentToReadOnly);
             false

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -61,6 +61,7 @@ pub mod parser_types;
 pub mod parser_utils;
 
 pub mod guardian_increment_completeness;
+pub mod guardian_modifiable_lvalue;
 pub mod guardian_pointer_arithmetic_completeness;
 pub mod guardian_struct_member;
 pub mod parser_gcc_extensions;

--- a/src/tests/guardian_modifiable_lvalue.rs
+++ b/src/tests/guardian_modifiable_lvalue.rs
@@ -1,0 +1,27 @@
+use crate::tests::test_utils::run_fail_with_message;
+
+#[test]
+fn test_assignment_to_incomplete_struct() {
+    run_fail_with_message(
+        r#"
+        struct S;
+        extern struct S s1, s2;
+        void f() {
+            s1 = s2;
+        }
+        "#,
+        "incomplete type",
+    );
+}
+
+#[test]
+fn test_assignment_to_void_lvalue() {
+    run_fail_with_message(
+        r#"
+        void f(void *p) {
+            *p = *p;
+        }
+        "#,
+        "incomplete type",
+    );
+}


### PR DESCRIPTION
This PR hardens the semantic analyzer by enforcing the C11 constraint that modifiable lvalues must have a complete object type (§6.3.2.1p1).

### Changes
- **Semantic Analyzer**: Updated `check_lvalue_and_modifiable` in `src/semantic/analyzer.rs` to verify type completeness using `self.registry.is_complete`.
- **Tests**: Created `src/tests/guardian_modifiable_lvalue.rs` with negative tests for incomplete struct assignment and `void` lvalue assignment.
- **Journal**: Added a critical learning entry to `.jules/guardian.md` regarding modifiable lvalue constraints.

### Verification
- Ran the new tests: `cargo test guardian_modifiable_lvalue` (Passed)
- Ran the full test suite: `cargo test` (Passed)
- Verified correct diagnostics are emitted for invalid C code.

---
*PR created automatically by Jules for task [17686150461104439539](https://jules.google.com/task/17686150461104439539) started by @bungcip*