### PR TITLE
⚡ Bolt: pre-calculate macro parameter expansion needs

### DIFF
--- a/src/pp/directives.rs
+++ b/src/pp/directives.rs
@@ -255,8 +255,7 @@ impl<'src> Preprocessor<'src> {
         };
 
         // Bolt ⚡: Pre-calculate expansion needs and detect __VA_OPT__.
-        let mut needs_expansion =
-            vec![false; macro_info.parameter_list.len() + if variadic.is_some() { 1 } else { 0 }];
+        let mut needs_expansion = vec![false; macro_info.parameter_list.len() + if variadic.is_some() { 1 } else { 0 }];
 
         for i in 0..macro_info.tokens.len() {
             let t = &macro_info.tokens[i];

--- a/src/pp/directives.rs
+++ b/src/pp/directives.rs
@@ -251,19 +251,43 @@ impl<'src> Preprocessor<'src> {
             tokens: Arc::from(tokens),
             parameter_list: Arc::from(params),
             variadic_arg: variadic,
+            parameter_needs_expansion: Arc::from([]), // Temporarily empty
         };
 
-        // Bolt ⚡: Pre-detect __VA_OPT__ in variadic macros to speed up expansion.
-        if macro_info.variadic_arg.is_some() {
-            for t in macro_info.tokens.iter() {
-                if let PPTokenKind::Identifier(sym) = t.kind
-                    && sym == self.keywords.va_opt
-                {
+        // Bolt ⚡: Pre-calculate expansion needs and detect __VA_OPT__.
+        let mut needs_expansion =
+            vec![false; macro_info.parameter_list.len() + if variadic.is_some() { 1 } else { 0 }];
+
+        for i in 0..macro_info.tokens.len() {
+            let t = &macro_info.tokens[i];
+            if let PPTokenKind::Identifier(sym) = t.kind {
+                // Check for __VA_OPT__
+                if variadic.is_some() && sym == self.keywords.va_opt {
                     macro_info.flags |= MacroFlags::HAS_VA_OPT;
-                    break;
+                }
+
+                // Check for parameter usage that requires expansion
+                let param_idx = if let Some(pos) = macro_info.parameter_list.iter().position(|&p| p == sym) {
+                    Some(pos)
+                } else if variadic == Some(sym) {
+                    Some(macro_info.parameter_list.len())
+                } else {
+                    None
+                };
+
+                if let Some(idx) = param_idx {
+                    let preceded_by_hash = i > 0 && macro_info.tokens[i - 1].kind == PPTokenKind::Hash;
+                    let preceded_by_hashhash = i > 0 && macro_info.tokens[i - 1].kind == PPTokenKind::HashHash;
+                    let followed_by_hashhash =
+                        i + 1 < macro_info.tokens.len() && macro_info.tokens[i + 1].kind == PPTokenKind::HashHash;
+
+                    if !preceded_by_hash && !preceded_by_hashhash && !followed_by_hashhash {
+                        needs_expansion[idx] = true;
+                    }
                 }
             }
         }
+        macro_info.parameter_needs_expansion = Arc::from(needs_expansion);
 
         if self.check_macro_redefinition(name, &name_token, &macro_info) {
             self.macros.insert(name, macro_info);

--- a/src/pp/macros.rs
+++ b/src/pp/macros.rs
@@ -1186,7 +1186,6 @@ impl<'src> Preprocessor<'src> {
 
         Ok((flags, params, variadic))
     }
-
 }
 
 /// Helper to cache source buffers for efficient token text retrieval

--- a/src/pp/macros.rs
+++ b/src/pp/macros.rs
@@ -159,13 +159,7 @@ impl<'src> Preprocessor<'src> {
         let mut expanded_args = Vec::with_capacity(args.len());
         for (idx, arg) in args.iter().enumerate() {
             let mut arg_clone = arg.clone();
-            let needs_expansion = if idx < macro_info.parameter_list.len() {
-                self.parameter_needs_expansion(macro_info, macro_info.parameter_list[idx])
-            } else if let Some(var_arg) = macro_info.variadic_arg {
-                self.parameter_needs_expansion(macro_info, var_arg)
-            } else {
-                false
-            };
+            let needs_expansion = macro_info.parameter_needs_expansion.get(idx).copied().unwrap_or(false);
 
             if needs_expansion {
                 self.expand_tokens(&mut arg_clone, false)?;
@@ -1010,13 +1004,7 @@ impl<'src> Preprocessor<'src> {
         let mut expanded_args = Vec::with_capacity(args.len());
         for (idx, arg) in args.iter().enumerate() {
             let mut arg_clone = arg.clone();
-            let needs_expansion = if idx < info.parameter_list.len() {
-                self.parameter_needs_expansion(&info, info.parameter_list[idx])
-            } else if let Some(var_arg) = info.variadic_arg {
-                self.parameter_needs_expansion(&info, var_arg)
-            } else {
-                false
-            };
+            let needs_expansion = info.parameter_needs_expansion.get(idx).copied().unwrap_or(false);
 
             if needs_expansion {
                 // Bolt ⚡: Ignore errors during argument prescan to match original behavior.
@@ -1199,24 +1187,6 @@ impl<'src> Preprocessor<'src> {
         Ok((flags, params, variadic))
     }
 
-    /// Check if a parameter is used in the replacement list in a way that requires its expanded argument
-    fn parameter_needs_expansion(&self, macro_info: &MacroInfo, param_sym: StringId) -> bool {
-        for i in 0..macro_info.tokens.len() {
-            if let PPTokenKind::Identifier(sym) = macro_info.tokens[i].kind
-                && sym == param_sym
-            {
-                let preceded_by_hash = i > 0 && macro_info.tokens[i - 1].kind == PPTokenKind::Hash;
-                let preceded_by_hashhash = i > 0 && macro_info.tokens[i - 1].kind == PPTokenKind::HashHash;
-                let followed_by_hashhash =
-                    i + 1 < macro_info.tokens.len() && macro_info.tokens[i + 1].kind == PPTokenKind::HashHash;
-
-                if !preceded_by_hash && !preceded_by_hashhash && !followed_by_hashhash {
-                    return true;
-                }
-            }
-        }
-        false
-    }
 }
 
 /// Helper to cache source buffers for efficient token text retrieval

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -529,6 +529,7 @@ impl<'src> Preprocessor<'src> {
             tokens: Arc::from(tokens),
             parameter_list: Arc::from([]),
             variadic_arg: None,
+            parameter_needs_expansion: Arc::from([]),
         };
         self.macros.insert(symbol, macro_info);
     }
@@ -542,6 +543,7 @@ impl<'src> Preprocessor<'src> {
             tokens: Arc::from(tokens),
             parameter_list: Arc::from([]),
             variadic_arg: None,
+            parameter_needs_expansion: Arc::from([]),
         };
         self.macros.insert(symbol, macro_info);
     }
@@ -551,12 +553,31 @@ impl<'src> Preprocessor<'src> {
         let symbol = StringId::new(name);
         let param_symbols: Vec<StringId> = params.iter().map(|&p| StringId::new(p)).collect();
         let tokens = self.lex_macro_value(body, "<builtin>");
+
+        // Pre-calculate expansion needs for built-in function-like macros
+        let mut needs_expansion = vec![false; param_symbols.len()];
+        for i in 0..tokens.len() {
+            if let PPTokenKind::Identifier(sym) = tokens[i].kind
+                && let Some(idx) = param_symbols.iter().position(|&p| p == sym)
+            {
+                let preceded_by_hash = i > 0 && tokens[i - 1].kind == PPTokenKind::Hash;
+                let preceded_by_hashhash = i > 0 && tokens[i - 1].kind == PPTokenKind::HashHash;
+                let followed_by_hashhash =
+                    i + 1 < tokens.len() && tokens[i + 1].kind == PPTokenKind::HashHash;
+
+                if !preceded_by_hash && !preceded_by_hashhash && !followed_by_hashhash {
+                    needs_expansion[idx] = true;
+                }
+            }
+        }
+
         let macro_info = MacroInfo {
             location: SourceLoc::builtin(),
             flags: MacroFlags::BUILTIN | MacroFlags::FUNCTION_LIKE,
             tokens: Arc::from(tokens),
             parameter_list: Arc::from(param_symbols),
             variadic_arg: None,
+            parameter_needs_expansion: Arc::from(needs_expansion),
         };
         self.macros.insert(symbol, macro_info);
     }

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -562,8 +562,7 @@ impl<'src> Preprocessor<'src> {
             {
                 let preceded_by_hash = i > 0 && tokens[i - 1].kind == PPTokenKind::Hash;
                 let preceded_by_hashhash = i > 0 && tokens[i - 1].kind == PPTokenKind::HashHash;
-                let followed_by_hashhash =
-                    i + 1 < tokens.len() && tokens[i + 1].kind == PPTokenKind::HashHash;
+                let followed_by_hashhash = i + 1 < tokens.len() && tokens[i + 1].kind == PPTokenKind::HashHash;
 
                 if !preceded_by_hash && !preceded_by_hashhash && !followed_by_hashhash {
                     needs_expansion[idx] = true;

--- a/src/pp/types.rs
+++ b/src/pp/types.rs
@@ -154,6 +154,7 @@ pub(crate) struct MacroInfo {
     pub(crate) tokens: Arc<[PPToken]>,
     pub(crate) parameter_list: Arc<[StringId]>,
     pub(crate) variadic_arg: Option<StringId>,
+    pub(crate) parameter_needs_expansion: Arc<[bool]>,
 }
 
 /// Represents conditional compilation state


### PR DESCRIPTION
This optimization pre-calculates whether function-like macro parameters require argument prescan during macro definition (at #define or for built-ins). By storing this in MacroInfo::parameter_needs_expansion, we avoid a linear scan of the macro body tokens for every parameter during every macro expansion, significantly improving preprocessor performance in macro-heavy code.

---
*PR created automatically by Jules for task [1786229323541011666](https://jules.google.com/task/1786229323541011666) started by @bungcip*