### PR TITLE
Implement Digraph Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -87,15 +87,15 @@ pub enum PPTokenKind {
 impl PPTokenKind {
     pub(crate) fn get_fixed_text(&self) -> Option<&'static str> {
         match self {
-            PPTokenKind::Hash => Some("#"),
-            PPTokenKind::HashHash => Some("##"),
+            PPTokenKind::Hash => None,
+            PPTokenKind::HashHash => None,
             PPTokenKind::Comma => Some(","),
             PPTokenKind::LeftParen => Some("("),
             PPTokenKind::RightParen => Some(")"),
-            PPTokenKind::LeftBracket => Some("["),
-            PPTokenKind::RightBracket => Some("]"),
-            PPTokenKind::LeftBrace => Some("{"),
-            PPTokenKind::RightBrace => Some("}"),
+            PPTokenKind::LeftBracket => None,
+            PPTokenKind::RightBracket => None,
+            PPTokenKind::LeftBrace => None,
+            PPTokenKind::RightBrace => None,
             PPTokenKind::Semicolon => Some(";"),
             PPTokenKind::Plus => Some("+"),
             PPTokenKind::Minus => Some("-"),
@@ -462,6 +462,36 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    // Possible %: or %:%:
+                    let pos_after_first_digraph = self.position;
+                    let at_start_after_first_digraph = self.at_start_of_line;
+                    if self.peek_char() == Some(b'%') {
+                        self.next_char(); // consume %
+                        if self.peek_char() == Some(b':') {
+                            self.next_char(); // consume :
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            // Backtrack: we have %: followed by %
+                            self.position = pos_after_first_digraph;
+                            self.at_start_of_line = at_start_after_first_digraph;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +519,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +582,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_embed;
 pub mod pp_features;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,113 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::create_test_pp_lexer;
+
+#[test]
+fn test_basic_digraphs() {
+    let mut lexer = create_test_pp_lexer("<: :> <% %> %: %:%:");
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("%:", PPTokenKind::Hash),
+        ("%:%:", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive() {
+    let src = "%:define FOO 1\nBAR";
+    let mut lexer = create_test_pp_lexer(src);
+
+    let t1 = lexer.next_token().unwrap();
+    assert_eq!(t1.kind, PPTokenKind::Hash);
+    assert_eq!(lexer.get_token_text(&t1), "%:");
+    assert!(t1.flags.contains(crate::pp::PPTokenFlags::STARTS_PP_LINE));
+
+    test_tokens!(
+        lexer,
+        ("define", PPTokenKind::Identifier(_)),
+        ("FOO", PPTokenKind::Identifier(_)),
+        ("1", PPTokenKind::Number),
+        ("", PPTokenKind::Eod),
+        ("BAR", PPTokenKind::Identifier(_)),
+    );
+}
+
+#[test]
+fn test_digraph_backtracking() {
+    // %: followed by something else should be Hash, then that something else
+    let mut lexer = create_test_pp_lexer("%: % : %:%");
+
+    // 1. %:
+    let t1 = lexer.next_token().unwrap();
+    assert_eq!(t1.kind, PPTokenKind::Hash);
+    assert_eq!(lexer.get_token_text(&t1), "%:");
+
+    // 2. %
+    let t2 = lexer.next_token().unwrap();
+    assert_eq!(t2.kind, PPTokenKind::Percent);
+    assert_eq!(lexer.get_token_text(&t2), "%");
+
+    // 3. :
+    let t3 = lexer.next_token().unwrap();
+    assert_eq!(t3.kind, PPTokenKind::Colon);
+    assert_eq!(lexer.get_token_text(&t3), ":");
+
+    // 4. %:%
+    // %: followed by % but not followed by :
+    // should be %: (Hash) then % (Percent)
+    let t4 = lexer.next_token().unwrap();
+    assert_eq!(t4.kind, PPTokenKind::Hash);
+    assert_eq!(lexer.get_token_text(&t4), "%:");
+
+    let t5 = lexer.next_token().unwrap();
+    assert_eq!(t5.kind, PPTokenKind::Percent);
+    assert_eq!(lexer.get_token_text(&t5), "%");
+}
+
+#[test]
+fn test_digraph_in_macro() {
+    use crate::tests::pp_common::setup_pp_snapshot;
+
+    let src = r#"
+#define STR(x) %:x
+#define CONCAT(x, y) x %:%: y
+STR(abc)
+CONCAT(1, 2)
+"#;
+    let tokens = setup_pp_snapshot(src);
+
+    // STR(abc) -> #abc -> "abc"
+    // Wait, #x in macro is stringification.
+    // %:x should also be stringification if it maps to Hash.
+
+    assert_eq!(tokens[0].kind, "StringLiteral");
+    assert_eq!(tokens[0].text, "\"abc\"");
+
+    // CONCAT(1, 2) -> 1 ## 2 -> 12
+    assert_eq!(tokens[1].kind, "Number");
+    assert_eq!(tokens[1].text, "12");
+}
+
+#[test]
+fn test_mixed_digraphs_and_standard() {
+    let mut lexer = create_test_pp_lexer("[ <: { <% ] :> } %> # %: ## %:%:");
+    test_tokens!(
+        lexer,
+        ("[", PPTokenKind::LeftBracket),
+        ("<:", PPTokenKind::LeftBracket),
+        ("{", PPTokenKind::LeftBrace),
+        ("<%", PPTokenKind::LeftBrace),
+        ("]", PPTokenKind::RightBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("}", PPTokenKind::RightBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("#", PPTokenKind::Hash),
+        ("%:", PPTokenKind::Hash),
+        ("##", PPTokenKind::HashHash),
+        ("%:%:", PPTokenKind::HashHash),
+    );
+}


### PR DESCRIPTION
Implemented C standard digraph support in the preprocessor lexer. This includes mapping digraphs like `<:`, `:>`, `<%`, `%>`, `%:`, and `%:%:` to their respective punctuators. Added comprehensive tests and updated documentation.

---
*PR created automatically by Jules for task [12421981337420924709](https://jules.google.com/task/12421981337420924709) started by @bungcip*