### PR TITLE
Systematic Cleanup of Unused Public APIs

### DIFF
--- a/src/ast/literal.rs
+++ b/src/ast/literal.rs
@@ -216,7 +216,7 @@ pub enum LitKind {
 }
 
 impl LitKind {
-    pub(crate) fn from_u8(v: u8) -> Self {
+    fn from_u8(v: u8) -> Self {
         match v {
             1 => Self::Float,
             2 => Self::Char,
@@ -430,7 +430,7 @@ impl LiteralTable {
 
 static LITERAL_TABLE: OnceLock<RwLock<LiteralTable>> = OnceLock::new();
 
-pub(crate) fn global_literal_table() -> &'static RwLock<LiteralTable> {
+fn global_literal_table() -> &'static RwLock<LiteralTable> {
     LITERAL_TABLE.get_or_init(|| RwLock::new(LiteralTable::default()))
 }
 

--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -136,7 +136,7 @@ impl<'a> MirGen<'a> {
         self.func_state.as_mut().expect("Not in a function")
     }
 
-    pub(super) fn get_func_info(&self) -> (MirFunctionId, Option<MirBlockId>) {
+    fn get_func_info(&self) -> (MirFunctionId, Option<MirBlockId>) {
         let state = self.func_state.as_ref().expect("Not in a function");
         (state.func_id, state.current_block)
     }
@@ -487,7 +487,7 @@ impl<'a> MirGen<'a> {
         self.visit_variable(sym, mir_type_id);
     }
 
-    pub(super) fn visit_variable(&mut self, sym: SymbolRef, mir_type_id: TypeId) {
+    fn visit_variable(&mut self, sym: SymbolRef, mir_type_id: TypeId) {
         let symbol = self.symbol_table.get_symbol(sym);
         let (is_global_sym, storage) = if let SymbolKind::Variable { is_global, storage, .. } = symbol.kind {
             (is_global, storage)
@@ -1905,7 +1905,7 @@ impl<'a> MirGen<'a> {
         Operand::Copy(Box::new(place))
     }
 
-    pub(super) fn try_fold_rvalue_to_const(&mut self, rvalue: &Rvalue, type_id: TypeId) -> Option<ConstValueId> {
+    fn try_fold_rvalue_to_const(&mut self, rvalue: &Rvalue, type_id: TypeId) -> Option<ConstValueId> {
         match rvalue {
             Rvalue::Use(op) => self.operand_to_const_id(op),
             Rvalue::StructLiteral(fields) => {
@@ -2108,7 +2108,7 @@ impl<'a> MirGen<'a> {
         self.visit_node(statement);
     }
 
-    pub(super) fn define_or_declare_function(
+    fn define_or_declare_function(
         &mut self,
         name: NameId,
         params: Vec<TypeId>,
@@ -2125,7 +2125,7 @@ impl<'a> MirGen<'a> {
         }
     }
 
-    pub(super) fn calculate_linkage(&self, storage: Option<StorageClass>, def_state: DefinitionState) -> MirLinkage {
+    fn calculate_linkage(&self, storage: Option<StorageClass>, def_state: DefinitionState) -> MirLinkage {
         if def_state == DefinitionState::DeclaredOnly {
             return MirLinkage::Import;
         }

--- a/src/driver/cli.rs
+++ b/src/driver/cli.rs
@@ -245,7 +245,7 @@ impl Cli {
     }
 
     /// Convert CLI arguments into compilation configuration
-    pub fn into_config(self) -> Result<CompileConfig, String> {
+    pub(crate) fn into_config(self) -> Result<CompileConfig, String> {
         // Validate input files first
         self.validate_input_files()?;
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -577,7 +577,7 @@ fn classify_punctuation(pp_token_kind: PPTokenKind) -> TokenKind {
 // pre-interns all keywords and stores them in a lazily-initialized `HashMap`.
 /// Subsequent lookups use the `StringId` directly, resulting in a much faster
 /// integer comparison instead of a string comparison.
-pub(crate) fn is_keyword(symbol: StringId, std: crate::lang_options::CStandard) -> Option<TokenKind> {
+fn is_keyword(symbol: StringId, std: crate::lang_options::CStandard) -> Option<TokenKind> {
     let kind = keyword_map().get(&symbol).copied()?;
 
     // C23 keywords: block certain spellings if standard is older than C23.

--- a/src/tests/pp_common.rs
+++ b/src/tests/pp_common.rs
@@ -66,10 +66,7 @@ pub(crate) fn setup_multi_file_pp_snapshot(
 }
 
 /// Helper function to set up preprocessor testing and return sm
-fn setup_pp_with_sm(
-    src: &str,
-    config: Option<PPConfig>,
-) -> Result<(Vec<DebugToken>, SourceManager), PPError> {
+fn setup_pp_with_sm(src: &str, config: Option<PPConfig>) -> Result<(Vec<DebugToken>, SourceManager), PPError> {
     let (tokens, sm, _) = setup_multi_file_pp_with_sm_and_diagnostics(vec![("<test>", src)], "<test>", config)?;
     Ok((tokens, sm))
 }

--- a/src/tests/pp_common.rs
+++ b/src/tests/pp_common.rs
@@ -14,7 +14,7 @@ pub struct DebugToken {
 }
 
 impl DebugToken {
-    pub fn from_token(token: &PPToken, sm: &SourceManager) -> Self {
+    pub(crate) fn from_token(token: &PPToken, sm: &SourceManager) -> Self {
         let name = token.kind.kind_name();
         let kind = if name.is_empty() {
             format!("{:?}", token.kind)
@@ -66,7 +66,7 @@ pub(crate) fn setup_multi_file_pp_snapshot(
 }
 
 /// Helper function to set up preprocessor testing and return sm
-pub(crate) fn setup_pp_with_sm(
+fn setup_pp_with_sm(
     src: &str,
     config: Option<PPConfig>,
 ) -> Result<(Vec<DebugToken>, SourceManager), PPError> {


### PR DESCRIPTION
Identified and downgraded visibility for multiple functions that were unnecessarily public or crate-public. Conducted a codebase-wide audit to ensure that only the intended public API in the `driver` module remains `pub`. This reduces technical debt and prevents accidental reliance on internal compiler implementation details by external consumers. All changes were verified through automated testing and manual usage analysis.

---
*PR created automatically by Jules for task [17643716402352723661](https://jules.google.com/task/17643716402352723661) started by @bungcip*