### PR TITLE
Implement C11 digraph support

### DIFF
--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -87,15 +87,15 @@ pub enum PPTokenKind {
 impl PPTokenKind {
     pub(crate) fn get_fixed_text(&self) -> Option<&'static str> {
         match self {
-            PPTokenKind::Hash => Some("#"),
-            PPTokenKind::HashHash => Some("##"),
+            PPTokenKind::Hash
+            | PPTokenKind::HashHash
+            | PPTokenKind::LeftBracket
+            | PPTokenKind::RightBracket
+            | PPTokenKind::LeftBrace
+            | PPTokenKind::RightBrace => None,
             PPTokenKind::Comma => Some(","),
             PPTokenKind::LeftParen => Some("("),
             PPTokenKind::RightParen => Some(")"),
-            PPTokenKind::LeftBracket => Some("["),
-            PPTokenKind::RightBracket => Some("]"),
-            PPTokenKind::LeftBrace => Some("{"),
-            PPTokenKind::RightBrace => Some("}"),
             PPTokenKind::Semicolon => Some(";"),
             PPTokenKind::Plus => Some("+"),
             PPTokenKind::Minus => Some("-"),
@@ -462,6 +462,36 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    let pos_after_first_colon = self.position;
+                    let at_start_after_first_colon = self.at_start_of_line;
+
+                    if self.peek_char() == Some(b'%') {
+                        self.next_char();
+                        if self.peek_char() == Some(b':') {
+                            self.next_char();
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            // Backtrack if not %:%:
+                            self.position = pos_after_first_colon;
+                            self.at_start_of_line = at_start_after_first_colon;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +519,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +582,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_embed;
 pub mod pp_features;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,65 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::create_test_pp_lexer;
+
+#[test]
+fn test_digraph_basic() {
+    let mut lexer = create_test_pp_lexer("<: :> <% %> %: %:%:");
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("%:", PPTokenKind::Hash),
+        ("%:%:", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive() {
+    let mut lexer = create_test_pp_lexer("%:define FOO 1\nFOO");
+
+    // Check %: as #
+    let t1 = lexer.next_token().unwrap();
+    assert_eq!(t1.kind, PPTokenKind::Hash);
+    assert_eq!(lexer.get_token_text(&t1), "%:");
+
+    let t2 = lexer.next_token().unwrap();
+    assert_eq!(lexer.get_token_text(&t2), "define");
+
+    let t3 = lexer.next_token().unwrap();
+    assert_eq!(lexer.get_token_text(&t3), "FOO");
+
+    let t4 = lexer.next_token().unwrap();
+    assert_eq!(lexer.get_token_text(&t4), "1");
+}
+
+#[test]
+fn test_digraph_mismatch() {
+    // These should NOT be digraphs
+    let mut lexer = create_test_pp_lexer("< : > < % : % :");
+    test_tokens!(
+        lexer,
+        ("<", PPTokenKind::Less),
+        (":", PPTokenKind::Colon),
+        (">", PPTokenKind::Greater),
+        ("<", PPTokenKind::Less),
+        ("%", PPTokenKind::Percent),
+        (":", PPTokenKind::Colon),
+        ("%", PPTokenKind::Percent),
+        (":", PPTokenKind::Colon),
+    );
+}
+
+#[test]
+fn test_digraph_nested() {
+    let mut lexer = create_test_pp_lexer("<% <: :> %>");
+    test_tokens!(
+        lexer,
+        ("<%", PPTokenKind::LeftBrace),
+        ("<:", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("%>", PPTokenKind::RightBrace),
+    );
+}


### PR DESCRIPTION
Added C11 digraph support to the lexer and preprocessor. Verified with unit tests covering basic usage, preprocessor directives, and edge cases. Fixed a clippy warning regarding an unnecessary mutable variable.

---
*PR created automatically by Jules for task [11917846113335068592](https://jules.google.com/task/11917846113335068592) started by @bungcip*