### PR TITLE
⚡ Bolt: Optimized Parser token cache by replacing VecDeque with Vec

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -129,3 +129,7 @@
 ## 2025-06-20 - UTF-8-Safe String Transformation via Slicing
 **Learning:** Transforming a `&str` by iterating over `as_bytes()` and casting to `char` (e.g., `bytes[i] as char`) is a major correctness bug that corrupts multi-byte UTF-8 sequences.
 **Action:** For performance-critical transformations like line-splice removal, use `memchr` to scan for ASCII triggers, then use string slicing and `push_str` to preserve the integrity of multi-byte UTF-8 sequences between triggers. This is both faster and correct.
+
+## 2025-06-25 - Eliminating VecDeque Overhead for Append-Only Caches
+**Learning:** Using `VecDeque` for a token cache in a parser that only appends and uses absolute indexing for lookahead/backtracking is an anti-pattern. `VecDeque` (a ring buffer) incurs overhead on every indexed access due to modular arithmetic or branching to handle wrap-around.
+**Action:** Use `Vec` for caches that only grow. It provides better cache locality and faster indexed access by avoiding ring-buffer logic.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,8 +4,6 @@
 //! It orchestrates the parsing process by delegating to specialized sub-modules for
 //! different language constructs.
 
-use std::collections::VecDeque;
-
 use crate::ast::literal::{LitKind, LitRef};
 use crate::ast::*;
 use crate::diagnostic::{DiagnosticEngine, ParseError, ParseErrorKind};
@@ -108,8 +106,12 @@ pub struct Parser<'arena, 'src, 'lexer> {
     pub(crate) ast: &'arena mut ParsedAst,
     pub(crate) lang_opts: &'src crate::lang_options::LangOptions,
 
-    // Token caching for lookahead and backtracking
-    pub(crate) token_cache: VecDeque<Token>,
+    // Bolt ⚡: Use a Vec instead of a VecDeque for the token cache.
+    // The parser only appends to this cache and accesses it via absolute indices
+    // for lookahead and backtracking; it never performs front-popping operations.
+    // Vec is more efficient as it avoids ring-buffer indexing overhead and
+    // provides better cache locality.
+    pub(crate) token_cache: Vec<Token>,
 
     // Type context for typedef tracking
     pub(crate) type_context: TypeDefContext,
@@ -154,7 +156,7 @@ impl<'arena, 'src, 'lexer> Parser<'arena, 'src, 'lexer> {
             current_idx: 0,
             ast,
             lang_opts,
-            token_cache: VecDeque::new(),
+            token_cache: Vec::new(),
             type_context: TypeDefContext::new(),
             keywords: ParserKeywords::new(),
             in_enum_underlying_type: false,
@@ -176,13 +178,13 @@ impl<'arena, 'src, 'lexer> Parser<'arena, 'src, 'lexer> {
         while self.token_cache.len() <= index {
             match self.lexer.next_token() {
                 Ok(Some(token)) => {
-                    self.token_cache.push_back(token);
+                    self.token_cache.push(token);
                 }
                 Ok(None) => break,
                 Err(e) => {
                     self.lexer.preprocessor.diag.report(e);
-                    let span = self.token_cache.back().map(|t| t.span).unwrap_or_default();
-                    self.token_cache.push_back(Token {
+                    let span = self.token_cache.last().map(|t| t.span).unwrap_or_default();
+                    self.token_cache.push(Token {
                         kind: TokenKind::EndOfFile,
                         span,
                     });


### PR DESCRIPTION
💡 What: Replaced \`VecDeque<Token>\` with \`Vec<Token>\` for the parser's \`token_cache\`.

🎯 Why: The parser only appends to this cache and uses absolute indexing for lookahead and backtracking. It never pops from the front. \`VecDeque\` (a ring buffer) incurs overhead on every indexed access due to wrap-around logic. \`Vec\` is more efficient and provides better cache locality.

📊 Impact: Improves parsing efficiency by eliminating ring-buffer indexing overhead in the parser's most-accessed data structure.

🔬 Measurement: Verified with \`cargo bench --bench compiler_benches\`. Correctness confirmed via \`cargo test\`.

---
*PR created automatically by Jules for task [13275059893957850758](https://jules.google.com/task/13275059893957850758) started by @bungcip*