### PR TITLE
feat: Implement C23 digraph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/design-document/preprocessor_design.md
+++ b/design-document/preprocessor_design.md
@@ -311,7 +311,7 @@ int x = invalid_syntax; // Error reported at original.c:51
 - **UTF-8 Only**: The preprocessor assumes and only supports UTF-8 encoded source files (no validation performed for performance)
 - **Direct Buffer Access**: Works directly with byte buffers from SourceManager, avoiding string conversions
 - **Unsafe UTF-8 Operations**: Uses `unsafe` operations assuming UTF-8 validity for maximum performance
-- **No Trigraph or Digraph Support**: Digraphs and Trigraphs are not supported. Trigraphs were officially removed in C23.
+- **No Trigraph Support**: Trigraphs are not supported. Trigraphs were officially removed in C23.
 
 ### Integration with Compiler Pipeline
 

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -462,6 +462,27 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let saved_pos = self.position;
+                    let saved_has_splice = self.has_splice;
+                    let saved_at_start = self.at_start_of_line;
+
+                    if consume_if!(b'%') && consume_if!(b':') {
+                        token!(PPTokenKind::HashHash, 4)
+                    } else {
+                        self.position = saved_pos;
+                        self.has_splice = saved_has_splice;
+                        self.at_start_of_line = saved_at_start;
+
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +510,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +573,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -589,13 +620,42 @@ impl PPLexer {
                 continue;
             }
 
-            // It's a newline. Consume it and check for '#' at the start of the next line.
+            // It's a newline. Consume it and check for '#' or '%:' at the start of the next line.
             self.next_char();
             self.skip_whitespace_and_comments();
 
             if let Some(b'#') = self.peek_char() {
                 // Found a directive! Stop skipping.
                 break;
+            }
+
+            if let Some(b'%') = self.peek_char() {
+                let saved_pos = self.position;
+                let saved_has_splice = self.has_splice;
+                let saved_at_start = self.at_start_of_line;
+
+                self.next_char();
+                if let Some(b':') = self.peek_char() {
+                    self.next_char();
+                    let is_hash_hash = if let Some(b'%') = self.peek_char() {
+                        self.next_char();
+                        self.peek_char() == Some(b':')
+                    } else {
+                        false
+                    };
+
+                    self.position = saved_pos;
+                    self.has_splice = saved_has_splice;
+                    self.at_start_of_line = saved_at_start;
+
+                    if !is_hash_hash {
+                        break;
+                    }
+                } else {
+                    self.position = saved_pos;
+                    self.has_splice = saved_has_splice;
+                    self.at_start_of_line = saved_at_start;
+                }
             }
 
             // Not a directive, continue skipping from the current position.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,78 @@
+use crate::pp::PPTokenKind;
+use crate::tests::pp_common::setup_pp_snapshot;
+
+// Helper to quickly assert token sequences from a source string.
+macro_rules! test_tokens {
+    ($source:expr, [$( ($kind:expr, $text:expr) ),* $(,)?]) => {
+        let tokens = setup_pp_snapshot($source);
+        let expected = vec![ $( ($kind, $text) ),* ];
+        assert_eq!(tokens.len(), expected.len(), "Token count mismatch");
+
+        for (i, (tok, (expected_kind, expected_text))) in tokens.iter().zip(expected.iter()).enumerate() {
+            assert_eq!(tok.kind, format!("{:?}", expected_kind), "Token kind mismatch at index {}", i);
+            assert_eq!(tok.text, *expected_text, "Token text mismatch at index {}", i);
+        }
+    };
+}
+
+#[test]
+fn test_digraph_punctuators() {
+    let source = "<: :> <% %> %: %:%:";
+
+    test_tokens!(
+        source,
+        [
+            (PPTokenKind::LeftBracket, "["),
+            (PPTokenKind::RightBracket, "]"),
+            (PPTokenKind::LeftBrace, "{"),
+            (PPTokenKind::RightBrace, "}"),
+            (PPTokenKind::Hash, "#"),
+            (PPTokenKind::HashHash, "##"),
+        ]
+    );
+}
+
+#[test]
+fn test_digraph_directives() {
+    let source = "
+%:define FOO 1
+%:if FOO
+int x = 42;
+%:endif
+";
+    let tokens = setup_pp_snapshot(source);
+
+    // The directive should be processed normally, so we only see the body tokens
+    assert_eq!(tokens.len(), 5);
+
+    // int x = 42 ;
+    let texts = vec!["int", "x", "=", "42", ";"];
+    for (i, text) in texts.iter().enumerate() {
+        assert_eq!(tokens[i].text, *text);
+    }
+}
+
+#[test]
+fn test_digraph_fast_skip() {
+    let source = "
+%:if 0
+  this is skipped;
+  int x = %:not_a_directive;
+  // %:fake directive in comment
+  %:if 1
+    nested skipped %:
+  %:endif
+%:else
+  int y = 1;
+%:endif
+";
+    let tokens = setup_pp_snapshot(source);
+
+    // Only "int y = 1;" should be returned
+    assert_eq!(tokens.len(), 5);
+
+    let texts = vec!["int", "y", "=", "1", ";"];
+    for (i, text) in texts.iter().enumerate() {
+        assert_eq!(tokens[i].text, *text);
+    }
+}


### PR DESCRIPTION
Implements support for C23 digraph sequences in the preprocessor lexer.

### Changes:
*   Added lexing support for digraphs (`<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) directly to their canonical `PPTokenKind` variants (e.g. `LeftBracket`, `Hash`).
*   Modified `fast_skip_to_directive` logic to accommodate `%:` for directive starting in disabled conditionals (`#if 0` -> `#else`/`#endif`).
*   Added the `pp_digraphs` test module to verify punctator conversion and directives that use `%:` and `%:%:`.
*   Removed limitations statements in documentation as the project now officially supports these sequences.

---
*PR created automatically by Jules for task [7532779707043822941](https://jules.google.com/task/7532779707043822941) started by @bungcip*