### PR TITLE
🛡️ Guardian: Typedef redefinition type identity protected

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -243,3 +243,8 @@ Action: Explicitly distinguish between different enum types during compatibility
 
 Learning: C11 6.5.1.1p2 prohibits variably modified (VM) types in generic associations. This constraint applies not only to direct VLAs (e.g. 'int[n]') but also to any VM type, including pointers to VLAs (e.g. 'int(*)[n]'). While Cendol's 'is_variably_modified' correctly handles this recursion, explicit tests are required to ensure these cases are consistently rejected with 'SemanticError::GenericVlaAssociation' to prevent them from reaching later compiler phases.
 Action: Always test VM type constraints using both direct VLAs and derived VM types (like pointers or multi-dimensional arrays) to ensure complete coverage of the language's VM type classification.
+
+2026-05-16 - [Typedef Redefinition Type Identity vs Compatibility]
+
+Learning: C11 6.7p3 requires that typedef redefinitions in the same scope denote the exact SAME type, not merely compatible types. This is a subtle distinction. While `int[]` and `int[10]` are compatible, they are not the same type. Similarly, `int` and `const int` are compatible in some contexts, but not the same. Enforcing strict type identity using `aliased_type != final_ty` during lowering prevents invalid redefinitions that would otherwise pass simple compatibility checks.
+Action: Add dedicated regression tests for `typedef` redefinition specifically targeting cases where types are compatible but not identical, to prevent regressions in this strict type identity constraint.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -144,3 +144,4 @@ pub mod regr_struct_bitfield;
 pub mod semantic_alignof_expr;
 pub mod semantic_pedantic_gnu_extensions;
 pub mod semantic_usual_arithmetic_conversions;
+pub mod guardian_typedef_redefinition;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -134,6 +134,7 @@ pub mod semantic_scope_invariants;
 pub mod semantic_static_assert;
 
 pub mod guardian_choose_expr;
+pub mod guardian_typedef_redefinition;
 pub mod regr_identifier_truncation;
 pub mod regr_init_range;
 pub mod regr_mixed_sign_comp;
@@ -144,4 +145,3 @@ pub mod regr_struct_bitfield;
 pub mod semantic_alignof_expr;
 pub mod semantic_pedantic_gnu_extensions;
 pub mod semantic_usual_arithmetic_conversions;
-pub mod guardian_typedef_redefinition;

--- a/src/tests/guardian_typedef_redefinition.rs
+++ b/src/tests/guardian_typedef_redefinition.rs
@@ -1,0 +1,50 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+
+#[test]
+fn test_typedef_redefinition_different_type() {
+    // C11 6.7p3: "If an identifier has no linkage, there shall be no more than one declaration of the identifier (in a declarator or type specifier) with the same scope and in the same name space, except for tags..."
+    // "typedef redefinition in the same scope must denote the SAME type."
+    run_fail_with_message(
+        r#"
+        typedef int arr[10];
+        typedef int arr[];
+        "#,
+        "redefinition of 'arr' with a different type",
+    );
+}
+
+#[test]
+fn test_typedef_redefinition_qualifiers() {
+    // int and const int are compatible types in some contexts, but they are not the SAME type.
+    run_fail_with_message(
+        r#"
+        typedef int T;
+        typedef const int T;
+        "#,
+        "redefinition of 'T' with a different type",
+    );
+}
+
+#[test]
+fn test_typedef_redefinition_atomic() {
+    run_fail_with_message(
+        r#"
+        typedef int T;
+        typedef _Atomic int T;
+        "#,
+        "redefinition of 'T' with a different type",
+    );
+}
+
+#[test]
+fn test_typedef_redefinition_same_type_allowed() {
+    run_pass(
+        r#"
+        typedef const int T;
+        typedef const int T;
+        int main() { return 0; }
+        "#,
+        CompilePhase::SemanticLowering,
+    );
+}


### PR DESCRIPTION
🧪 What: Added `guardian_typedef_redefinition.rs` to verify that `typedef` redefinitions exactly match the target type.
🎯 Why: C11 §6.7p3 requires that `typedef` redefinitions in the same scope denote the EXACT SAME type, not merely compatible types. This test prevents regressions where compatible but non-identical types (like `int[]` and `int[10]`, or `int` and `const int`) might be incorrectly accepted.
🛠️ Phase: Semantic Lowering
🔬 Verify: Run `cargo test guardian_typedef_redefinition` or `cargo test`

---
*PR created automatically by Jules for task [6402545047116554206](https://jules.google.com/task/6402545047116554206) started by @bungcip*