### PR TITLE
🛡️ Guardian: [compiler behavior protected]

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -224,3 +224,8 @@ Action: Enforce storage class constraints for block-scope functions in semantic 
 
 Learning: C11 6.3.2.1p1 requires the left operand of an assignment to be a modifiable lvalue, which specifically prohibits objects with incomplete types. While incomplete arrays decay to pointers (making them complete), other incomplete types like 'void' (via dereference) or forward-declared structures remain incomplete and must be rejected during semantic analysis of assignments.
 Action: Enforce completeness checks in 'check_lvalue_and_modifiable' for all lvalues to ensure standard compliance for assignments and other mutating operations.
+
+2026-04-20 - [Alignment Specifier Redeclaration Constraints]
+
+Learning: C11 §6.7.5p5 mandates that if any declaration of an identifier has an alignment specifier, the first declaration MUST specify an alignment, and it must be at least as strict as any subsequent one. Furthermore, if any declaration has it, every other declaration must either omit it or match the first one exactly. Cendol previously allowed adding alignment in subsequent declarations or mismatched alignments if they were specified later.
+Action: Enforce alignment consistency during global symbol merging in the symbol table, ensuring that first declarations are not "upgraded" with alignment and that subsequent alignment specifiers match the initial one.

--- a/src/semantic/errors.rs
+++ b/src/semantic/errors.rs
@@ -53,7 +53,9 @@ impl SemanticDiag {
 
         if let Some((message, span)) = match &self.kind {
             SemanticError::Redefinition { first_def, .. }
-            | SemanticError::RedefinitionWithDifferentType { first_def, .. } => {
+            | SemanticError::RedefinitionWithDifferentType { first_def, .. }
+            | SemanticError::MismatchedAlignment { first_def, .. }
+            | SemanticError::MissingInitialAlignment { first_def, .. } => {
                 Some(("previous definition is here", *first_def))
             }
             SemanticError::GenericMultipleDefault { first_def, .. } => {
@@ -100,6 +102,16 @@ pub enum SemanticError {
         name: NameId,
     },
     Redefinition {
+        name: NameId,
+        first_def: SourceSpan,
+    },
+    MismatchedAlignment {
+        name: NameId,
+        existing_align: u16,
+        new_align: u16,
+        first_def: SourceSpan,
+    },
+    MissingInitialAlignment {
         name: NameId,
         first_def: SourceSpan,
     },
@@ -454,6 +466,18 @@ impl SemanticError {
             SemanticError::Redefinition { name, .. } => format!("redefinition of '{}'", name),
             SemanticError::RedefinitionWithDifferentType { name, .. } => {
                 format!("redefinition of '{}' with a different type", name)
+            }
+            SemanticError::MismatchedAlignment {
+                name,
+                new_align,
+                existing_align,
+                ..
+            } => format!(
+                "alignment of '{}' ({}) does not match the first declaration ({})",
+                name, new_align, existing_align
+            ),
+            SemanticError::MissingInitialAlignment { name, .. } => {
+                format!("first declaration of '{}' does not specify an alignment", name)
             }
             SemanticError::TypeMismatch { expected, found } => format!(
                 "type mismatch: expected {}, found {}",

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -483,7 +483,12 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                     Ok(sym) => {
                         constant_syms.push(sym);
                     }
-                    Err(SymbolTableError::InvalidRedefinition { existing, .. }) => {
+                    Err(e) => {
+                        let existing = match e {
+                            SymbolTableError::InvalidRedefinition { existing, .. } => existing,
+                            SymbolTableError::AlignmentMismatch { existing, .. } => existing,
+                            SymbolTableError::MissingInitialAlignment { existing, .. } => existing,
+                        };
                         let first_def = self.symbol_table.get_symbol(existing).def_span;
                         self.report_error(node.span, SemanticError::Redefinition { name: *name, first_def });
                         constant_syms.push(existing); // keep a reference so index stays aligned
@@ -1056,7 +1061,12 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             span,
         ) {
             Ok(sym) => sym,
-            Err(SymbolTableError::InvalidRedefinition { existing, .. }) => {
+            Err(e) => {
+                let existing = match e {
+                    SymbolTableError::InvalidRedefinition { existing, .. } => existing,
+                    SymbolTableError::AlignmentMismatch { existing, .. } => existing,
+                    SymbolTableError::MissingInitialAlignment { existing, .. } => existing,
+                };
                 let entry = self.symbol_table.get_symbol(existing);
                 if entry.def_state == DefinitionState::Defined {
                     let first_def = entry.def_span;
@@ -1376,9 +1386,12 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
 
             self.check_function_specs(spec_info, init.span);
 
-            let symbol = if let Err(SymbolTableError::InvalidRedefinition { existing, .. }) =
-                self.symbol_table.define_typedef(name, final_ty, span)
-            {
+            let symbol = if let Err(e) = self.symbol_table.define_typedef(name, final_ty, span) {
+                let existing = match e {
+                    SymbolTableError::InvalidRedefinition { existing, .. } => existing,
+                    SymbolTableError::AlignmentMismatch { existing, .. } => existing,
+                    SymbolTableError::MissingInitialAlignment { existing, .. } => existing,
+                };
                 let existing_symbol = self.symbol_table.get_symbol(existing);
                 if let SymbolKind::Typedef { aliased_type } = existing_symbol.kind {
                     if aliased_type != final_ty {
@@ -1485,7 +1498,12 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             span,
         ) {
             Ok(sym) => sym,
-            Err(SymbolTableError::InvalidRedefinition { existing, .. }) => {
+            Err(e) => {
+                let existing = match e {
+                    SymbolTableError::InvalidRedefinition { existing, .. } => existing,
+                    SymbolTableError::AlignmentMismatch { existing, .. } => existing,
+                    SymbolTableError::MissingInitialAlignment { existing, .. } => existing,
+                };
                 let first_def = self.symbol_table.get_symbol(existing).def_span;
                 self.report_error(span, SemanticError::Redefinition { name, first_def });
                 existing
@@ -1670,15 +1688,41 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             symbol: match sym_res {
                 Ok(sym) => sym,
                 Err(SymbolTableError::InvalidRedefinition { existing, .. }) => existing,
+                Err(SymbolTableError::AlignmentMismatch { existing, .. }) => existing,
+                Err(SymbolTableError::MissingInitialAlignment { existing, .. }) => existing,
             },
             init: init_expr,
         };
         self.ast.set_kind(node, NodeKind::VarDecl(var_decl));
 
         // Validation against redefinition or alignment issues
-        if let Err(SymbolTableError::InvalidRedefinition { existing, .. }) = sym_res {
-            let first_def = self.symbol_table.get_symbol(existing).def_span;
-            self.report_error(span, SemanticError::Redefinition { name, first_def });
+        match sym_res {
+            Err(SymbolTableError::InvalidRedefinition { existing, .. }) => {
+                let first_def = self.symbol_table.get_symbol(existing).def_span;
+                self.report_error(span, SemanticError::Redefinition { name, first_def });
+            }
+            Err(SymbolTableError::AlignmentMismatch {
+                existing,
+                existing_align,
+                new_align,
+                ..
+            }) => {
+                let first_def = self.symbol_table.get_symbol(existing).def_span;
+                self.report_error(
+                    span,
+                    SemanticError::MismatchedAlignment {
+                        name,
+                        existing_align,
+                        new_align,
+                        first_def,
+                    },
+                );
+            }
+            Err(SymbolTableError::MissingInitialAlignment { existing, .. }) => {
+                let first_def = self.symbol_table.get_symbol(existing).def_span;
+                self.report_error(span, SemanticError::MissingInitialAlignment { name, first_def });
+            }
+            _ => {}
         }
 
         if !spec_info.is_packed

--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -113,6 +113,17 @@ pub enum SymbolKind {
 pub enum SymbolTableError {
     #[error("Invalid redefinition: symbol '{name}' cannot be redefined")]
     InvalidRedefinition { name: NameId, existing: SymbolRef },
+
+    #[error("Alignment mismatch for '{name}': new alignment {new_align} does not match existing {existing_align}")]
+    AlignmentMismatch {
+        name: NameId,
+        existing: SymbolRef,
+        existing_align: u16,
+        new_align: u16,
+    },
+
+    #[error("Missing alignment for '{name}': first declaration did not specify an alignment")]
+    MissingInitialAlignment { name: NameId, existing: SymbolRef },
 }
 
 use serde::Serialize;
@@ -596,13 +607,17 @@ impl SymbolTable {
             {
                 match (existing_align, new_align) {
                     (Some(a), Some(b)) if a != b => {
-                        return Err(SymbolTableError::InvalidRedefinition { name, existing: sym });
+                        return Err(SymbolTableError::AlignmentMismatch {
+                            name,
+                            existing: sym,
+                            existing_align: *a,
+                            new_align: *b,
+                        });
                     }
-                    (None, Some(b)) => {
-                        // Inherit alignment from new declaration
-                        if let SymbolKind::Variable { alignment, .. } = &mut existing.kind {
-                            *alignment = Some(*b);
-                        }
+                    (None, Some(_)) => {
+                        // C11 6.7.5p5: If any declaration of an identifier has an alignment specifier,
+                        // then the first declaration shall specify an alignment...
+                        return Err(SymbolTableError::MissingInitialAlignment { name, existing: sym });
                     }
                     _ => {}
                 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -75,6 +75,7 @@ pub mod codegen_regr;
 pub mod driver_defines;
 pub mod gnu_attributes;
 pub mod guardian_alias_completeness;
+pub mod guardian_alignas_redeclaration;
 pub mod guardian_alignas_vla;
 pub mod guardian_alignof_bitfield;
 pub mod guardian_array_init;

--- a/src/tests/guardian_alignas_redeclaration.rs
+++ b/src/tests/guardian_alignas_redeclaration.rs
@@ -1,0 +1,56 @@
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+use crate::driver::artifact::CompilePhase;
+
+#[test]
+fn test_alignas_redeclaration_constraints() {
+    // C11 6.7.5p5: "If any declaration of an identifier has an alignment specifier,
+    // then the first declaration shall specify an alignment at least as strict as
+    // that specified by any subsequent declaration of that identifier."
+    //
+    // And "if any declaration of an identifier has an alignment specifier,
+    // every other declaration of that identifier shall either specify no
+    // alignment or specify an alignment that is the same as the first one."
+
+    // 1. First declaration must specify alignment if any subsequent one does.
+    run_fail_with_message(
+        r#"
+        int x;
+        _Alignas(8) int x;
+        "#,
+        "first declaration of 'x' does not specify an alignment",
+    );
+
+    // 2. Mismatched alignment in subsequent declaration.
+    run_fail_with_message(
+        r#"
+        _Alignas(8) int x;
+        _Alignas(16) int x;
+        "#,
+        "alignment of 'x' (16) does not match the first declaration (8)",
+    );
+
+    // 3. Subsequent declaration can omit alignment.
+    run_pass(
+        r#"
+        _Alignas(8) int x;
+        int x;
+        int main() {
+            _Static_assert(_Alignof(x) == 8, "Alignment should be inherited");
+            return 0;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+
+    // 4. Same alignment in subsequent declaration is OK.
+    run_pass(
+        r#"
+        _Alignas(8) int x;
+        _Alignas(8) int x;
+        int main() {
+            return 0;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}

--- a/src/tests/semantic_scope.rs
+++ b/src/tests/semantic_scope.rs
@@ -383,7 +383,7 @@ fn test_global_variable_alignment_mismatch() {
         _Alignas(8) int foo;
         _Alignas(16) int foo;
     "#;
-    run_fail_with_message(source, "redefinition");
+    run_fail_with_message(source, "alignment of 'foo' (16) does not match the first declaration (8)");
 }
 
 #[test]


### PR DESCRIPTION
Implemented C11 alignment redeclaration constraints as per §6.7.5p5. Added specialized diagnostics for alignment mismatches and missing initial alignment. Verified with new regression tests and existing test suite.

---
*PR created automatically by Jules for task [17140204135456283272](https://jules.google.com/task/17140204135456283272) started by @bungcip*