### PR TITLE
Implement C11 digraph support

### DIFF
--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -87,15 +87,19 @@ pub enum PPTokenKind {
 impl PPTokenKind {
     pub(crate) fn get_fixed_text(&self) -> Option<&'static str> {
         match self {
-            PPTokenKind::Hash => Some("#"),
-            PPTokenKind::HashHash => Some("##"),
+            // ⚡ Bolt: Punctuators that have digraph equivalents (e.g. #, [, {)
+            // must NOT have fixed text, so that the preprocessor uses the
+            // original source text for stringification and other operations.
+            PPTokenKind::Hash
+            | PPTokenKind::HashHash
+            | PPTokenKind::LeftBracket
+            | PPTokenKind::RightBracket
+            | PPTokenKind::LeftBrace
+            | PPTokenKind::RightBrace => None,
+
             PPTokenKind::Comma => Some(","),
             PPTokenKind::LeftParen => Some("("),
             PPTokenKind::RightParen => Some(")"),
-            PPTokenKind::LeftBracket => Some("["),
-            PPTokenKind::RightBracket => Some("]"),
-            PPTokenKind::LeftBrace => Some("{"),
-            PPTokenKind::RightBrace => Some("}"),
             PPTokenKind::Semicolon => Some(";"),
             PPTokenKind::Plus => Some("+"),
             PPTokenKind::Minus => Some("-"),
@@ -462,6 +466,34 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    if self.peek_char() == Some(b'%') {
+                        let saved_pos = self.position;
+                        let saved_at_start = self.at_start_of_line;
+                        self.next_char();
+                        if consume_if!(b':') {
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            // Backtrack to after %:
+                            self.position = saved_pos;
+                            self.at_start_of_line = saved_at_start;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +521,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +584,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_embed;
 pub mod pp_features;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,65 @@
+use crate::pp::pp_lexer::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::*;
+
+#[test]
+fn test_digraphs_basic() {
+    let mut lexer = create_test_pp_lexer("<: :> <% %> %: %:%:");
+
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("%:", PPTokenKind::Hash),
+        ("%:%:", PPTokenKind::HashHash)
+    );
+}
+
+#[test]
+fn test_digraph_directive() {
+    let source = "%:define FOO 1\nFOO";
+    let tokens = setup_pp_snapshot(source);
+
+    // After expansion, it should just be "1"
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].text, "1");
+}
+
+#[test]
+fn test_digraph_stringification() {
+    let source = "#define STR(x) #x\nSTR(<: :>)";
+    let tokens = setup_pp_snapshot(source);
+
+    assert_eq!(tokens.len(), 1);
+    // The stringified version should contain the original spelling
+    assert_eq!(tokens[0].text, "\"<: :>\"");
+}
+
+#[test]
+fn test_digraph_edge_cases() {
+    let mut lexer = create_test_pp_lexer("%:% :");
+
+    test_tokens!(
+        lexer,
+        ("%:", PPTokenKind::Hash),
+        ("%", PPTokenKind::Percent),
+        (":", PPTokenKind::Colon)
+    );
+}
+
+#[test]
+fn test_digraph_not_pasting() {
+    let mut lexer = create_test_pp_lexer("%: %:");
+
+    test_tokens!(lexer, ("%:", PPTokenKind::Hash), ("%:", PPTokenKind::Hash));
+}
+
+#[test]
+fn test_digraph_in_macro() {
+    let source = "#define LBRACK <: \n LBRACK";
+    let tokens = setup_pp_snapshot(source);
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].text, "<:");
+}


### PR DESCRIPTION
Implemented C11 digraph support in the preprocessor lexer, added unit tests, and verified with manual and automated checks.

---
*PR created automatically by Jules for task [14013517875883500572](https://jules.google.com/task/14013517875883500572) started by @bungcip*