### PR TITLE
⚡ Bolt: Optimize string literal metadata access

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -13,7 +13,7 @@ use crate::{
         const_eval::ConstEvalCtx,
         conversions::{integer_promotion, usual_arithmetic_conversions},
         errors::{SemanticDiag, SemanticError},
-        literal_utils::lower_string_literal,
+        literal_utils::{get_string_builtin_type, get_string_literal_size},
         types::TypeClass,
     },
 };
@@ -3386,12 +3386,14 @@ impl<'a> SemanticAnalyzer<'a> {
                 Some(QualType::unqualified(ty))
             }
             LitVal::String { value, prefix } => {
-                let parsed = lower_string_literal(&value, prefix);
-                let element_type = self.registry.get_builtin_type(parsed.builtin_type);
+                // Bolt ⚡: Use metadata-only accessors to avoid full literal lowering.
+                let builtin_type = get_string_builtin_type(prefix);
+                let size = get_string_literal_size(&value, prefix);
+                let element_type = self.registry.get_builtin_type(builtin_type);
 
                 let array_type = self
                     .registry
-                    .array_of(element_type, ArraySizeType::Constant(parsed.size));
+                    .array_of(element_type, ArraySizeType::Constant(size));
                 let _ = self.registry.ensure_layout(array_type);
                 Some(QualType::new(array_type, TypeQualifiers::empty()))
             }

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -3391,9 +3391,7 @@ impl<'a> SemanticAnalyzer<'a> {
                 let size = get_string_literal_size(&value, prefix);
                 let element_type = self.registry.get_builtin_type(builtin_type);
 
-                let array_type = self
-                    .registry
-                    .array_of(element_type, ArraySizeType::Constant(size));
+                let array_type = self.registry.array_of(element_type, ArraySizeType::Constant(size));
                 let _ = self.registry.ensure_layout(array_type);
                 Some(QualType::new(array_type, TypeQualifiers::empty()))
             }

--- a/src/semantic/const_eval.rs
+++ b/src/semantic/const_eval.rs
@@ -7,7 +7,7 @@
 use crate::ast::literal::{FloatSuffix, LitVal};
 use crate::ast::{Ast, BinaryOp, NodeKind, NodeRef, StringId, UnaryOp};
 use crate::semantic::conversions::{integer_promotion, usual_arithmetic_conversions};
-use crate::semantic::literal_utils::lower_string_literal;
+use crate::semantic::literal_utils::{get_string_builtin_type, get_string_literal_size};
 use crate::semantic::types::ArraySizeType;
 use crate::semantic::{BuiltinType, QualType, SemanticInfo, SymbolKind, SymbolTable, TypeRegistry};
 
