### PR TITLE
chore: remove unused dependencies from Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,18 +130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,10 +159,7 @@ name = "cendol"
 version = "0.3.0"
 dependencies = [
  "annotate-snippets",
- "anyhow",
  "bitflags",
- "bitvec",
- "bumpalo",
  "chrono",
  "clap",
  "cranelift",
@@ -186,7 +171,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
  "insta",
- "itertools 0.14.0",
  "libc",
  "log",
  "memchr",
@@ -492,7 +476,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.13.0",
+ "itertools",
  "num-traits",
  "oorandom",
  "page_size",
@@ -512,7 +496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.13.0",
+ "itertools",
 ]
 
 [[package]]
@@ -626,12 +610,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -798,15 +776,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1020,12 +989,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rayon"
@@ -1253,12 +1216,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -1666,15 +1623,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,10 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-bumpalo = "3.20"
 hashbrown = { version = "0.17", features = ["serde"] }
 thiserror = "2.0"
-anyhow = "1.0"
 log = "0.4"
 env_logger = "0.11"
-itertools = "0.14"
 indexmap = "2.13"
 chrono = "0.4"
 memchr = "2.7"
@@ -23,7 +20,6 @@ cranelift-module = "0.131"
 cranelift-object = "0.131"
 cranelift-frontend = "0.131"
 annotate-snippets = "0.12"
-bitvec = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 thin-vec = {version = "0.2", features = ["serde"]}
 smallvec = { version = "1.15", features = ["serde"] }


### PR DESCRIPTION
Removed `anyhow`, `bitvec`, `bumpalo`, and `itertools` from Cargo.toml as they are not used in the codebase.

---
*PR created automatically by Jules for task [16855340461507803662](https://jules.google.com/task/16855340461507803662) started by @bungcip*