### PR TITLE
Implement C11 digraph support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Features**:
+  - Full C11 digraph support in the preprocessor and lexer (`<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`).
+
 ## [0.2.0] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Features
 
 - **Full C23 Preprocessor**: Complete preprocessor with macro expansion, conditional compilation, file inclusion, and built-in macros (`__FILE__`, `__LINE__`, etc.)
-- **Lexer**: Tokenization of C23 source code with proper handling of literals, keywords, and operators
+- **Lexer**: Tokenization of C23 source code with proper handling of literals, keywords, and operators, including full digraph support
 - **Parser**: Comprehensive C23 syntax parsing using Pratt parsing for expressions and recursive descent for statements
 - **Semantic Analysis**: Type checking, symbol resolution, and semantic validation
 - **Code Generation**: Compiles to native object code using Cranelift backend
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -425,6 +425,43 @@ impl PPLexer {
                     token!(PPTokenKind::Hash, 1, token_flags)
                 }
             }
+            b'%' => {
+                if consume_if!(b':') {
+                    let pos_after_colon = self.position;
+                    let at_start_after_colon = self.at_start_of_line;
+                    let has_splice_after_colon = self.has_splice;
+
+                    if consume_if!(b'%') {
+                        if consume_if!(b':') {
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            self.position = pos_after_colon;
+                            self.at_start_of_line = at_start_after_colon;
+                            self.has_splice = has_splice_after_colon;
+
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b'=') {
+                    token!(PPTokenKind::ModAssign, 2)
+                } else {
+                    token!(PPTokenKind::Percent, 1)
+                }
+            }
             b'+' => {
                 if consume_if!(b'+') {
                     token!(PPTokenKind::Increment, 2)
@@ -459,13 +496,6 @@ impl PPLexer {
                     token!(PPTokenKind::Slash, 1)
                 }
             }
-            b'%' => {
-                if consume_if!(b'=') {
-                    token!(PPTokenKind::ModAssign, 2)
-                } else {
-                    token!(PPTokenKind::Percent, 1)
-                }
-            }
             b'=' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::Equal, 2)
@@ -481,7 +511,11 @@ impl PPLexer {
                 }
             }
             b'<' => {
-                if consume_if!(b'<') {
+                if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
+                } else if consume_if!(b'<') {
                     if consume_if!(b'=') {
                         token!(PPTokenKind::LeftShiftAssign, 3)
                     } else {
@@ -548,7 +582,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -593,9 +633,23 @@ impl PPLexer {
             self.next_char();
             self.skip_whitespace_and_comments();
 
-            if let Some(b'#') = self.peek_char() {
-                // Found a directive! Stop skipping.
-                break;
+            if let Some(ch) = self.peek_char() {
+                if ch == b'#' {
+                    break;
+                }
+                if ch == b'%' {
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    self.next_char();
+                    if self.peek_char() == Some(b':') {
+                        // Found %: directive starter
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+                        break;
+                    }
+                    self.position = saved_pos;
+                    self.at_start_of_line = saved_at_start;
+                }
             }
 
             // Not a directive, continue skipping from the current position.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,78 @@
+use crate::pp::pp_lexer::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_basic_digraphs() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive_starter() {
+    let source = "%:define FOO 1\nFOO";
+    let tokens = setup_pp_snapshot(source);
+
+    // Should be expanded to 1
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Number
+      text: \"1\"
+    ");
+}
+
+#[test]
+fn test_digraph_fast_skip() {
+    let source = "
+%:if 0
+  this is skipped;
+%:else
+  this is not skipped
+%:endif
+";
+    let tokens = setup_pp_snapshot(source);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: this
+    - kind: Identifier
+      text: is
+    - kind: Identifier
+      text: not
+    - kind: Identifier
+      text: skipped
+    ");
+}
+
+#[test]
+fn test_digraph_token_pasting() {
+    let source = "#define PASTE(a, b) a %:%: b\nPASTE(x, y)";
+    let tokens = setup_pp_snapshot(source);
+
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: xy
+    ");
+}
+
+#[test]
+fn test_mixed_digraphs_and_punctuators() {
+    let source = "<% [ ] %>";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("{", PPTokenKind::LeftBrace),
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("}", PPTokenKind::RightBrace),
+    );
+}


### PR DESCRIPTION
Implemented full C11 digraph support in the preprocessor and lexer. Digraphs are correctly mapped to their punctuator equivalents, support directive initiation, and token pasting. Comprehensive tests and documentation updates are included.

---
*PR created automatically by Jules for task [12731335944785136583](https://jules.google.com/task/12731335944785136583) started by @bungcip*