### PR TITLE
🛡️ Guardian: Verify C11 static array declarator constraints

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -96,6 +96,7 @@ pub mod guardian_parameter_compatibility;
 pub mod guardian_parameter_completeness;
 pub mod guardian_register_constraints;
 pub mod guardian_sizeof_alignof;
+pub mod guardian_static_array_constraints;
 pub mod guardian_ternary_pointer_constraints;
 pub mod guardian_typedef_member_function;
 pub mod guardian_vla;

--- a/src/tests/guardian_static_array_constraints.rs
+++ b/src/tests/guardian_static_array_constraints.rs
@@ -1,0 +1,41 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+
+#[test]
+fn test_static_in_typedef_array_prohibited() {
+    // C11 6.7.6.2p1: "The optional type qualifiers and the keyword static shall appear
+    // only in a declaration of a function parameter with an array type..."
+    run_fail_with_message(
+        "typedef int T[static 10];",
+        "static in array declarator only allowed in function parameters",
+    );
+}
+
+#[test]
+fn test_qualifiers_in_typedef_array_prohibited() {
+    run_fail_with_message(
+        "typedef int T[const 10];",
+        "type qualifiers in array declarator only allowed in function parameters",
+    );
+}
+
+#[test]
+fn test_static_in_block_scope_array_prohibited() {
+    run_fail_with_message(
+        "void f() { int a[static 10]; }",
+        "static in array declarator only allowed in function parameters",
+    );
+}
+
+#[test]
+fn test_static_in_file_scope_array_prohibited() {
+    run_fail_with_message(
+        "int a[static 10];",
+        "static in array declarator only allowed in function parameters",
+    );
+}
+
+#[test]
+fn test_static_in_function_parameter_allowed() {
+    run_pass("void f(int a[static 10]);", CompilePhase::SemanticLowering);
+}


### PR DESCRIPTION
Added a new Guardian test case to verify C11 §6.7.6.2p1 constraints on the use of 'static' and type qualifiers within array declarators. The test ensures these are correctly rejected in `typedef`, block-scope, and file-scope declarations, while remaining permitted in function parameters.

---
*PR created automatically by Jules for task [11466604848678162566](https://jules.google.com/task/11466604848678162566) started by @bungcip*