### PR TITLE
Implement C23 #embed preprocessor directive

### DIFF
--- a/src/pp/directives.rs
+++ b/src/pp/directives.rs
@@ -101,6 +101,7 @@ impl<'src> Preprocessor<'src> {
             DirectiveKind::Pragma => self.handle_pragma(),
             DirectiveKind::Error => self.handle_error(),
             DirectiveKind::Warning => self.handle_warning(),
+            DirectiveKind::Embed => self.handle_embed(),
             _ => unreachable!("ICE: Conditional directives handled separately"),
         }
     }
@@ -296,11 +297,11 @@ impl<'src> Preprocessor<'src> {
 
         let (path_str, is_angled) = match tokens[0].kind {
             PPTokenKind::StringLiteral | PPTokenKind::Less => {
-                self.parse_include_path_tokens(&tokens, first_token.location)?
+                self.parse_include_path_tokens(&tokens, first_token.location, false)?
             }
             _ => {
                 self.expand_tokens(&mut tokens, false)?;
-                self.parse_include_path_tokens(&tokens, first_token.location)?
+                self.parse_include_path_tokens(&tokens, first_token.location, false)?
             }
         };
 
@@ -327,7 +328,12 @@ impl<'src> Preprocessor<'src> {
         Ok(())
     }
 
-    fn parse_include_path_tokens(&self, tokens: &[PPToken], diag_loc: SourceLoc) -> Result<(String, bool), PPError> {
+    fn parse_include_path_tokens(
+        &self,
+        tokens: &[PPToken],
+        diag_loc: SourceLoc,
+        allow_extra: bool,
+    ) -> Result<(String, bool), PPError> {
         if tokens.is_empty() {
             return self.emit_error(PPErrorKind::InvalidIncludePath, diag_loc);
         }
@@ -335,7 +341,7 @@ impl<'src> Preprocessor<'src> {
         let first = &tokens[0];
         match first.kind {
             PPTokenKind::StringLiteral => {
-                if tokens.len() > 1 {
+                if !allow_extra && tokens.len() > 1 {
                     return self.emit_error(PPErrorKind::ExpectedEod, tokens[1].location);
                 }
                 let text = self.get_token_text(first);
@@ -353,7 +359,7 @@ impl<'src> Preprocessor<'src> {
                     }
                 }
                 let idx = greater_idx.ok_or_else(|| self.error(PPErrorKind::InvalidIncludePath, diag_loc))?;
-                if idx + 1 < tokens.len() {
+                if !allow_extra && idx + 1 < tokens.len() {
                     return self.emit_error(PPErrorKind::ExpectedEod, tokens[idx + 1].location);
                 }
                 let path_parts = &tokens[1..idx];
@@ -369,6 +375,94 @@ impl<'src> Preprocessor<'src> {
 
     fn handle_include_next(&mut self) -> Result<(), PPError> {
         self.do_handle_include(true)
+    }
+
+    fn handle_embed(&mut self) -> Result<(), PPError> {
+        let first_token = self.expect_token()?;
+
+        let mut tokens = std::iter::once(first_token)
+            .chain(self.collect_tokens_until_eod())
+            .collect::<Vec<_>>();
+
+        if !matches!(tokens[0].kind, PPTokenKind::StringLiteral | PPTokenKind::Less) {
+            self.expand_tokens(&mut tokens, false)?;
+        }
+
+        let (path_str, is_angled) = self.parse_include_path_tokens(&tokens, first_token.location, true)?;
+
+        let mut limit = None;
+        let mut i = if is_angled {
+            tokens
+                .iter()
+                .position(|t| t.kind == PPTokenKind::Greater)
+                .ok_or_else(|| self.error(PPErrorKind::InvalidIncludePath, first_token.location))?
+                + 1
+        } else {
+            1
+        };
+
+        while i < tokens.len() {
+            let t = &tokens[i];
+            if let PPTokenKind::Identifier(sym) = t.kind
+                && sym.as_str() == "limit"
+            {
+                i += 1;
+                if i < tokens.len() && tokens[i].kind == PPTokenKind::LeftParen {
+                    i += 1;
+                    if i < tokens.len() && tokens[i].kind == PPTokenKind::Number {
+                        let text = self.get_token_text(&tokens[i]);
+                        limit = Some(
+                            text.parse::<usize>()
+                                .map_err(|_| self.error(PPErrorKind::InvalidDirective, tokens[i].location))?,
+                        );
+                        i += 1;
+                    } else {
+                        let loc = if i < tokens.len() {
+                            tokens[i].location
+                        } else {
+                            t.location
+                        };
+                        return self.emit_error(PPErrorKind::InvalidDirective, loc);
+                    }
+
+                    if i < tokens.len() && tokens[i].kind == PPTokenKind::RightParen {
+                        i += 1;
+                    } else {
+                        return self.emit_error(PPErrorKind::InvalidDirective, t.location);
+                    }
+                } else {
+                    return self.emit_error(PPErrorKind::InvalidDirective, t.location);
+                }
+                continue;
+            }
+            i += 1;
+        }
+
+        let include_source_id = self.resolve_include_path(&path_str, is_angled, first_token.location)?;
+        let buffer = self.sm.get_buffer_arc(include_source_id);
+
+        let bytes_to_embed = if let Some(l) = limit {
+            buffer.len().min(l)
+        } else {
+            buffer.len()
+        };
+
+        if bytes_to_embed == 0 {
+            return Ok(());
+        }
+
+        let mut embed_text = String::with_capacity(bytes_to_embed * 4);
+        for (idx, &byte) in buffer[..bytes_to_embed].iter().enumerate() {
+            if idx > 0 {
+                embed_text.push_str(", ");
+            }
+            embed_text.push_str(&byte.to_string());
+        }
+
+        let (embed_tokens, _) = self.tokenize_synthetic(&embed_text, "<embed>", FileKind::MacroExpansion);
+        self.pending_tokens.extend(embed_tokens.into_iter().rev());
+
+        Ok(())
     }
 
     fn resolve_include_path(&mut self, path: &str, is_angled: bool, loc: SourceLoc) -> Result<SourceId, PPError> {

--- a/src/pp/keyword_table.rs
+++ b/src/pp/keyword_table.rs
@@ -19,6 +19,7 @@ pub enum DirectiveKind {
     Pragma,
     Error,
     Warning,
+    Embed,
 }
 
 /// Table of pre-interned preprocessor keywords for O(1) identification
@@ -40,6 +41,7 @@ pub struct PPKeywordTable {
     pub(crate) pragma: StringId,
     pub(crate) error: StringId,
     pub(crate) warning: StringId,
+    pub(crate) embed: StringId,
     pub(crate) defined: StringId, // For the defined operator in expressions
     pub(crate) has_include: StringId,
     pub(crate) has_include_next: StringId,
@@ -158,6 +160,7 @@ impl PPKeywordTable {
             pragma: StringId::new("pragma"),
             error: StringId::new("error"),
             warning: StringId::new("warning"),
+            embed: StringId::new("embed"),
             defined: StringId::new("defined"),
             has_include: StringId::new("__has_include"),
             has_include_next: StringId::new("__has_include_next"),
@@ -285,6 +288,8 @@ impl PPKeywordTable {
             Some(DirectiveKind::Error)
         } else if symbol == self.warning {
             Some(DirectiveKind::Warning)
+        } else if symbol == self.embed {
+            Some(DirectiveKind::Embed)
         } else {
             None
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,6 +18,7 @@ pub mod driver_source_manager;
 pub mod pp_common;
 pub mod pp_conditionals;
 pub mod pp_directives;
+pub mod pp_embed;
 pub mod pp_features;
 pub mod pp_includes;
 pub mod pp_internal;

--- a/src/tests/pp_embed.rs
+++ b/src/tests/pp_embed.rs
@@ -1,0 +1,122 @@
+use crate::diagnostic::DiagnosticEngine;
+use crate::pp::PPTokenKind;
+use crate::pp::preprocessor::Preprocessor;
+use crate::pp::types::PPConfig;
+use crate::source_manager::SourceManager;
+
+#[test]
+fn test_embed_basic() {
+    let source = r#"
+#embed "test.bin"
+"#;
+    let mut sm = SourceManager::new();
+    let mut diag = DiagnosticEngine::default();
+    let config = PPConfig::default();
+
+    // The source itself must be added to SourceManager
+    let source_id = sm.add_buffer(
+        source.as_bytes().to_vec(),
+        "main.c",
+        None,
+        crate::source_manager::FileKind::Real,
+    );
+
+    // Add the file to be embedded
+    sm.add_buffer(vec![1, 2, 3], "test.bin", None, crate::source_manager::FileKind::Real);
+
+    let mut pp = Preprocessor::new(&mut sm, &mut diag, &config);
+    let tokens = pp.process(source_id, &config).unwrap();
+
+    let kinds: Vec<_> = tokens.iter().map(|t| t.kind).collect();
+    // 1, Comma, 2, Comma, 3, Eof
+    assert_eq!(kinds.len(), 6);
+    assert!(matches!(kinds[0], PPTokenKind::Number));
+    assert!(matches!(kinds[1], PPTokenKind::Comma));
+    assert!(matches!(kinds[2], PPTokenKind::Number));
+    assert!(matches!(kinds[3], PPTokenKind::Comma));
+    assert!(matches!(kinds[4], PPTokenKind::Number));
+    assert!(matches!(kinds[5], PPTokenKind::Eof));
+}
+
+#[test]
+fn test_embed_limit() {
+    let source = r#"
+#embed "test.bin" limit(2)
+"#;
+    let mut sm = SourceManager::new();
+    let mut diag = DiagnosticEngine::default();
+    let config = PPConfig::default();
+
+    let source_id = sm.add_buffer(
+        source.as_bytes().to_vec(),
+        "main.c",
+        None,
+        crate::source_manager::FileKind::Real,
+    );
+    sm.add_buffer(
+        vec![1, 2, 3, 4],
+        "test.bin",
+        None,
+        crate::source_manager::FileKind::Real,
+    );
+
+    let mut pp = Preprocessor::new(&mut sm, &mut diag, &config);
+    let tokens = pp.process(source_id, &config).unwrap();
+
+    let kinds: Vec<_> = tokens.iter().map(|t| t.kind).collect();
+    // 1, Comma, 2, Eof
+    assert_eq!(kinds.len(), 4);
+    assert!(matches!(kinds[0], PPTokenKind::Number));
+    assert!(matches!(kinds[1], PPTokenKind::Comma));
+    assert!(matches!(kinds[2], PPTokenKind::Number));
+    assert!(matches!(kinds[3], PPTokenKind::Eof));
+}
+
+#[test]
+fn test_embed_not_found() {
+    let source = r#"
+#embed "nonexistent.bin"
+"#;
+    let mut sm = SourceManager::new();
+    let mut diag = DiagnosticEngine::default();
+    let config = PPConfig::default();
+
+    let source_id = sm.add_buffer(
+        source.as_bytes().to_vec(),
+        "main.c",
+        None,
+        crate::source_manager::FileKind::Real,
+    );
+
+    let mut pp = Preprocessor::new(&mut sm, &mut diag, &config);
+    let result = pp.process(source_id, &config);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_embed_macro() {
+    let source = r#"
+#define FILE "test.bin"
+#embed FILE
+"#;
+    let mut sm = SourceManager::new();
+    let mut diag = DiagnosticEngine::default();
+    let config = PPConfig::default();
+
+    let source_id = sm.add_buffer(
+        source.as_bytes().to_vec(),
+        "main.c",
+        None,
+        crate::source_manager::FileKind::Real,
+    );
+    sm.add_buffer(vec![42], "test.bin", None, crate::source_manager::FileKind::Real);
+
+    let mut pp = Preprocessor::new(&mut sm, &mut diag, &config);
+    let tokens = pp.process(source_id, &config).unwrap();
+
+    let kinds: Vec<_> = tokens.iter().map(|t| t.kind).collect();
+    // 42, Eof
+    assert_eq!(kinds.len(), 2);
+    assert!(matches!(kinds[0], PPTokenKind::Number));
+    assert!(matches!(kinds[1], PPTokenKind::Eof));
+}


### PR DESCRIPTION
Implement the C23 #embed preprocessor directive, including support for the limit(N) parameter and macro expansion of arguments. Added unit tests and ensured robust handling of malformed input.

---
*PR created automatically by Jules for task [2119730798131852079](https://jules.google.com/task/2119730798131852079) started by @bungcip*