### PR TITLE
test: Add coverage for `__builtin_trap()` parser node

### DIFF
--- a/src/tests/parser_decl.rs
+++ b/src/tests/parser_decl.rs
@@ -607,7 +607,7 @@ fn test_designated_initializer_struct_with_range() {
 #[test]
 fn test_static_assert() {
     let resolved = setup_declaration("_Static_assert(1, \"ok\");");
-    insta::assert_yaml_snapshot!(&resolved, @r"
+    insta::assert_yaml_snapshot!(&resolved, @"
     StaticAssert:
       - LiteralInt: 1
       - ok

--- a/src/tests/parser_expr.rs
+++ b/src/tests/parser_expr.rs
@@ -474,6 +474,12 @@ fn test_builtin_alloca() {
     let resolved = setup_expr("__builtin_alloca(42)");
     insta::assert_yaml_snapshot!(&resolved, @"
     BuiltinAlloca:
-      LiteralInt: 42    
+      LiteralInt: 42
     ");
+}
+
+#[test]
+fn test_builtin_trap() {
+    let resolved = setup_expr("__builtin_trap()");
+    insta::assert_yaml_snapshot!(&resolved, @"BuiltinTrap");
 }

--- a/src/tests/parser_utils.rs
+++ b/src/tests/parser_utils.rs
@@ -55,6 +55,7 @@ pub(crate) enum ResolvedNodeKind {
     Continue,                               // Continue statement
     Switch(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>),
     BuiltinAlloca(Box<ResolvedNodeKind>),
+    BuiltinTrap,
     Case(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>), // Case statement
     CaseRange(Box<ResolvedNodeKind>, Box<ResolvedNodeKind>, Box<ResolvedNodeKind>), // GNU Case range statement
     Default(Box<ResolvedNodeKind>),                     // Default statement
@@ -371,6 +372,7 @@ pub(crate) fn resolve_node(ast: &ParsedAst, node: ParsedNodeRef) -> ResolvedNode
         ParsedNodeKind::EmptyStmt | ParsedNodeKind::Dummy => ResolvedNodeKind::Empty,
         // Add more cases as needed for other ParsedNodeKind variants used in tests
         ParsedNodeKind::BuiltinAlloca(expr) => ResolvedNodeKind::BuiltinAlloca(Box::new(resolve_node(ast, *expr))),
+        ParsedNodeKind::BuiltinTrap => ResolvedNodeKind::BuiltinTrap,
         _ => panic!("Unsupported ParsedNodeKind for resolution: {:?}", node.kind),
     }
 }

--- a/src/tests/semantic_expr.rs
+++ b/src/tests/semantic_expr.rs
@@ -689,24 +689,24 @@ fn test_long_long_literal_suffix() {
         "#;
     let mir = setup_mir(source);
     insta::assert_snapshot!(mir, @"
-        type %t0 = i32
-        type %t1 = i64
+    type %t0 = i32
+    type %t1 = i64
 
-        fn main() -> i32
-        {
-          locals {
-            %a: i64
-            %b: i64
-            %c: i64
-          }
+    fn main() -> i32
+    {
+      locals {
+        %a: i64
+        %b: i64
+        %c: i64
+      }
 
-          bb1:
-            %a = const -2147483648
-            %b = const 2147483648
-            %c = const 2147483648
-            return const 0
-        }
-        ");
+      bb1:
+        %a = const -2147483648
+        %b = const 2147483648
+        %c = const 2147483648
+        return const 0
+    }
+    ");
 }
 
 #[test]

--- a/src/tests/semantic_init.rs
+++ b/src/tests/semantic_init.rs
@@ -269,7 +269,7 @@ fn test_local_mixed_array_struct_designators() {
         }
     "#;
     let mir = setup_mir(source);
-    insta::assert_snapshot!(mir, @r"
+    insta::assert_snapshot!(mir, @"
     type %t0 = i32
     type %t1 = struct S { arr: %t2, val: %t0 }
     type %t2 = [3]%t0
@@ -296,7 +296,7 @@ fn test_local_nested_array_init() {
         }
     "#;
     let mir = setup_mir(source);
-    insta::assert_snapshot!(mir, @r"
+    insta::assert_snapshot!(mir, @"
     type %t0 = i32
     type %t1 = [2]%t0
     type %t2 = [2]%t1
@@ -323,7 +323,7 @@ fn test_local_nested_array_init_with_designators() {
         }
     "#;
     let mir = setup_mir(source);
-    insta::assert_snapshot!(mir, @r"
+    insta::assert_snapshot!(mir, @"
     type %t0 = i32
     type %t1 = [2]%t0
     type %t2 = [2]%t1

--- a/src/tests/semantic_mir.rs
+++ b/src/tests/semantic_mir.rs
@@ -554,7 +554,7 @@ fn test_function_with_many_return_types() {
         "#;
 
     let mir_dump = setup_mir(source);
-    insta::assert_snapshot!(mir_dump, @r"
+    insta::assert_snapshot!(mir_dump, @"
     type %t0 = i32
     type %t1 = f64
     type %t2 = i8
@@ -1356,7 +1356,7 @@ fn test_gnu_statement_expression_labels_and_void() {
     "#;
 
     let mir_dump = setup_mir(source);
-    insta::assert_snapshot!(mir_dump, @r#"
+    insta::assert_snapshot!(mir_dump, @"
     type %t0 = void
     type %t1 = i32
     type %t2 = bool
@@ -1384,7 +1384,7 @@ fn test_gnu_statement_expression_labels_and_void() {
         %x = const 1
         br bb2
     }
-    "#);
+    ");
 }
 
 #[test]


### PR DESCRIPTION
Added a new snapshot test in `src/tests/parser_expr.rs` to exercise the `__builtin_trap()` parsing code paths, successfully increasing the test coverage for `src/parser/expressions.rs`. Also updated `src/tests/parser_utils.rs` to correctly resolve the `ParsedNodeKind::BuiltinTrap` AST node for the test harness.

---
*PR created automatically by Jules for task [7911396969474990412](https://jules.google.com/task/7911396969474990412) started by @bungcip*