### PR TITLE
🛡️ Guardian: Enforce C11 function return type constraints (arrays and functions)

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -248,3 +248,8 @@ Action: Always test VM type constraints using both direct VLAs and derived VM ty
 
 Learning: C11 6.7p3 requires that typedef redefinitions in the same scope denote the exact SAME type, not merely compatible types. This is a subtle distinction. While `int[]` and `int[10]` are compatible, they are not the same type. Similarly, `int` and `const int` are compatible in some contexts, but not the same. Enforcing strict type identity using `aliased_type != final_ty` during lowering prevents invalid redefinitions that would otherwise pass simple compatibility checks.
 Action: Add dedicated regression tests for `typedef` redefinition specifically targeting cases where types are compatible but not identical, to prevent regressions in this strict type identity constraint.
+
+2024-05-18 - [Function Return Type Constraints]
+
+Learning: C11 6.7.6.3p1 states that functions cannot return arrays or function types. However, when parsing code, `int f()[10];` or `int f()();` are often rejected as invalid syntax during the parsing phase ("Declaration not allowed in this context"). To properly test the semantic analysis phase enforcement of this constraint without parser interference, one must use `typedef` to obscure the array or function type, e.g., `typedef int arr[10]; arr f();`.
+Action: When testing semantic constraints involving complex derived types (like arrays or functions) in positions that might have syntactic limitations, use `typedef`s to bypass parser rejections and ensure the semantic rules are correctly enforced.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -136,6 +136,7 @@ pub mod semantic_static_assert;
 
 pub mod driver_warning_formatting;
 pub mod guardian_choose_expr;
+pub mod guardian_function_return_type_constraints;
 pub mod guardian_typedef_redefinition;
 pub mod pp_pedantic_directives;
 pub mod pp_pedantic_dollar;
@@ -151,4 +152,3 @@ pub mod semantic_cleanup_diag;
 pub mod semantic_pedantic_gnu_extensions;
 pub mod semantic_return;
 pub mod semantic_usual_arithmetic_conversions;
-pub mod guardian_function_return_type_constraints;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -151,3 +151,4 @@ pub mod semantic_cleanup_diag;
 pub mod semantic_pedantic_gnu_extensions;
 pub mod semantic_return;
 pub mod semantic_usual_arithmetic_conversions;
+pub mod guardian_function_return_type_constraints;

--- a/src/tests/guardian_function_return_type_constraints.rs
+++ b/src/tests/guardian_function_return_type_constraints.rs
@@ -1,0 +1,50 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+
+#[test]
+fn test_function_returning_array_rejected() {
+    // C11 6.7.6.3p1: A function declarator shall not specify a return type that is a function type or an array type.
+    run_fail_with_message(
+        r#"
+        typedef int arr[10];
+        arr f();
+        "#,
+        "function cannot return an array type",
+    );
+}
+
+#[test]
+fn test_function_returning_function_rejected() {
+    // C11 6.7.6.3p1: A function declarator shall not specify a return type that is a function type or an array type.
+    run_fail_with_message(
+        r#"
+        typedef int func();
+        func f();
+        "#,
+        "function cannot return a function type",
+    );
+}
+
+#[test]
+fn test_function_returning_pointer_to_array_accepted() {
+    run_pass(
+        r#"
+        typedef int arr[10];
+        arr *f();
+        int main() { return 0; }
+        "#,
+        CompilePhase::SemanticLowering,
+    );
+}
+
+#[test]
+fn test_function_returning_pointer_to_function_accepted() {
+    run_pass(
+        r#"
+        typedef int func();
+        func *f();
+        int main() { return 0; }
+        "#,
+        CompilePhase::SemanticLowering,
+    );
+}


### PR DESCRIPTION
🧪 What: Add test to ensure functions cannot return arrays or functions.
🎯 Why: Prevents miscompilation by properly handling semantic constraints on function return types.
🛠️ Phase: Semantic Lowering
🔬 Verify: Run `cargo test guardian_function_return_type_constraints`

---
*PR created automatically by Jules for task [15061170571722216555](https://jules.google.com/task/15061170571722216555) started by @bungcip*