### PR TITLE
Implement C11 Digraph Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,36 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let mut is_hash_hash = false;
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    let saved_has_splice = self.has_splice;
+
+                    if self.peek_char() == Some(b'%') {
+                        self.next_char();
+                        if self.peek_char() == Some(b':') {
+                            self.next_char();
+                            is_hash_hash = true;
+                        }
+                    }
+
+                    if is_hash_hash {
+                        token!(PPTokenKind::HashHash, 4)
+                    } else {
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+                        self.has_splice = saved_has_splice;
+
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +519,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +582,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,71 @@
+use crate::pp::pp_lexer::PPTokenKind;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_digraphs_basic() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    let mut tokens = Vec::new();
+    while let Some(token) = lexer.next_token() {
+        tokens.push(token);
+    }
+
+    assert_eq!(tokens[0].kind, PPTokenKind::LeftBracket);
+    assert_eq!(tokens[1].kind, PPTokenKind::RightBracket);
+    assert_eq!(tokens[2].kind, PPTokenKind::LeftBrace);
+    assert_eq!(tokens[3].kind, PPTokenKind::RightBrace);
+    assert_eq!(tokens[4].kind, PPTokenKind::Hash);
+    assert_eq!(tokens[5].kind, PPTokenKind::HashHash);
+}
+
+#[test]
+fn test_digraph_directive() {
+    let source = "%:define FOO 1\nFOO";
+    let tokens = setup_pp_snapshot(source);
+
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].text, "1");
+}
+
+#[test]
+fn test_digraph_macro_concatenation() {
+    let source = "#define CAT(a, b) a %:%: b\nCAT(1, 2)";
+    let tokens = setup_pp_snapshot(source);
+
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].text, "12");
+}
+
+#[test]
+fn test_digraph_macro_stringize() {
+    let source = "#define STR(a) %:a\nSTR(hello)";
+    let tokens = setup_pp_snapshot(source);
+
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].text, "\"hello\"");
+}
+
+#[test]
+fn test_digraph_edge_case_hashhash() {
+    // %:% should be %: (Hash) and % (Percent)
+    let source = "%:%";
+    let mut lexer = create_test_pp_lexer(source);
+
+    let t1 = lexer.next_token().unwrap();
+    assert_eq!(t1.kind, PPTokenKind::Hash);
+
+    let t2 = lexer.next_token().unwrap();
+    assert_eq!(t2.kind, PPTokenKind::Percent);
+}
+
+#[test]
+fn test_digraph_nested() {
+    let source = "<% <: :> %>";
+    let mut lexer = create_test_pp_lexer(source);
+
+    assert_eq!(lexer.next_token().unwrap().kind, PPTokenKind::LeftBrace);
+    assert_eq!(lexer.next_token().unwrap().kind, PPTokenKind::LeftBracket);
+    assert_eq!(lexer.next_token().unwrap().kind, PPTokenKind::RightBracket);
+    assert_eq!(lexer.next_token().unwrap().kind, PPTokenKind::RightBrace);
+}


### PR DESCRIPTION
I have implemented support for C11 digraphs in the preprocessor. 

Key changes:
1.  Modified `src/pp/pp_lexer.rs` to recognize digraph sequences and map them to their corresponding punctuator tokens.
2.  Ensured `%:` correctly initiates preprocessor directives when at the start of a line.
3.  Implemented backtracking for `%:%:` to correctly handle cases where a sequence starts like `%:%:` but is actually a shorter digraph followed by another token.
4.  Added a new test file `src/tests/pp_digraphs.rs` with comprehensive coverage for digraphs in various contexts (basic tokens, directives, macro stringizing, and concatenation).
5.  Updated `README.md` to remove digraphs from the list of limitations.

All tests passed, and `cargo clippy` and `cargo fmt` were run to ensure code quality.

---
*PR created automatically by Jules for task [6539535188397835039](https://jules.google.com/task/6539535188397835039) started by @bungcip*