### PR TITLE
⚡ Bolt: Optimize parser token cache using Vec

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,8 +4,6 @@
 //! It orchestrates the parsing process by delegating to specialized sub-modules for
 //! different language constructs.
 
-use std::collections::VecDeque;
-
 use crate::ast::literal::{LitKind, LitRef};
 use crate::ast::*;
 use crate::diagnostic::{DiagnosticEngine, ParseError, ParseErrorKind};
@@ -109,7 +107,7 @@ pub struct Parser<'arena, 'src, 'lexer> {
     pub(crate) lang_opts: &'src crate::lang_options::LangOptions,
 
     // Token caching for lookahead and backtracking
-    pub(crate) token_cache: VecDeque<Token>,
+    pub(crate) token_cache: Vec<Token>,
 
     // Type context for typedef tracking
     pub(crate) type_context: TypeDefContext,
@@ -154,7 +152,7 @@ impl<'arena, 'src, 'lexer> Parser<'arena, 'src, 'lexer> {
             current_idx: 0,
             ast,
             lang_opts,
-            token_cache: VecDeque::new(),
+            token_cache: Vec::new(),
             type_context: TypeDefContext::new(),
             keywords: ParserKeywords::new(),
             in_enum_underlying_type: false,
@@ -176,13 +174,13 @@ impl<'arena, 'src, 'lexer> Parser<'arena, 'src, 'lexer> {
         while self.token_cache.len() <= index {
             match self.lexer.next_token() {
                 Ok(Some(token)) => {
-                    self.token_cache.push_back(token);
+                    self.token_cache.push(token);
                 }
                 Ok(None) => break,
                 Err(e) => {
                     self.lexer.preprocessor.diag.report(e);
-                    let span = self.token_cache.back().map(|t| t.span).unwrap_or_default();
-                    self.token_cache.push_back(Token {
+                    let span = self.token_cache.last().map(|t| t.span).unwrap_or_default();
+                    self.token_cache.push(Token {
                         kind: TokenKind::EndOfFile,
                         span,
                     });


### PR DESCRIPTION
### 💡 What: The optimization implemented
Changed `Parser::token_cache` from `VecDeque<Token>` to `Vec<Token>`.

### 🎯 Why: The performance problem it solves
The `token_cache` was using a `VecDeque` even though it was only ever used for appending and indexed access. `VecDeque` has more overhead than a simple `Vec` due to its ring-buffer implementation and potential non-contiguous memory layout. In the parser's hot path, this adds unnecessary branching and potential cache misses.

### 📊 Impact: Expected performance improvement
Small reduction in memory overhead and faster token retrieval during lookahead/backtracking. While micro-level, these savings aggregate across large translation units like the SQLite amalgamation.

### 🔬 Measurement: How to verify the improvement
Verified that `token_cache` is never popped or shifted using `grep`.
Ran `cargo test` and `cargo bench --bench compiler_benches`.
Performance remains stable with slightly improved consistency in the parser stage.

---
*PR created automatically by Jules for task [6675625236216300954](https://jules.google.com/task/6675625236216300954) started by @bungcip*