### PR TITLE
Implement C digraph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Cendol is a C23 compiler implemented in Rust. It is a project to understand the 
 ## Limitations
 
 - **No Trigraph Support**: Trigraphs (three-character sequences like `??=`, `??<`, etc.) are not supported. Note: Trigraphs were officially removed in C23.
-- **No Digraph Support**: Digraphs (two-character sequences like `<:`, `:>`, `<%`, `%>`, `%:`, `%:%:`) are not supported.
 - **No K&R Function Declarations**: Functions declared with an empty parameter list (e.g., `int foo()`) are treated as `int foo(void)`, following C23.
 - **Missing C23 Language Features**:
   - **Bit-precise integers** (`_BitInt(N)`) are not yet implemented.

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -87,15 +87,18 @@ pub enum PPTokenKind {
 impl PPTokenKind {
     pub(crate) fn get_fixed_text(&self) -> Option<&'static str> {
         match self {
-            PPTokenKind::Hash => Some("#"),
-            PPTokenKind::HashHash => Some("##"),
+            // Tokens that have digraph equivalents return None to ensure we use
+            // the original spelling from the source buffer.
+            PPTokenKind::Hash
+            | PPTokenKind::HashHash
+            | PPTokenKind::LeftBracket
+            | PPTokenKind::RightBracket
+            | PPTokenKind::LeftBrace
+            | PPTokenKind::RightBrace => None,
+
             PPTokenKind::Comma => Some(","),
             PPTokenKind::LeftParen => Some("("),
             PPTokenKind::RightParen => Some(")"),
-            PPTokenKind::LeftBracket => Some("["),
-            PPTokenKind::RightBracket => Some("]"),
-            PPTokenKind::LeftBrace => Some("{"),
-            PPTokenKind::RightBrace => Some("}"),
             PPTokenKind::Semicolon => Some(";"),
             PPTokenKind::Plus => Some("+"),
             PPTokenKind::Minus => Some("-"),
@@ -462,6 +465,35 @@ impl PPLexer {
             b'%' => {
                 if consume_if!(b'=') {
                     token!(PPTokenKind::ModAssign, 2)
+                } else if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBrace, 2)
+                } else if consume_if!(b':') {
+                    if self.peek_char() == Some(b'%') {
+                        let saved_pos = self.position;
+                        let saved_sol = self.at_start_of_line;
+                        self.next_char(); // consume second %
+                        if self.peek_char() == Some(b':') {
+                            self.next_char(); // consume second :
+                            token!(PPTokenKind::HashHash, 4)
+                        } else {
+                            // Only %: so far, but next wasn't %, so we backtrack
+                            self.position = saved_pos;
+                            self.at_start_of_line = saved_sol;
+                            let mut token_flags = flags;
+                            if is_at_start_of_line {
+                                token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                                self.in_directive_line = true;
+                            }
+                            token!(PPTokenKind::Hash, 2, token_flags)
+                        }
+                    } else {
+                        let mut token_flags = flags;
+                        if is_at_start_of_line {
+                            token_flags |= PPTokenFlags::STARTS_PP_LINE;
+                            self.in_directive_line = true;
+                        }
+                        token!(PPTokenKind::Hash, 2, token_flags)
+                    }
                 } else {
                     token!(PPTokenKind::Percent, 1)
                 }
@@ -489,6 +521,10 @@ impl PPLexer {
                     }
                 } else if consume_if!(b'=') {
                     token!(PPTokenKind::LessEqual, 2)
+                } else if consume_if!(b':') {
+                    token!(PPTokenKind::LeftBracket, 2)
+                } else if consume_if!(b'%') {
+                    token!(PPTokenKind::LeftBrace, 2)
                 } else {
                     token!(PPTokenKind::Less, 1)
                 }
@@ -548,7 +584,13 @@ impl PPLexer {
                 token!(PPTokenKind::Dot, 1)
             }
             b'?' => token!(PPTokenKind::Question, 1),
-            b':' => token!(PPTokenKind::Colon, 1),
+            b':' => {
+                if consume_if!(b'>') {
+                    token!(PPTokenKind::RightBracket, 2)
+                } else {
+                    token!(PPTokenKind::Colon, 1)
+                }
+            }
             b',' => token!(PPTokenKind::Comma, 1),
             b';' => token!(PPTokenKind::Semicolon, 1),
             b'(' => token!(PPTokenKind::LeftParen, 1),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,6 +17,7 @@ pub mod driver_source_manager;
 
 pub mod pp_common;
 pub mod pp_conditionals;
+pub mod pp_digraphs;
 pub mod pp_directives;
 pub mod pp_embed;
 pub mod pp_features;

--- a/src/tests/pp_digraphs.rs
+++ b/src/tests/pp_digraphs.rs
@@ -1,0 +1,94 @@
+use crate::pp::PPTokenKind;
+use crate::test_tokens;
+use crate::tests::pp_common::{create_test_pp_lexer, setup_pp_snapshot};
+
+#[test]
+fn test_all_digraph_tokens() {
+    let source = "<: :> <% %> %: %:%:";
+    let mut lexer = create_test_pp_lexer(source);
+
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        (":>", PPTokenKind::RightBracket),
+        ("<%", PPTokenKind::LeftBrace),
+        ("%>", PPTokenKind::RightBrace),
+        ("%:", PPTokenKind::Hash),
+        ("%:%:", PPTokenKind::HashHash),
+    );
+}
+
+#[test]
+fn test_digraph_directive() {
+    // Digraph %: should work as # for directives
+    let source = "%:define FOO 1\nFOO";
+    let tokens = setup_pp_snapshot(source);
+
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].text, "1");
+}
+
+#[test]
+fn test_digraph_stringification() {
+    let source = "#define STR(x) #x\nSTR(a)";
+    let tokens = setup_pp_snapshot(source);
+    assert_eq!(tokens[0].text, "\"a\"");
+
+    // With digraph stringification
+    let source = "#define STR2(x) %:x\nSTR2(a)";
+    let tokens = setup_pp_snapshot(source);
+    assert_eq!(tokens[0].text, "\"a\"");
+}
+
+#[test]
+fn test_digraph_concatenation() {
+    let source = "#define CONCAT(a, b) a %:%: b\nCONCAT(x, y)";
+    let tokens = setup_pp_snapshot(source);
+    assert_eq!(tokens[0].text, "xy");
+}
+
+#[test]
+fn test_digraph_mixed() {
+    let source = "<: %> <% :>";
+    let mut lexer = create_test_pp_lexer(source);
+    test_tokens!(
+        lexer,
+        ("<:", PPTokenKind::LeftBracket),
+        ("%>", PPTokenKind::RightBrace),
+        ("<%", PPTokenKind::LeftBrace),
+        (":>", PPTokenKind::RightBracket),
+    );
+}
+
+#[test]
+fn test_digraph_backtrack() {
+    let mut lexer = create_test_pp_lexer("%: %");
+    test_tokens!(lexer, ("%:", PPTokenKind::Hash), ("%", PPTokenKind::Percent),);
+
+    let mut lexer = create_test_pp_lexer("%: :");
+    test_tokens!(lexer, ("%:", PPTokenKind::Hash), (":", PPTokenKind::Colon),);
+
+    let mut lexer = create_test_pp_lexer("%:% :");
+    test_tokens!(
+        lexer,
+        ("%:", PPTokenKind::Hash),
+        ("%", PPTokenKind::Percent),
+        (":", PPTokenKind::Colon),
+    );
+}
+
+#[test]
+fn test_xor_regression() {
+    let mut lexer = create_test_pp_lexer("^ ^=");
+    test_tokens!(lexer, ("^", PPTokenKind::Xor), ("^=", PPTokenKind::XorAssign),);
+
+    // Ensure ^: is not a digraph
+    let mut lexer = create_test_pp_lexer("^: ^>");
+    test_tokens!(
+        lexer,
+        ("^", PPTokenKind::Xor),
+        (":", PPTokenKind::Colon),
+        ("^", PPTokenKind::Xor),
+        (">", PPTokenKind::Greater),
+    );
+}


### PR DESCRIPTION
I have implemented full support for C digraphs (`<:`, `:>`, `<%`, `%>`, `%:`, and `%:%:`) in the preprocessor. This includes:
1. Lexical analysis of digraph sequences into their equivalent punctuator tokens.
2. Support for `%:` as a directive starter at the beginning of a line.
3. Proper handling of `%:%:` for token concatenation.
4. preservation of original source spelling during stringification and error reporting.
5. A new test suite `src/tests/pp_digraphs.rs` covering these features and regressions.
6. Documentation updates in `README.md`.

---
*PR created automatically by Jules for task [15820893030682580375](https://jules.google.com/task/15820893030682580375) started by @bungcip*