### PR TITLE
Implement digraph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 
 ## Features
 
-- **Full C23 Preprocessor**: Complete preprocessor with macro expansion, conditional compilation, file inclusion, and built-in macros (`__FILE__`, `__LINE__`, etc.)
+- **Full C23 Preprocessor**: Complete preprocessor with macro expansion, conditional compilation, file inclusion, built-in macros (`__FILE__`, `__LINE__`, etc.), and digraph support
 - **Lexer**: Tokenization of C23 source code with proper handling of literals, keywords, and operators
 - **Parser**: Comprehensive C23 syntax parsing using Pratt parsing for expressions and recursive descent for statements
 - **Semantic Analysis**: Type checking, symbol resolution, and semantic validation
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -459,13 +459,6 @@ impl PPLexer {
                     token!(PPTokenKind::Slash, 1)
                 }
             }
-            b'%' => {
-                if consume_if!(b'=') {
-                    token!(PPTokenKind::ModAssign, 2)
-                } else {
-                    token!(PPTokenKind::Percent, 1)
-                }
-            }
             b'=' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::Equal, 2)
@@ -489,6 +482,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -531,6 +528,32 @@ impl PPLexer {
                     token!(PPTokenKind::Xor, 1)
                 }
             }
+            b'%' => {
+                if consume_if!(b'=') {
+                    token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b':') {
+                    // Check for %:%: digraph for ##
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    if consume_if!(b'%') && consume_if!(b':') {
+                        token!(PPTokenKind::HashHash, 4)
+                    } else {
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else {
+                    token!(PPTokenKind::Percent, 1)
+                }
+            }
             b'~' => token!(PPTokenKind::Tilde, 1),
             b'.' => 'ellipsis: {
                 let pos_after_first = self.position;
@@ -548,7 +571,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -593,9 +622,21 @@ impl PPLexer {
             self.next_char();
             self.skip_whitespace_and_comments();
 
-            if let Some(b'#') = self.peek_char() {
-                // Found a directive! Stop skipping.
-                break;
+            match self.peek_char() {
+                Some(b'#') => break,
+                Some(b'%') => {
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    self.next_char(); // consume %
+                    if self.peek_char() == Some(b':') {
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+                        break;
+                    }
+                    self.position = saved_pos;
+                    self.at_start_of_line = saved_at_start;
+                }
+                _ => {}
             }
 
             // Not a directive, continue skipping from the current position.
@@ -718,7 +759,7 @@ impl PPLexer {
             b'0'..=b'9' => Some(self.lex_number(start_pos, ch, flags)),
             b'"' => Some(self.lex_string_literal(start_pos, &[ch], flags)),
             b'\'' => Some(self.lex_char_literal(start_pos, &[ch], flags)),
-            b'#' | b'%' => Some(self.lex_operator(start_pos, ch, flags)),
+            b'#' | b'%' | b':' => Some(self.lex_operator(start_pos, ch, flags)),
             b'.' => {
                 if let Some(next_ch) = self.peek_char()
                     && next_ch.is_ascii_digit()
@@ -729,8 +770,8 @@ impl PPLexer {
                 }
             }
             // All operators and punctuation are handled by the optimized helper function.
-            b'+' | b'-' | b'*' | b'/' | b'=' | b'!' | b'<' | b'>' | b'&' | b'|' | b'^' | b'~' | b'?' | b':' | b','
-            | b';' | b'(' | b')' | b'[' | b']' | b'{' | b'}' => Some(self.lex_operator(start_pos, ch, flags)),
+            b'+' | b'-' | b'*' | b'/' | b'=' | b'!' | b'<' | b'>' | b'&' | b'|' | b'^' | b'~' | b'?' | b',' | b';'
+            | b'(' | b')' | b'[' | b']' | b'{' | b'}' => Some(self.lex_operator(start_pos, ch, flags)),
             _ => Some(PPToken::new(
                 PPTokenKind::Unknown,
                 flags,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_features;
 pub mod pp_includes;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,84 @@
+use crate::pp::{PPTokenFlags, PPTokenKind};
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_digraph_lexing() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_at_start_of_line() {
+    let source = "%:define X 1";
+    let mut lexer = create_test_pp_lexer(source);
+
+    let token = lexer.next_token().unwrap();
+    assert_eq!(token.kind, PPTokenKind::Hash);
+    assert!(token.flags.contains(PPTokenFlags::STARTS_PP_LINE));
+
+    test_tokens!(
+        lexer,
+        ("define", PPTokenKind::Identifier(_)),
+        ("X", PPTokenKind::Identifier(_)),
+        ("1", PPTokenKind::Number),
+    );
+}
+
+#[test]
+fn test_digraph_hash_hash_concatenation() {
+    let src = r#"
+#define CONCAT(a, b) a %:%: b
+CONCAT(foo, bar)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: foobar
+    ");
+}
+
+#[test]
+fn test_digraph_hash_stringification() {
+    let src = r#"
+#define STR(x) %:x
+STR(hello)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: StringLiteral
+      text: "\"hello\""
+    "#);
+}
+
+#[test]
+fn test_mixed_digraphs_and_standard() {
+    let source = "<% [ ] %>";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("{", PPTokenKind::LeftBrace),
+        ("[", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("}", PPTokenKind::RightBrace),
+    );
+}
+
+#[test]
+fn test_digraph_regression_percent_colon_not_hash() {
+    let source = "% :"; // with space
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(lexer, ("%", PPTokenKind::Percent), (":", PPTokenKind::Colon),);
+}


### PR DESCRIPTION
Implemented full digraph support in the Cendol C23 compiler, covering all six standard digraphs. Updated the preprocessor's lexer and directive skipping logic to handle digraph-based directives and macro operators. Comprehensive unit tests were added and verified.

---
*PR created automatically by Jules for task [6957271271332943283](https://jules.google.com/task/6957271271332943283) started by @bungcip*