### PR TITLE
test: Add test coverage for BuiltinType::to_unsigned

### DIFF
--- a/src/tests/semantic_types.rs
+++ b/src/tests/semantic_types.rs
@@ -715,3 +715,18 @@ fn test_is_value_fitting_coverage() {
     assert!(registry.is_value_fitting(i32::MIN as i64, ty_signed_int));
     assert!(!registry.is_value_fitting(u32::MAX as i64, ty_signed_int));
 }
+
+#[test]
+fn test_to_unsigned() {
+    use crate::semantic::types::BuiltinType;
+    assert_eq!(BuiltinType::Char.to_unsigned(), BuiltinType::UChar);
+    assert_eq!(BuiltinType::SChar.to_unsigned(), BuiltinType::UChar);
+    assert_eq!(BuiltinType::Short.to_unsigned(), BuiltinType::UShort);
+    assert_eq!(BuiltinType::Int.to_unsigned(), BuiltinType::UInt);
+    assert_eq!(BuiltinType::Signed.to_unsigned(), BuiltinType::UInt);
+    assert_eq!(BuiltinType::Long.to_unsigned(), BuiltinType::ULong);
+    assert_eq!(BuiltinType::LongLong.to_unsigned(), BuiltinType::ULongLong);
+    // Already unsigned or not signed integer type shouldn't change
+    assert_eq!(BuiltinType::UInt.to_unsigned(), BuiltinType::UInt);
+    assert_eq!(BuiltinType::Float.to_unsigned(), BuiltinType::Float);
+}


### PR DESCRIPTION
This patch introduces a new unit test, `test_to_unsigned`, to verify the correctness of the `BuiltinType::to_unsigned` method in `src/semantic/types.rs`. This provides direct coverage for branches converting signed integral types to their corresponding unsigned forms, ensuring accurate logic and improving overall code coverage.

---
*PR created automatically by Jules for task [957145340946240924](https://jules.google.com/task/957145340946240924) started by @bungcip*