### PR TITLE
Implement C11 Digraph Support

### DIFF
--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -87,15 +87,15 @@ pub enum PPTokenKind {
 impl PPTokenKind {
     pub(crate) fn get_fixed_text(&self) -> Option<&'static str> {
         match self {
-            PPTokenKind::Hash => Some("#"),
-            PPTokenKind::HashHash => Some("##"),
+            PPTokenKind::Hash => None,
+            PPTokenKind::HashHash => None,
             PPTokenKind::Comma => Some(","),
             PPTokenKind::LeftParen => Some("("),
             PPTokenKind::RightParen => Some(")"),
-            PPTokenKind::LeftBracket => Some("["),
-            PPTokenKind::RightBracket => Some("]"),
-            PPTokenKind::LeftBrace => Some("{"),
-            PPTokenKind::RightBrace => Some("}"),
+            PPTokenKind::LeftBracket => None,
+            PPTokenKind::RightBracket => None,
+            PPTokenKind::LeftBrace => None,
+            PPTokenKind::RightBrace => None,
             PPTokenKind::Semicolon => Some(";"),
             PPTokenKind::Plus => Some("+"),
             PPTokenKind::Minus => Some("-"),
@@ -462,6 +462,36 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let pos_after_first = self.position;
+                    let at_start_after_first = self.at_start_of_line;
+                    let has_splice_after_first = self.has_splice;
+                    if self.peek_char() == Some(b'%') {
+                        self.next_char();
+                        if self.peek_char() == Some(b':') {
+                            self.next_char();
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            self.position = pos_after_first;
+                            self.at_start_of_line = at_start_after_first;
+                            self.has_splice = has_splice_after_first;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +519,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -535,6 +569,7 @@ impl PPLexer {
             b'.' => 'ellipsis: {
                 let pos_after_first = self.position;
                 let at_start_after_first = self.at_start_of_line;
+                let has_splice_after_first = self.has_splice;
                 if self.peek_char() == Some(b'.') {
                     self.next_char(); // Consume second '.'
                     if self.peek_char() == Some(b'.') {
@@ -544,11 +579,18 @@ impl PPLexer {
                     // It was '..', which is not a valid C token. Backtrack to handle it as a single '.'
                     self.position = pos_after_first;
                     self.at_start_of_line = at_start_after_first;
+                    self.has_splice = has_splice_after_first;
                 }
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),
@@ -593,9 +635,26 @@ impl PPLexer {
             self.next_char();
             self.skip_whitespace_and_comments();
 
-            if let Some(b'#') = self.peek_char() {
-                // Found a directive! Stop skipping.
-                break;
+            if let Some(ch) = self.peek_char() {
+                if ch == b'#' {
+                    // Found a directive! Stop skipping.
+                    break;
+                } else if ch == b'%' {
+                    // Check for digraph %:
+                    let saved_pos = self.position;
+                    let saved_at_start = self.at_start_of_line;
+                    let saved_has_splice = self.has_splice;
+                    self.next_char();
+                    if self.peek_char() == Some(b':') {
+                        self.position = saved_pos;
+                        self.at_start_of_line = saved_at_start;
+                        self.has_splice = saved_has_splice;
+                        break;
+                    }
+                    self.position = saved_pos;
+                    self.at_start_of_line = saved_at_start;
+                    self.has_splice = saved_has_splice;
+                }
             }
 
             // Not a directive, continue skipping from the current position.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_embed;
 pub mod pp_features;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,88 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_all_digraph_tokens() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("%:", PPTokenKind::Hash),
+        ("%:%:", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive() {
+    let src = r#"
+%:define FOO 1
+%:if FOO
+OK
+%:endif
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_pasting() {
+    let src = r#"
+#define PASTE(a, b) a %:%: b
+int PASTE(x, y) = 42;
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_stringification() {
+    let src = r#"
+#define STR(x) %:x
+char *s = STR(<: :>);
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_mixed_with_standard() {
+    let source = "<: ] { %> # %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("%:%:", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_fast_skip() {
+    let src = r#"
+#if 0
+  %:define SHOULD_NOT_HAPPEN
+#else
+  OK
+#endif
+"#;
+    let tokens = setup_pp_snapshot(src);
+    insta::assert_yaml_snapshot!(tokens);
+}
+
+#[test]
+fn test_digraph_not_pasting() {
+    // %:%: is ##, but %: followed by something else is just # followed by that thing
+    let source = "%:%";
+    let mut lexer = create_test_pp_lexer(source);
+    test_tokens!(lexer, ("%:", PPTokenKind::Hash), ("%", PPTokenKind::Percent),);
+}

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_directive.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_directive.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Identifier
+  text: OK

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_fast_skip.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_fast_skip.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Identifier
+  text: OK

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_pasting.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_pasting.snap
@@ -1,0 +1,14 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Identifier
+  text: int
+- kind: Identifier
+  text: xy
+- kind: Assign
+  text: "="
+- kind: Number
+  text: "42"
+- kind: Semicolon
+  text: ;

--- a/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_stringification.snap
+++ b/src/tests/snapshots/cendol__tests__pp_digraphs__digraph_stringification.snap
@@ -1,0 +1,16 @@
+---
+source: src/tests/pp_digraphs.rs
+expression: tokens
+---
+- kind: Identifier
+  text: char
+- kind: Star
+  text: "*"
+- kind: Identifier
+  text: s
+- kind: Assign
+  text: "="
+- kind: StringLiteral
+  text: "\"<: :>\""
+- kind: Semicolon
+  text: ;


### PR DESCRIPTION
Implement C11 digraph support in the preprocessor. This includes tokenization of all digraph sequences, support for digraphs in preprocessor directives (e.g., `%:define`), and ensuring that the original digraph spelling is preserved during macro stringification. Comprehensive unit tests and regression checks were performed.

---
*PR created automatically by Jules for task [6910698351540511517](https://jules.google.com/task/6910698351540511517) started by @bungcip*