### PR TITLE
Implement C11 digraph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/design-document/preprocessor_design.md
+++ b/design-document/preprocessor_design.md
@@ -311,7 +311,7 @@ int x = invalid_syntax; // Error reported at original.c:51
 - **UTF-8 Only**: The preprocessor assumes and only supports UTF-8 encoded source files (no validation performed for performance)
 - **Direct Buffer Access**: Works directly with byte buffers from SourceManager, avoiding string conversions
 - **Unsafe UTF-8 Operations**: Uses `unsafe` operations assuming UTF-8 validity for maximum performance
-- **No Trigraph or Digraph Support**: Digraphs and Trigraphs are not supported. Trigraphs were officially removed in C23.
+- **No Trigraph Support**: Trigraphs are not supported. Trigraphs were officially removed in C23.
 
 ### Integration with Compiler Pipeline
 

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,36 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    if self.peek_char() == Some(b'%') {
+                        let saved_pos = self.position;
+                        let saved_at_start = self.at_start_of_line;
+                        self.next_char(); // consume second '%'
+                        if self.peek_char() == Some(b':') {
+                            self.next_char(); // consume second ':'
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            // It was %:%, which is not %:%:.
+                            // Lex it as Hash and leave second % for next token.
+                            self.position = saved_pos;
+                            self.at_start_of_line = saved_at_start;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +519,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +582,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -593,9 +633,42 @@ impl PPLexer {
             self.next_char();
             self.skip_whitespace_and_comments();
 
-            if let Some(b'#') = self.peek_char() {
-                // Found a directive! Stop skipping.
-                break;
+            if let Some(ch) = self.peek_char() {
+                if ch == b'#' {
+                    // Found a directive! Stop skipping.
+                    break;
+                } else if ch == b'%' {
+                    // Check for %: digraph but not %:%:
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    self.next_char(); // consume %
+                    if self.peek_char() == Some(b':') {
+                        self.next_char(); // consume :
+                        if self.peek_char() == Some(b'%') {
+                            self.next_char(); // consume second %
+                            if self.peek_char() == Some(b':') {
+                                // It was %:%:, not a directive.
+                                // Backtrack to after the newline (skip_whitespace_and_comments handles this)
+                                self.position = saved_pos;
+                                self.at_start_of_line = saved_at_start;
+                            } else {
+                                // It was %:%, which starts with %:. Found directive!
+                                self.position = saved_pos;
+                                self.at_start_of_line = saved_at_start;
+                                break;
+                            }
+                        } else {
+                            // Found %:! Directive!
+                            self.position = saved_pos;
+                            self.at_start_of_line = saved_at_start;
+                            break;
+                        }
+                    } else {
+                        // Not a digraph.
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+                    }
+                }
             }
 
             // Not a directive, continue skipping from the current position.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,97 @@
+use crate::pp::{PPTokenFlags, PPTokenKind};
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_digraphs_lexing() {
+    // <: -> [
+    // :> -> ]
+    // <% -> {
+    // %> -> }
+    // %: -> #
+    // %:%: -> ##
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_starts_pp_line() {
+    let source = "%:define FOO 1";
+    let mut lexer = create_test_pp_lexer(source);
+
+    let token = lexer.next_token().unwrap();
+    assert_eq!(token.kind, PPTokenKind::Hash);
+    assert!(token.flags.contains(PPTokenFlags::STARTS_PP_LINE));
+    assert_eq!(token.length, 2);
+
+    test_tokens!(
+        lexer,
+        ("define", PPTokenKind::Identifier(_)),
+        ("FOO", PPTokenKind::Identifier(_)),
+        ("1", PPTokenKind::Number),
+        ("", PPTokenKind::Eod),
+    );
+}
+
+#[test]
+fn test_digraph_not_starts_pp_line() {
+    let source = "int x; %:define FOO 1";
+    let mut lexer = create_test_pp_lexer(source);
+
+    let _ = lexer.next_token(); // int
+    let _ = lexer.next_token(); // x
+    let _ = lexer.next_token(); // ;
+
+    let token = lexer.next_token().unwrap();
+    assert_eq!(token.kind, PPTokenKind::Hash);
+    assert!(!token.flags.contains(PPTokenFlags::STARTS_PP_LINE));
+    assert_eq!(token.length, 2);
+}
+
+#[test]
+fn test_digraph_hashhash_length() {
+    let source = "%:%:";
+    let mut lexer = create_test_pp_lexer(source);
+    let token = lexer.next_token().unwrap();
+    assert_eq!(token.kind, PPTokenKind::HashHash);
+    assert_eq!(token.length, 4);
+}
+
+#[test]
+fn test_digraphs_in_macros() {
+    let src = r#"
+#define STR(x) %:x
+#define JOIN(x, y) x %:%: y
+
+STR(abc)
+JOIN(a, b)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_as_directive_start() {
+    let src = r#"
+%:ifdef UNDEFINED
+FAIL
+%:else
+OK
+%:endif
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: OK
+    ");
+}

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraphs_in_macros.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraphs_in_macros.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: StringLiteral
+  text: "\"abc\""
+- kind: Identifier
+  text: ab


### PR DESCRIPTION
I have implemented full support for C11 digraphs in the preprocessor. This includes:
- Updating the lexer to recognize all six digraphs and map them to the correct `PPTokenKind`.
- Correctly handling `%:` as a directive starter at the beginning of a line.
- Distinguishing between `%:` and `%:%:` (token pasting) even at the start of a line.
- Updating the optimized `fast_skip_to_directive` to recognize `%:`-started directives.
- Adding a new test suite `src/tests/pp_digraphs.rs` with snapshot and unit tests.
- Updating documentation to reflect that digraphs are now supported.

All tests passed, and code was verified with clippy and fmt.

---
*PR created automatically by Jules for task [10600436029294961915](https://jules.google.com/task/10600436029294961915) started by @bungcip*