### PR TITLE
Add `__builtin_bit_cast` parsing coverage

### DIFF
--- a/src/tests/parser_expr.rs
+++ b/src/tests/parser_expr.rs
@@ -480,6 +480,12 @@ fn test_builtin_alloca() {
 }
 
 #[test]
+fn test_builtin_bit_cast() {
+    let resolved = setup_expr("__builtin_bit_cast(float, 42)");
+    insta::assert_yaml_snapshot!(resolved);
+}
+
+#[test]
 fn test_builtin_trap() {
     let resolved = setup_expr("__builtin_trap()");
     insta::assert_yaml_snapshot!(&resolved, @"

--- a/src/tests/parser_utils.rs
+++ b/src/tests/parser_utils.rs
@@ -219,7 +219,10 @@ pub(crate) fn resolve_node(ast: &ParsedAst, node: ParsedNodeRef) -> ResolvedNode
         ),
         ParsedNodeKind::BuiltinBitCast(ty, expr) => ResolvedNodeKind::FunctionCall(
             Box::new(ResolvedNodeKind::Ident("__builtin_bit_cast".to_string())),
-            vec![ResolvedNodeKind::Ident(format!("parsed_type_{}", ty.base.get())), resolve_node(ast, *expr)],
+            vec![
+                ResolvedNodeKind::Ident(format!("parsed_type_{}", ty.base.get())),
+                resolve_node(ast, *expr),
+            ],
         ),
         ParsedNodeKind::BuiltinTypesCompatibleP(boxed) => {
             let (t1, t2) = &**boxed;

--- a/src/tests/parser_utils.rs
+++ b/src/tests/parser_utils.rs
@@ -217,6 +217,10 @@ pub(crate) fn resolve_node(ast: &ParsedAst, node: ParsedNodeRef) -> ResolvedNode
             Box::new(ResolvedNodeKind::Ident("__builtin_complex".to_string())),
             vec![resolve_node(ast, *r), resolve_node(ast, *i)],
         ),
+        ParsedNodeKind::BuiltinBitCast(ty, expr) => ResolvedNodeKind::FunctionCall(
+            Box::new(ResolvedNodeKind::Ident("__builtin_bit_cast".to_string())),
+            vec![ResolvedNodeKind::Ident(format!("parsed_type_{}", ty.base.get())), resolve_node(ast, *expr)],
+        ),
         ParsedNodeKind::BuiltinTypesCompatibleP(boxed) => {
             let (t1, t2) = &**boxed;
             ResolvedNodeKind::FunctionCall(

--- a/src/tests/snapshots/cendol__tests__parser_expr__builtin_bit_cast.snap
+++ b/src/tests/snapshots/cendol__tests__parser_expr__builtin_bit_cast.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/parser_expr.rs
+expression: resolved
+---
+FunctionCall:
+  - Ident: __builtin_bit_cast
+  - - Ident: parsed_type_1
+    - LiteralInt: 42


### PR DESCRIPTION
Adds a unit test for `__builtin_bit_cast` expressions to increase code coverage in `src/parser/expressions.rs`.

---
*PR created automatically by Jules for task [15517851578205892260](https://jules.google.com/task/15517851578205892260) started by @bungcip*