### PR TITLE
Implement Digraph Support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,7 +339,7 @@ When writing tests, choose the minimum phase needed to validate your assertion.
 3. **Continue on error** — The compiler reports as many errors as possible rather than stopping at the first one.
 4. **C11 strict compliance** — Follow the C11 standard closely. Constraint violations are tracked in `.jules/guardian.md`.
 5. **No K&R style** — Empty parameter lists `int foo()` are treated as `int foo(void)`.
-6. **No trigraphs/digraphs** — Not supported; modern C only.
+6. **No trigraphs** — Not supported; modern C only. Digraphs are fully supported.
 7. **Minimize allocations** — Use `SmallVec`, `Cow`, `Arc<[T]>`, and pre-allocated buffers in hot paths.
 
 ## Adding New Features

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -87,15 +87,18 @@ pub enum PPTokenKind {
 impl PPTokenKind {
     pub(crate) fn get_fixed_text(&self) -> Option<&'static str> {
         match self {
-            PPTokenKind::Hash => Some("#"),
-            PPTokenKind::HashHash => Some("##"),
+            // Punctuation that has digraph equivalents must return None to ensure we
+            // fallback to get_token_text to preserve original spelling (e.g. <: vs [).
+            PPTokenKind::Hash
+            | PPTokenKind::HashHash
+            | PPTokenKind::LeftBracket
+            | PPTokenKind::RightBracket
+            | PPTokenKind::LeftBrace
+            | PPTokenKind::RightBrace => None,
+
             PPTokenKind::Comma => Some(","),
             PPTokenKind::LeftParen => Some("("),
             PPTokenKind::RightParen => Some(")"),
-            PPTokenKind::LeftBracket => Some("["),
-            PPTokenKind::RightBracket => Some("]"),
-            PPTokenKind::LeftBrace => Some("{"),
-            PPTokenKind::RightBrace => Some("}"),
             PPTokenKind::Semicolon => Some(";"),
             PPTokenKind::Plus => Some("+"),
             PPTokenKind::Minus => Some("-"),
@@ -425,6 +428,42 @@ impl PPLexer {
                     token!(PPTokenKind::Hash, 1, token_flags)
                 }
             }
+            b'%' => {
+                if consume_if!(b'=') {
+                    token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let pos_after_colon = self.position;
+                    let at_start_after_colon = self.at_start_of_line;
+                    if self.peek_char() == Some(b'%') {
+                        self.next_char(); // consume second '%'
+                        if self.peek_char() == Some(b':') {
+                            self.next_char(); // consume second ':'
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            // Backtrack if not %:%:
+                            self.position = pos_after_colon;
+                            self.at_start_of_line = at_start_after_colon;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
+                } else {
+                    token!(PPTokenKind::Percent, 1)
+                }
+            }
             b'+' => {
                 if consume_if!(b'+') {
                     token!(PPTokenKind::Increment, 2)
@@ -459,13 +498,6 @@ impl PPLexer {
                     token!(PPTokenKind::Slash, 1)
                 }
             }
-            b'%' => {
-                if consume_if!(b'=') {
-                    token!(PPTokenKind::ModAssign, 2)
-                } else {
-                    token!(PPTokenKind::Percent, 1)
-                }
-            }
             b'=' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::Equal, 2)
@@ -489,6 +521,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +584,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_embed;
 pub mod pp_features;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,100 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_all_digraph_tokens() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("%:", PPTokenKind::Hash),
+        ("%:%:", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive_starter() {
+    let source = "%:define FOO 1\nFOO";
+    let tokens = setup_pp_snapshot(source);
+
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Number
+      text: \"1\"
+    ");
+}
+
+#[test]
+fn test_digraph_token_pasting() {
+    let source = r#"
+%:define PASTE(a, b) a %:%: b
+PASTE(foo, bar)
+"#;
+    let tokens = setup_pp_snapshot(source);
+
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: Identifier
+      text: foobar
+    ");
+}
+
+#[test]
+fn test_digraph_stringification() {
+    let source = r#"
+%:define STR(x) %:x
+STR(foo)
+"#;
+    let tokens = setup_pp_snapshot(source);
+
+    insta::assert_yaml_snapshot!(tokens, @r#"
+    - kind: StringLiteral
+      text: "\"foo\""
+    "#);
+}
+
+#[test]
+fn test_digraph_mixed_with_standard() {
+    let source = "<: [ :> ] <% { %> }";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        ("[", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("]", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("{", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("}", PPTokenKind::RightBrace),
+    );
+}
+
+#[test]
+fn test_percent_colon_backtracking() {
+    let source = "%:%";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(lexer, ("%:", PPTokenKind::Hash), ("%", PPTokenKind::Percent),);
+}
+
+#[test]
+fn test_digraph_in_macro_body() {
+    let source = r#"
+#define BRACKETS <: :>
+BRACKETS
+"#;
+    let tokens = setup_pp_snapshot(source);
+
+    insta::assert_yaml_snapshot!(tokens, @"
+    - kind: LeftBracket
+      text: \"<:\"
+    - kind: RightBracket
+      text: \":>\"
+    ");
+}


### PR DESCRIPTION
Implemented full support for C digraphs in the preprocessor lexer. This includes all 6 standard digraphs, proper handling of directives started with `%:`, and token pasting with `%:%:`. The implementation ensures that the original spelling is preserved for stringification and diagnostics. Comprehensive unit tests and updated documentation are included.

---
*PR created automatically by Jules for task [12819848549189232900](https://jules.google.com/task/12819848549189232900) started by @bungcip*