### PR TITLE
Implement C Digraph Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,37 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let pos_after_digraph_hash = self.position;
+                    let at_start_after_digraph_hash = self.at_start_of_line;
+                    let has_splice_after_digraph_hash = self.has_splice;
+
+                    if consume_if!(b'%') {
+                        if consume_if!(b':') {
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            // Backtrack to after %:
+                            self.position = pos_after_digraph_hash;
+                            self.at_start_of_line = at_start_after_digraph_hash;
+                            self.has_splice = has_splice_after_digraph_hash;
+
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +520,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +583,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,52 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_digraph_bracket() {
+    let source = "<: :>";
+    let mut lexer = create_test_pp_lexer(source);
+    test_tokens!(lexer, ("[", PPTokenKind::LeftBracket), ("]", PPTokenKind::RightBracket),);
+}
+
+#[test]
+fn test_digraph_brace() {
+    let source = "<% %>";
+    let mut lexer = create_test_pp_lexer(source);
+    test_tokens!(lexer, ("{", PPTokenKind::LeftBrace), ("}", PPTokenKind::RightBrace),);
+}
+
+#[test]
+fn test_digraph_hash() {
+    let source = "%: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+    test_tokens!(lexer, ("#", PPTokenKind::Hash), ("##", PPTokenKind::HashHash),);
+}
+
+#[test]
+fn test_digraph_hash_directive() {
+    let src = r#"
+%:define FOO 1
+#if FOO
+OK
+%:endif
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: OK
+    ");
+}
+
+#[test]
+fn test_digraph_mixture() {
+    let source = "<: %> <% :>";
+    let mut lexer = create_test_pp_lexer(source);
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("}", PPTokenKind::RightBrace),
+        ("{", PPTokenKind::LeftBrace),
+        ("]", PPTokenKind::RightBracket),
+    );
+}


### PR DESCRIPTION
I have implemented support for C digraphs in the Cendol compiler's preprocessor.

Key changes:
- Updated `src/pp/pp_lexer.rs` to recognize and tokenize digraphs:
    - `<:` -> `[`
    - `<%` -> `{`
    - `:>` -> `]`
    - `%>` -> `}`
    - `%:` -> `#` (with support for starting preprocessor directives)
    - `%:%:` -> `##`
- Added comprehensive unit tests in `src/tests/pp_digraphs.rs` covering all digraph cases and their interaction with the preprocessor.
- Updated `README.md` to remove "No Digraph Support" from the limitations list.
- Verified that all 1502 tests pass, ensuring no regressions.
- Ensured the code is properly formatted and linted with `cargo fmt` and `cargo clippy`.

---
*PR created automatically by Jules for task [5875284401811809778](https://jules.google.com/task/5875284401811809778) started by @bungcip*