### PR TITLE
Implement C Digraph Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,23 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    if consume_if!(b'%') && consume_if!(b':') {
+                        return token!(PPTokenKind::HashHash, 4);
+                    }
+                    self.position = saved_pos;
+                    self.at_start_of_line = saved_at_start;
+
+                    let mut token_flags = flags;
+                    if is_at_start_of_line {
+                        token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                        self.in_directive_line = true;
+                    }
+                    token!(PPTokenKind::Hash, 2, token_flags)
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +506,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +569,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -589,13 +616,27 @@ impl PPLexer {
                 continue;
             }
 
-            // It's a newline. Consume it and check for '#' at the start of the next line.
+            // It's a newline. Consume it and check for '#' or '%:' at the start of the next line.
             self.next_char();
             self.skip_whitespace_and_comments();
 
-            if let Some(b'#') = self.peek_char() {
-                // Found a directive! Stop skipping.
-                break;
+            if let Some(next_c) = self.peek_char() {
+                if next_c == b'#' {
+                    // Found a directive! Stop skipping.
+                    break;
+                } else if next_c == b'%' {
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    self.next_char(); // consume '%'
+                    if self.peek_char() == Some(b':') {
+                        // Found a digraph directive '%:'! Stop skipping.
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+                        break;
+                    }
+                    self.position = saved_pos;
+                    self.at_start_of_line = saved_at_start;
+                }
             }
 
             // Not a directive, continue skipping from the current position.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,90 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::*;
+
+#[test]
+fn test_pp_digraphs_basic() {
+    // <:  -> [
+    // :>  -> ]
+    // <%  -> {
+    // %>  -> }
+    run_pass(
+        r#"
+        int main() <%
+            int arr<:5:>;
+            return 0;
+        %>
+        "#,
+        CompilePhase::Parse,
+    );
+}
+
+#[test]
+fn test_pp_digraph_directive() {
+    // %:  -> #
+    run_pass(
+        r#"
+        %:define FOO 42
+        int x = FOO;
+        "#,
+        CompilePhase::Parse,
+    );
+}
+
+#[test]
+fn test_pp_digraph_pasting() {
+    // %:%: -> ##
+    run_pass(
+        r#"
+        #define GLUE(a, b) a %:%: b
+        int GLUE(x, 1) = 42;
+        "#,
+        CompilePhase::Parse,
+    );
+}
+
+#[test]
+fn test_pp_digraph_hash_hash_mixed() {
+    run_pass(
+        r#"
+        #define GLUE1(a, b) a ## b
+        #define GLUE2(a, b) a %:%: b
+        int GLUE1(var, 1) = 1;
+        int GLUE2(var, 2) = 2;
+        "#,
+        CompilePhase::Parse,
+    );
+}
+
+#[test]
+fn test_pp_digraph_all() {
+    run_pass(
+        r#"
+        %:define STR(x) %:x
+        const char *s = STR(hello);
+
+        int main() <%
+            int a<:2:> = <% 1, 2 %>;
+            return 0;
+        %>
+        "#,
+        CompilePhase::Parse,
+    );
+}
+
+#[test]
+fn test_pp_digraph_skipping() {
+    run_pass(
+        r#"
+        #if 0
+        %:define FAKE
+        #endif
+
+        %:if 0
+        #define ALSO_FAKE
+        %:endif
+
+        int x = 0;
+        "#,
+        CompilePhase::Parse,
+    );
+}


### PR DESCRIPTION
Implemented all six C digraphs (<:, :>, <%, %>, %:, %:%:) in the preprocessor lexer. This includes support for digraphs in expressions, preprocessor directives (using %:), and token pasting (using %:%:). Updated the directive skipping logic to correctly handle digraph-based directives. Added comprehensive integration tests and updated documentation.

---
*PR created automatically by Jules for task [13572944196817867280](https://jules.google.com/task/13572944196817867280) started by @bungcip*