### PR TITLE
Increase test coverage for C23 trailing attributes in parser

### DIFF
--- a/src/tests/parser_c23_attributes.rs
+++ b/src/tests/parser_c23_attributes.rs
@@ -105,3 +105,14 @@ fn test_attribute_coverage() {
         CStandard::C23,
     );
 }
+
+#[test]
+fn test_trailing_attributes() {
+    run_pass_with_std(
+        r#"
+        int x __attribute__((aligned(8))) [[maybe_unused]] __asm__("my_x");
+        "#,
+        CompilePhase::Parse,
+        CStandard::C23,
+    );
+}


### PR DESCRIPTION
A. Coverage increased
- **Analysis:** The `parse_trailing_attributes_and_asm` function in `src/parser/declarations.rs` had an uncovered branch at line 602 for `specifiers.extend(parse_c23_attribute(parser)?);`.
- **Added Code:** Added `test_trailing_attributes` to `src/tests/parser_c23_attributes.rs` that explicitly combines standard GNU attributes (`__attribute__`), C23 attributes (`[[maybe_unused]]`), and inline assembly (`__asm__`) on a trailing variable declaration context.
- **Coverage Improvement:** By providing a test case with a trailing C23 attribute, this exercises the previously untested execution path in the parser. The `cargo llvm-cov report --show-missing-lines` output confirms coverage of this branch, successfully increasing the overall coverage metrics.

---
*PR created automatically by Jules for task [876999183542800104](https://jules.google.com/task/876999183542800104) started by @bungcip*