@@ -129,8 +129,10 @@ impl<'a> ConstEvalCtx<'a> {
             LitVal::Char(_, prefix) => prefix.get_type(self.registry),
             LitVal::Float { suffix, .. } => suffix.get_type(self.registry),
             LitVal::String { value, prefix } => {
-                let parsed_str = lower_string_literal(value, *prefix);
-                let builtin_base = match parsed_str.builtin_type {
+                // Bolt ⚡: Use metadata-only accessors.
+                let builtin_type = get_string_builtin_type(*prefix);
+                let size = get_string_literal_size(value, *prefix);
+                let builtin_base = match builtin_type {
                     BuiltinType::Char => self.registry.type_char,
                     BuiltinType::Int => self.registry.type_int,
                     BuiltinType::UShort => self.registry.type_short_unsigned,
@@ -139,7 +141,7 @@ impl<'a> ConstEvalCtx<'a> {
                     _ => self.registry.type_char,
                 };
                 self.registry
-                    .find_array_type(builtin_base, ArraySizeType::Constant(parsed_str.size))
+                    .find_array_type(builtin_base, ArraySizeType::Constant(size))
                     .unwrap_or(self.registry.type_error)
             }
             LitVal::Nullptr => self.registry.type_nullptr_t,

--- a/src/semantic/literal_utils.rs
+++ b/src/semantic/literal_utils.rs
@@ -7,16 +7,41 @@ pub struct StringLiteralValue {
     pub size: usize,
 }
 
-pub(crate) fn lower_string_literal(content: &str, prefix: StrPrefix) -> StringLiteralValue {
-    let builtin_type = match prefix {
+/// Metadata about a string literal without its full value buffer.
+/// Bolt ⚡: This allows phases like semantic analysis and lowering to resolve
+/// literal types and sizes without incurring the heap allocation cost of a Vec<i64>.
+pub(crate) fn get_string_builtin_type(prefix: StrPrefix) -> BuiltinType {
+    match prefix {
         StrPrefix::Wide => BuiltinType::Int,
         StrPrefix::Utf16 => BuiltinType::UShort,
         StrPrefix::Utf32 => BuiltinType::UInt,
         StrPrefix::Utf8 => BuiltinType::UChar,
         StrPrefix::None => BuiltinType::Char,
-    };
+    }
+}
 
-    let mut values = Vec::new();
+/// Calculate the number of elements in the string literal, including the null terminator.
+/// Bolt ⚡: Optimized metadata-only calculation to avoid full literal lowering.
+pub(crate) fn get_string_literal_size(content: &str, prefix: StrPrefix) -> usize {
+    match prefix {
+        StrPrefix::None | StrPrefix::Utf8 => content.len() + 1,
+        StrPrefix::Wide | StrPrefix::Utf32 => content.chars().count() + 1,
+        StrPrefix::Utf16 => {
+            let mut len = 0;
+            for c in content.chars() {
+                len += c.len_utf16();
+            }
+            len + 1
+        }
+    }
+}
+
+pub(crate) fn lower_string_literal(content: &str, prefix: StrPrefix) -> StringLiteralValue {
+    let builtin_type = get_string_builtin_type(prefix);
+    let size = get_string_literal_size(content, prefix);
+
+    // Bolt ⚡: Use with_capacity to ensure a single allocation.
+    let mut values = Vec::with_capacity(size);
     match prefix {
         StrPrefix::None | StrPrefix::Utf8 => {
             values.extend(content.bytes().map(|b| b as i64));
@@ -35,7 +60,7 @@ pub(crate) fn lower_string_literal(content: &str, prefix: StrPrefix) -> StringLi
 
     StringLiteralValue {
         builtin_type,
-        size: values.len(),
+        size,
         values,
     }
 }

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -21,7 +21,7 @@ use crate::diagnostic::{DiagnosticEngine, DiagnosticLevel};
 use crate::lang_options::CStandard;
 use crate::semantic::const_eval::ConstEvalCtx;
 use crate::semantic::errors::{SemanticDiag, SemanticError};
-use crate::semantic::literal_utils::lower_string_literal;
+use crate::semantic::literal_utils::{get_string_builtin_type, get_string_literal_size};
 use crate::semantic::symbol_table::{DefinitionState, SymbolTableError};
 use crate::semantic::{
     ArraySizeType, BuiltinFunctionKind, BuiltinType, EnumConstant, Namespace, ScopeId, StructMember, SymbolKind,
@@ -2485,9 +2485,11 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             LitVal::Float { suffix, .. } => suffix.get_type(self.registry),
             LitVal::Char(_, prefix) => prefix.get_type(self.registry),
             LitVal::String { value: s, prefix } => {
-                let parsed = lower_string_literal(&s, prefix);
-                let elem = self.registry.get_builtin_type(parsed.builtin_type);
-                self.registry.array_of(elem, ArraySizeType::Constant(parsed.size))
+                // Bolt ⚡: Use metadata-only accessors to avoid full literal lowering.
+                let builtin_type = get_string_builtin_type(prefix);
+                let size = get_string_literal_size(&s, prefix);
+                let elem = self.registry.get_builtin_type(builtin_type);
+                self.registry.array_of(elem, ArraySizeType::Constant(size))
             }
             LitVal::Nullptr => self.registry.type_nullptr_t,
             LitVal::True | LitVal::False => self.registry.type_bool,
@@ -2498,7 +2500,8 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
     fn try_deduce_string_initializer_size(&mut self, init_node: NodeRef, element_type: TypeRef) -> Option<usize> {
         match self.ast.get_kind(init_node) {
             NodeKind::Literal(literal_id) => match literal_id.get_val() {
-                LitVal::String { value, prefix } => Some(lower_string_literal(&value, prefix).size),
+                // Bolt ⚡: Use metadata-only accessor to avoid full literal lowering.
+                LitVal::String { value, prefix } => Some(get_string_literal_size(&value, prefix)),
                 _ => None,
             },
             NodeKind::InitializerList(list) if list.init_len > 0 => {
@@ -2506,13 +2509,15 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                     && item.designator_len == 0
                     && let NodeKind::Literal(literal_id) = self.ast.get_kind(item.initializer)
                     && let LitVal::String { value, prefix } = literal_id.get_val()
-                    && let parsed = lower_string_literal(&value, prefix)
+                    // Bolt ⚡: Use metadata-only accessors.
+                    && let builtin_type = get_string_builtin_type(prefix)
+                    && let size = get_string_literal_size(&value, prefix)
                     && self.registry.is_compatible(
                         QualType::unqualified(element_type),
-                        QualType::unqualified(self.registry.get_builtin_type(parsed.builtin_type)),
+                        QualType::unqualified(self.registry.get_builtin_type(builtin_type)),
                     )
                 {
-                    Some(parsed.size)
+                    Some(size)
                 } else {
                     None
                 }


### PR DESCRIPTION
💡 What: The optimization implemented
This PR optimizes how the compiler processes string literals during semantic analysis, lowering, and constant evaluation. It introduces metadata-only accessors that resolve a literal's builtin type and element count without performing a full lowering to an integer buffer.

🎯 Why: The performance problem it solves
Previously, the compiler called `lower_string_literal` every time it needed to know the type or size of a string literal. This function always allocates a `Vec<i64>` and traverses the entire string content. In large files (like SQLite), this leads to massive redundant heap allocations and CPU churn, as the full value is often only needed during MIR generation.

📊 Impact: Expected performance improvement
Reduces memory pressure and CPU cycles during the analysis phase, especially for large C source files. Measurements on SQLite show that while the overall analysis time is dominated by other factors, this change eliminates thousands of short-lived `Vec<i64>` allocations.

🔬 Measurement: How to verify the improvement
Run `cargo bench --bench compiler_benches -- --quick` to ensure no regression and observe the impact on the 'analyze_sqlite' stage. Correctness is verified by the full test suite.


---
*PR created automatically by Jules for task [17060183338892910958](https://jules.google.com/task/17060183338892910958) started by @bungcip*