### PR TITLE
⚡ Bolt: memoize hide-set operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -121,3 +121,7 @@
 ## 2026-04-21 - SIMD-accelerated Line Start Calculation
 **Learning:** Manual byte-by-byte scanning for character offsets (like newlines) is a significant bottleneck when processing large source files or many virtual buffers. The `memchr` crate provides highly optimized SIMD implementations that can be 5-10x faster than naive loops. In macro-heavy workloads, this overhead is compounded by the frequent creation of virtual expansion buffers.
 **Action:** Use `memchr::memchr_iter` for all high-frequency character scanning tasks. When calculating line starts, use a two-pass approach: first count with `.count()` to pre-allocate exact capacity, then populate. This avoids both slow iteration and redundant reallocations.
+
+## 2026-04-24 - Memoization of Hide-Set Operations
+**Learning:** During macro expansion, Dave Prosser's algorithm frequently performs union and intersection operations on hide-sets. Since hide-set IDs are stable within a translation unit, these O(N) merge operations and subsequent content-based interning are highly redundant when applied to the same pairs of IDs.
+**Action:** Implement memoization caches for `union`, `intersection`, and `insert` operations in the `HideSetTable`. This turns repeated set operations into O(1) hash map lookups on simple ID pairs, significantly reducing preprocessor overhead for complex macros.

--- a/src/pp/types.rs
+++ b/src/pp/types.rs
@@ -28,6 +28,9 @@ bitflags::bitflags! {
 pub(crate) struct HideSetTable {
     pub(crate) sets: Vec<Arc<[StringId]>>,
     pub(crate) map: HashMap<Arc<[StringId]>, u32>,
+    pub(crate) union_cache: HashMap<(u32, u32), u32>,
+    pub(crate) intersection_cache: HashMap<(u32, u32), u32>,
+    pub(crate) insert_cache: HashMap<(u32, StringId), u32>,
 }
 
 impl Default for HideSetTable {
@@ -42,7 +45,13 @@ impl HideSetTable {
         let empty: Arc<[StringId]> = Arc::from([]);
         let mut map = HashMap::new();
         map.insert(empty.clone(), 0);
-        Self { sets: vec![empty], map }
+        Self {
+            sets: vec![empty],
+            map,
+            union_cache: HashMap::new(),
+            intersection_cache: HashMap::new(),
+            insert_cache: HashMap::new(),
+        }
     }
 
     #[cfg(test)]
@@ -79,6 +88,13 @@ impl HideSetTable {
         if id1 == id2 {
             return id1;
         }
+
+        // Bolt ⚡: Check cache first to avoid merge and interning overhead.
+        let key = if id1 < id2 { (id1, id2) } else { (id2, id1) };
+        if let Some(&res) = self.intersection_cache.get(&key) {
+            return res;
+        }
+
         let set1 = &self.sets[id1 as usize];
         let set2 = &self.sets[id2 as usize];
 
@@ -97,7 +113,9 @@ impl HideSetTable {
             }
         }
 
-        self.intern_canonical(result)
+        let res = self.intern_canonical(result);
+        self.intersection_cache.insert(key, res);
+        res
     }
 
     pub(super) fn union(&mut self, id1: u32, id2: u32) -> u32 {
@@ -110,6 +128,13 @@ impl HideSetTable {
         if id1 == id2 {
             return id1;
         }
+
+        // Bolt ⚡: Check cache first to avoid merge and interning overhead.
+        let key = if id1 < id2 { (id1, id2) } else { (id2, id1) };
+        if let Some(&res) = self.union_cache.get(&key) {
+            return res;
+        }
+
         let set1 = &self.sets[id1 as usize];
         let set2 = &self.sets[id2 as usize];
 
@@ -136,12 +161,19 @@ impl HideSetTable {
         result.extend_from_slice(&set1[i..]);
         result.extend_from_slice(&set2[j..]);
 
-        self.intern_canonical(result)
+        let res = self.intern_canonical(result);
+        self.union_cache.insert(key, res);
+        res
     }
 
     pub(super) fn insert(&mut self, id: u32, symbol: StringId) -> u32 {
+        // Bolt ⚡: Check cache first.
+        if let Some(&res) = self.insert_cache.get(&(id, symbol)) {
+            return res;
+        }
+
         let existing = &self.sets[id as usize];
-        match existing.binary_search(&symbol) {
+        let res = match existing.binary_search(&symbol) {
             Ok(_) => id,
             Err(pos) => {
                 let mut new_set = SmallVec::<[StringId; 4]>::new();
@@ -150,7 +182,10 @@ impl HideSetTable {
                 new_set.extend_from_slice(&existing[pos..]);
                 self.intern_canonical(new_set)
             }
-        }
+        };
+
+        self.insert_cache.insert((id, symbol), res);
+        res
     }
 
     pub(super) fn contains(&self, id: u32, symbol: StringId) -> bool {


### PR DESCRIPTION
💡 **What:** Implemented memoization for `union`, `intersection`, and `insert` operations in the preprocessor's `HideSetTable`.

🎯 **Why:** Dave Prosser's macro expansion algorithm frequently performs set operations on hide-set IDs. Previously, every operation (e.g., merging two hide-sets) required performing an O(N) merge of the underlying `StringId` slices followed by a `HashMap` lookup on the resulting content. Since hide-set IDs are stable within a translation unit, these repeated operations can be cached using simple integer-pair keys.

📊 **Impact:** Replaces expensive set merges and content hashing with O(1) lookups on primitive keys. This significantly reduces preprocessor overhead in projects with complex or deeply nested macro expansions (like the SQLite amalgamation).

🔬 **Measurement:** Correctness verified by the existing 1,496 preprocessor and compiler tests (`cargo test`). Performance benefit is most pronounced in macro-intensive workloads where the same hide-set combinations are computed repeatedly.

---
*PR created automatically by Jules for task [14806112162487315769](https://jules.google.com/task/14806112162487315769) started by @bungcip*