### PR TITLE
Implement C11 Digraph Support

### DIFF
--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -87,15 +87,15 @@ pub enum PPTokenKind {
 impl PPTokenKind {
     pub(crate) fn get_fixed_text(&self) -> Option<&'static str> {
         match self {
-            PPTokenKind::Hash => Some("#"),
-            PPTokenKind::HashHash => Some("##"),
+            PPTokenKind::Hash
+            | PPTokenKind::HashHash
+            | PPTokenKind::LeftBracket
+            | PPTokenKind::RightBracket
+            | PPTokenKind::LeftBrace
+            | PPTokenKind::RightBrace => None,
             PPTokenKind::Comma => Some(","),
             PPTokenKind::LeftParen => Some("("),
             PPTokenKind::RightParen => Some(")"),
-            PPTokenKind::LeftBracket => Some("["),
-            PPTokenKind::RightBracket => Some("]"),
-            PPTokenKind::LeftBrace => Some("{"),
-            PPTokenKind::RightBrace => Some("}"),
             PPTokenKind::Semicolon => Some(";"),
             PPTokenKind::Plus => Some("+"),
             PPTokenKind::Minus => Some("-"),
@@ -462,6 +462,23 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let pos_after = self.position;
+                    let sol_after = self.at_start_of_line;
+                    if consume_if!(b'%') && consume_if!(b':') {
+                        token!(PPTokenKind::HashHash, 4)
+                    } else {
+                        self.position = pos_after;
+                        self.at_start_of_line = sol_after;
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +506,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +569,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_embed;
 pub mod pp_features;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,85 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::create_test_pp_lexer;
+
+#[test]
+fn test_digraph_lexing() {
+    let mut lexer = create_test_pp_lexer("<: :> <% %> %: %:%:");
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("%:", PPTokenKind::Hash),
+        ("%:%:", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_stringification() {
+    use crate::tests::pp_common::setup_pp_snapshot;
+    let src = r#"
+#define STR(x) #x
+STR(<:)
+STR(:>)
+STR(<%)
+STR(%>)
+STR(%:)
+STR(%:%:)
+"#;
+    let tokens = setup_pp_snapshot(src);
+
+    // Each stringification should preserve the original digraph spelling
+    assert_eq!(tokens[0].text, "\"<:\"");
+    assert_eq!(tokens[1].text, "\":>\"");
+    assert_eq!(tokens[2].text, "\"<%\"");
+    assert_eq!(tokens[3].text, "\"%>\"");
+    assert_eq!(tokens[4].text, "\"%:\"");
+    assert_eq!(tokens[5].text, "\"%:%:\"");
+}
+
+#[test]
+fn test_digraph_preprocessor_directive() {
+    use crate::tests::pp_common::setup_pp_snapshot;
+    let src = r#"
+%:define FOO 1
+#if FOO
+int x;
+%:endif
+"#;
+    let tokens = setup_pp_snapshot(src);
+    assert_eq!(tokens.len(), 3); // int, x, ;
+    assert_eq!(tokens[0].text, "int");
+    assert_eq!(tokens[1].text, "x");
+}
+
+#[test]
+fn test_digraph_token_pasting() {
+    use crate::tests::pp_common::setup_pp_snapshot;
+    let src = r#"
+#define PASTE(a, b) a %:%: b
+PASTE(foo, bar)
+"#;
+    let tokens = setup_pp_snapshot(src);
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].text, "foobar");
+}
+
+#[test]
+fn test_digraph_mixed_with_standard() {
+    let mut lexer = create_test_pp_lexer("<: [ :> ] <% { %> } %: #");
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        ("[", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("{", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("}", PPTokenKind::RightBrace),
+        ("%:", PPTokenKind::Hash),
+        ("#", PPTokenKind::Hash),
+    );
+}


### PR DESCRIPTION
Implemented C11 digraph support in the preprocessor lexer. Digraphs are alternative character sequences (`<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) that are equivalent to standard punctuators (`[`, `]`, `{`, `}`, `#`, `##`). The implementation ensures that digraphs are correctly tokenized and that their original spellings are preserved during preprocessor operations like stringification. Comprehensive unit tests were added to verify the functionality.

---
*PR created automatically by Jules for task [16899447875139694365](https://jules.google.com/task/16899447875139694365) started by @bungcip*