### PR TITLE
test: add `sizeof('a')` test in `semantic_const_eval`

### DIFF
--- a/src/tests/semantic_const_eval.rs
+++ b/src/tests/semantic_const_eval.rs
@@ -429,3 +429,13 @@ fn test_const_eval_char_float_2() {
     let result = ctx.eval_float(init_expr);
     assert_eq!(result, Some(97.5));
 }
+
+#[test]
+fn test_const_eval_char_type() {
+    let source = "int test_var = sizeof('a');";
+    let val_str = evaluate_program(source);
+    insta::assert_snapshot!(format!("Source: {}\nResult: {}", source, val_str), @"
+    Source: int test_var = sizeof('a');
+    Result: 4
+    ");
+}


### PR DESCRIPTION
Adds exactly one test to evaluate the size of a character literal via `get_literal_type()`. Since a character literal is evaluated as an `int` in C, this outputs 4. This increases test coverage in `src/semantic/const_eval.rs`.

---
*PR created automatically by Jules for task [9103378428949916800](https://jules.google.com/task/9103378428949916800) started by @bungcip*