### PR TITLE
refactor: simplify redundant boolean comparisons

### DIFF
--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1074,7 +1074,7 @@ impl<'a> MirGen<'a> {
         self.visit_node(body);
 
         // If body falls through, go to merge
-        if self.current_block_has_terminator() == false {
+        if !self.current_block_has_terminator() {
             // Check if terminator is Unreachable (default) - if so, we can replace it or just leave it?
             // `current_block_has_terminator` returns false if it is Unreachable.
             // But if we are in body_entry_dummy and it's empty, we shouldn't jump to merge.

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -1283,7 +1283,7 @@ impl<'a> MirGen<'a> {
             obj_qt.ty()
         };
 
-        if record_ty.is_record() == false {
+        if !record_ty.is_record() {
             panic!("ICE: Member access on non-record type");
         }
 


### PR DESCRIPTION
I audited the codebase to look for cleanup opportunities as instructed (e.g. redundant logic, dead code). I investigated dependencies using `cargo machete` and found no unused crates. I analyzed "hacks" and "temporary" logic but decided against speculative removals, favoring small, focused refactors.

Specifically, I used `cargo clippy` to identify redundant boolean comparisons (`== false`), and simplified them to standard logical negations (`!x`) in:
- `src/codegen/mir_gen.rs`
- `src/codegen/mir_gen_expression.rs`

This maintains behavior, improves code clarity, and removes clippy lint warnings without risking regressions. All tests pass successfully.

---
*PR created automatically by Jules for task [10249756312723247611](https://jules.google.com/task/10249756312723247611) started by @bungcip*