### PR TITLE
Add test coverage for pedantic GNU statement expression warning

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -139,3 +139,4 @@ pub mod regr_shadowing;
 pub mod regr_struct_bitfield;
 pub mod semantic_alignof_expr;
 pub mod semantic_usual_arithmetic_conversions;
+pub mod semantic_pedantic_gnu_extensions;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -138,5 +138,5 @@ pub mod regr_sds_l1;
 pub mod regr_shadowing;
 pub mod regr_struct_bitfield;
 pub mod semantic_alignof_expr;
-pub mod semantic_usual_arithmetic_conversions;
 pub mod semantic_pedantic_gnu_extensions;
+pub mod semantic_usual_arithmetic_conversions;

--- a/src/tests/semantic_pedantic_gnu_extensions.rs
+++ b/src/tests/semantic_pedantic_gnu_extensions.rs
@@ -1,0 +1,20 @@
+use crate::diagnostic::DiagnosticLevel;
+
+#[test]
+fn test_gnu_statement_expression_warning() {
+    let source = r#"
+        int main() {
+            int x = ({ int y = 5; y; });
+            return x;
+        }
+    "#;
+    let mut config = crate::driver::cli::CompileConfig::from_virtual_file(
+        source.to_string(),
+        crate::driver::artifact::CompilePhase::SemanticLowering,
+    );
+    config.lang_options.pedantic = true;
+    let mut driver = crate::driver::compiler::CompilerDriver::from_config(config);
+    let _ = driver.run_pipeline(crate::driver::artifact::CompilePhase::SemanticLowering);
+    let diags = driver.get_diagnostics();
+    assert!(diags.iter().any(|d| d.message.contains("use of GNU statement expression extension") && d.level == DiagnosticLevel::Warning));
+}

--- a/src/tests/semantic_pedantic_gnu_extensions.rs
+++ b/src/tests/semantic_pedantic_gnu_extensions.rs
@@ -1,4 +1,4 @@
-use crate::diagnostic::DiagnosticLevel;
+use crate::tests::test_utils;
 
 #[test]
 fn test_gnu_statement_expression_warning() {
@@ -15,6 +15,5 @@ fn test_gnu_statement_expression_warning() {
     config.lang_options.pedantic = true;
     let mut driver = crate::driver::compiler::CompilerDriver::from_config(config);
     let _ = driver.run_pipeline(crate::driver::artifact::CompilePhase::SemanticLowering);
-    let diags = driver.get_diagnostics();
-    assert!(diags.iter().any(|d| d.message.contains("use of GNU statement expression extension") && d.level == DiagnosticLevel::Warning));
+    test_utils::check_diagnostic_message_only(&driver, "use of GNU statement expression extension");
 }


### PR DESCRIPTION
Adds a new test in `src/tests/semantic_pedantic_gnu_extensions.rs` to exercise the previously uncovered `SemanticError::GnuStatementExpression` code path when `config.lang_options.pedantic` is enabled. This increases coverage in `src/semantic/errors.rs`.

---
*PR created automatically by Jules for task [1085802358161049277](https://jules.google.com/task/1085802358161049277) started by @bungcip*