### PR TITLE
⚡ Bolt: Optimize and fix UTF-8-safe de_splice

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -125,3 +125,7 @@
 ## 2026-04-24 - Memoization of Hide-Set Operations
 **Learning:** During macro expansion, Dave Prosser's algorithm frequently performs union and intersection operations on hide-sets. Since hide-set IDs are stable within a translation unit, these O(N) merge operations and subsequent content-based interning are highly redundant when applied to the same pairs of IDs.
 **Action:** Implement memoization caches for `union`, `intersection`, and `insert` operations in the `HideSetTable`. This turns repeated set operations into O(1) hash map lookups on simple ID pairs, significantly reducing preprocessor overhead for complex macros.
+
+## 2025-06-20 - UTF-8-Safe String Transformation via Slicing
+**Learning:** Transforming a `&str` by iterating over `as_bytes()` and casting to `char` (e.g., `bytes[i] as char`) is a major correctness bug that corrupts multi-byte UTF-8 sequences.
+**Action:** For performance-critical transformations like line-splice removal, use `memchr` to scan for ASCII triggers, then use string slicing and `push_str` to preserve the integrity of multi-byte UTF-8 sequences between triggers. This is both faster and correct.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -1353,31 +1353,45 @@ impl Iterator for PPLexer {
     }
 }
 
-/// Remove line splices (backslash followed by optional whitespace and newline) from text.
+/// ⚡ Bolt: Optimized and UTF-8-safe line splice removal.
+/// This uses memchr to fast-scan for backslashes and appends slices of the original
+/// string, which is both faster and correctly preserves multi-byte UTF-8 sequences.
 pub(crate) fn de_splice(raw: &str) -> String {
-    let mut result = String::with_capacity(raw.len());
     let bytes = raw.as_bytes();
+
+    let mut result = String::with_capacity(raw.len());
+    let mut last_end = 0;
     let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'\\' {
-            let mut j = i + 1;
-            // Skip whitespace after backslash
-            while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
-                j += 1;
-            }
-            if j < bytes.len() && (bytes[j] == b'\n' || bytes[j] == b'\r') {
-                // Line splice found!
-                if bytes[j] == b'\r' && j + 1 < bytes.len() && bytes[j + 1] == b'\n' {
-                    i = j + 2;
-                } else {
-                    i = j + 1;
-                }
-                continue;
-            }
+
+    while let Some(pos) = memchr::memchr(b'\\', &bytes[i..]) {
+        let backslash_pos = i + pos;
+
+        // Check if it's a splice: \ [ws] \n or \ [ws] \r [\n]
+        let mut j = backslash_pos + 1;
+        while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
+            j += 1;
         }
-        result.push(bytes[i] as char);
-        i += 1;
+
+        if j < bytes.len() && (bytes[j] == b'\n' || bytes[j] == b'\r') {
+            // Found a splice! Append the text before the backslash.
+            result.push_str(&raw[last_end..backslash_pos]);
+
+            // Skip the backslash and the newline (and optional whitespace)
+            if bytes[j] == b'\r' && j + 1 < bytes.len() && bytes[j + 1] == b'\n' {
+                i = j + 2;
+            } else {
+                i = j + 1;
+            }
+            last_end = i;
+        } else {
+            // Not a splice, just a regular backslash.
+            // Continue scanning after this backslash.
+            i = backslash_pos + 1;
+        }
     }
+
+    // Append the remaining part
+    result.push_str(&raw[last_end..]);
     result
 }
 
@@ -1433,6 +1447,27 @@ mod tests {
         let t1 = lexer.next_token().unwrap();
         assert!(matches!(t1.kind, PPTokenKind::Identifier(_)));
         assert_eq!(t1.get_text(), "abcdef");
+    }
+
+    #[test]
+    fn test_de_splice_utf8() {
+        // Simple case: no backslash
+        assert_eq!(de_splice("🦀"), "🦀");
+
+        // Simple splice
+        assert_eq!(de_splice("a\\\nb"), "ab");
+
+        // Splice with multi-byte UTF-8
+        assert_eq!(de_splice("🦀\\\n🐙"), "🦀🐙");
+
+        // Splice with whitespace and Windows line endings
+        assert_eq!(de_splice("abc\\  \r\ndef"), "abcdef");
+
+        // Regular backslash (not a splice)
+        assert_eq!(de_splice("a\\b"), "a\\b");
+
+        // Mixed
+        assert_eq!(de_splice("🦀\\\\\n🐙"), "🦀\\🐙");
     }
 
     #[test]


### PR DESCRIPTION
💡 What: Optimized the `de_splice` function in the preprocessor lexer and fixed a critical UTF-8 corruption bug.

🎯 Why: The original implementation iterated over bytes and cast them to `char`, which incorrectly zero-extended individual bytes of multi-byte UTF-8 sequences (like emojis or non-ASCII characters), leading to data corruption when line splices were present. Additionally, character-by-character processing was inefficient.

📊 Impact: 
- Fixed silent data corruption for UTF-8 characters in macro arguments and string literals.
- Improved performance of line splice removal by using `memchr` (SIMD-accelerated) and bulk string appends.
- Reduces CPU overhead in the preprocessor's token cleanup and stringification paths.

🔬 Measurement: 
- Verified with a repro script that multi-byte characters like "🦀" are now preserved correctly.
- Added unit test `test_de_splice_utf8` covering various scenarios.
- All 1500+ existing tests passed.

---
*PR created automatically by Jules for task [12416955336735449883](https://jules.google.com/task/12416955336735449883) started by @bungcip*