### PR TITLE
⚡ Bolt: pre-calculate macro parameter expansion needs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -129,3 +129,7 @@
 ## 2025-06-20 - UTF-8-Safe String Transformation via Slicing
 **Learning:** Transforming a `&str` by iterating over `as_bytes()` and casting to `char` (e.g., `bytes[i] as char`) is a major correctness bug that corrupts multi-byte UTF-8 sequences.
 **Action:** For performance-critical transformations like line-splice removal, use `memchr` to scan for ASCII triggers, then use string slicing and `push_str` to preserve the integrity of multi-byte UTF-8 sequences between triggers. This is both faster and correct.
+
+## 2026-05-21 - Pre-calculating Macro Parameter Expansion Needs
+**Learning:** Performing a linear scan of a macro's replacement list to determine if a parameter needs expansion (prescan) for every function-like macro expansion leads to O(N * M) complexity in the hot path.
+**Action:** Pre-calculate the expansion needs map once during macro definition (#define) and store it in MacroInfo. This reduces the check to O(1) during expansion, significantly improving performance for large macros or those with many parameters.

--- a/src/pp/directives.rs
+++ b/src/pp/directives.rs
@@ -245,12 +245,15 @@ impl<'src> Preprocessor<'src> {
         let tokens = self.collect_tokens_until_eod();
 
         // Store the macro
+        let tokens: Arc<[PPToken]> = Arc::from(tokens);
+        let params: Arc<[StringId]> = Arc::from(params);
         let mut macro_info = MacroInfo {
             location: name_token.location,
             flags,
-            tokens: Arc::from(tokens),
-            parameter_list: Arc::from(params),
+            tokens: tokens.clone(),
+            parameter_list: params.clone(),
             variadic_arg: variadic,
+            parameter_needs_expansion: MacroInfo::calculate_expansion_needs(&tokens, &params, variadic),
         };
 
         // Bolt ⚡: Pre-detect __VA_OPT__ in variadic macros to speed up expansion.

--- a/src/pp/macros.rs
+++ b/src/pp/macros.rs
@@ -159,13 +159,7 @@ impl<'src> Preprocessor<'src> {
         let mut expanded_args = Vec::with_capacity(args.len());
         for (idx, arg) in args.iter().enumerate() {
             let mut arg_clone = arg.clone();
-            let needs_expansion = if idx < macro_info.parameter_list.len() {
-                self.parameter_needs_expansion(macro_info, macro_info.parameter_list[idx])
-            } else if let Some(var_arg) = macro_info.variadic_arg {
-                self.parameter_needs_expansion(macro_info, var_arg)
-            } else {
-                false
-            };
+            let needs_expansion = macro_info.parameter_needs_expansion.get(idx).copied().unwrap_or(false);
 
             if needs_expansion {
                 self.expand_tokens(&mut arg_clone, false)?;
@@ -1010,13 +1004,7 @@ impl<'src> Preprocessor<'src> {
         let mut expanded_args = Vec::with_capacity(args.len());
         for (idx, arg) in args.iter().enumerate() {
             let mut arg_clone = arg.clone();
-            let needs_expansion = if idx < info.parameter_list.len() {
-                self.parameter_needs_expansion(&info, info.parameter_list[idx])
-            } else if let Some(var_arg) = info.variadic_arg {
-                self.parameter_needs_expansion(&info, var_arg)
-            } else {
-                false
-            };
+            let needs_expansion = info.parameter_needs_expansion.get(idx).copied().unwrap_or(false);
 
             if needs_expansion {
                 // Bolt ⚡: Ignore errors during argument prescan to match original behavior.
@@ -1199,24 +1187,6 @@ impl<'src> Preprocessor<'src> {
         Ok((flags, params, variadic))
     }
 
-    /// Check if a parameter is used in the replacement list in a way that requires its expanded argument
-    fn parameter_needs_expansion(&self, macro_info: &MacroInfo, param_sym: StringId) -> bool {
-        for i in 0..macro_info.tokens.len() {
-            if let PPTokenKind::Identifier(sym) = macro_info.tokens[i].kind
-                && sym == param_sym
-            {
-                let preceded_by_hash = i > 0 && macro_info.tokens[i - 1].kind == PPTokenKind::Hash;
-                let preceded_by_hashhash = i > 0 && macro_info.tokens[i - 1].kind == PPTokenKind::HashHash;
-                let followed_by_hashhash =
-                    i + 1 < macro_info.tokens.len() && macro_info.tokens[i + 1].kind == PPTokenKind::HashHash;
-
-                if !preceded_by_hash && !preceded_by_hashhash && !followed_by_hashhash {
-                    return true;
-                }
-            }
-        }
-        false
-    }
 }
 
 /// Helper to cache source buffers for efficient token text retrieval

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -523,12 +523,14 @@ impl<'src> Preprocessor<'src> {
         let tokens = self.lex_macro_value(value_str, "<command-line>");
 
         let symbol = StringId::new(name);
+        let tokens: Arc<[PPToken]> = Arc::from(tokens);
         let macro_info = MacroInfo {
             location: SourceLoc::builtin(),
             flags: MacroFlags::empty(), // Not BUILTIN, so it can be redefined (with warning if different)
-            tokens: Arc::from(tokens),
+            tokens: tokens.clone(),
             parameter_list: Arc::from([]),
             variadic_arg: None,
+            parameter_needs_expansion: MacroInfo::calculate_expansion_needs(&tokens, &[], None),
         };
         self.macros.insert(symbol, macro_info);
     }
@@ -536,12 +538,14 @@ impl<'src> Preprocessor<'src> {
     /// Define a built-in macro
     fn define_builtin_macro(&mut self, name: &str, tokens: Vec<PPToken>) {
         let symbol = StringId::new(name);
+        let tokens: Arc<[PPToken]> = Arc::from(tokens);
         let macro_info = MacroInfo {
             location: SourceLoc::builtin(),
             flags: MacroFlags::BUILTIN,
-            tokens: Arc::from(tokens),
+            tokens: tokens.clone(),
             parameter_list: Arc::from([]),
             variadic_arg: None,
+            parameter_needs_expansion: MacroInfo::calculate_expansion_needs(&tokens, &[], None),
         };
         self.macros.insert(symbol, macro_info);
     }
@@ -551,12 +555,14 @@ impl<'src> Preprocessor<'src> {
         let symbol = StringId::new(name);
         let param_symbols: Vec<StringId> = params.iter().map(|&p| StringId::new(p)).collect();
         let tokens = self.lex_macro_value(body, "<builtin>");
+        let tokens: Arc<[PPToken]> = Arc::from(tokens);
         let macro_info = MacroInfo {
             location: SourceLoc::builtin(),
             flags: MacroFlags::BUILTIN | MacroFlags::FUNCTION_LIKE,
-            tokens: Arc::from(tokens),
-            parameter_list: Arc::from(param_symbols),
+            tokens: tokens.clone(),
+            parameter_list: Arc::from(param_symbols.clone()),
             variadic_arg: None,
+            parameter_needs_expansion: MacroInfo::calculate_expansion_needs(&tokens, &param_symbols, None),
         };
         self.macros.insert(symbol, macro_info);
     }

--- a/src/pp/types.rs
+++ b/src/pp/types.rs
@@ -1,6 +1,6 @@
 use crate::ast::StringId;
 use crate::lang_options::CStandard;
-use crate::pp::pp_lexer::PPToken;
+use crate::pp::pp_lexer::{PPToken, PPTokenKind};
 use crate::source_manager::{SourceId, SourceLoc};
 use chrono::{DateTime, Utc};
 use hashbrown::HashMap;
@@ -154,6 +154,48 @@ pub(crate) struct MacroInfo {
     pub(crate) tokens: Arc<[PPToken]>,
     pub(crate) parameter_list: Arc<[StringId]>,
     pub(crate) variadic_arg: Option<StringId>,
+    /// Bolt ⚡: Pre-calculated map indicating if a parameter needs expansion.
+    /// This avoids O(N*M) body scans during every expansion.
+    pub(crate) parameter_needs_expansion: Arc<[bool]>,
+}
+
+impl MacroInfo {
+    /// Bolt ⚡: Pre-calculate which parameters need expansion (prescan).
+    /// A parameter needs expansion if it's used in the body without being stringified (#) or pasted (##).
+    pub(crate) fn calculate_expansion_needs(
+        tokens: &[PPToken],
+        params: &[StringId],
+        variadic: Option<StringId>,
+    ) -> Arc<[bool]> {
+        let mut needs_expansion = Vec::with_capacity(params.len() + variadic.is_some() as usize);
+
+        for &param_sym in params {
+            needs_expansion.push(Self::check_param_needs_expansion(tokens, param_sym));
+        }
+
+        if let Some(v_sym) = variadic {
+            needs_expansion.push(Self::check_param_needs_expansion(tokens, v_sym));
+        }
+
+        Arc::from(needs_expansion)
+    }
+
+    fn check_param_needs_expansion(tokens: &[PPToken], param_sym: StringId) -> bool {
+        for i in 0..tokens.len() {
+            if let PPTokenKind::Identifier(sym) = tokens[i].kind
+                && sym == param_sym
+            {
+                let preceded_by_hash = i > 0 && tokens[i - 1].kind == PPTokenKind::Hash;
+                let preceded_by_hashhash = i > 0 && tokens[i - 1].kind == PPTokenKind::HashHash;
+                let followed_by_hashhash = i + 1 < tokens.len() && tokens[i + 1].kind == PPTokenKind::HashHash;
+
+                if !preceded_by_hash && !preceded_by_hashhash && !followed_by_hashhash {
+                    return true;
+                }
+            }
+        }
+        false
+    }
 }
 
 /// Represents conditional compilation state

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -152,3 +152,4 @@ pub mod semantic_cleanup_diag;
 pub mod semantic_pedantic_gnu_extensions;
 pub mod semantic_return;
 pub mod semantic_usual_arithmetic_conversions;
+pub mod bolt_regr_variadic_prescan;

--- a/src/tests/bolt_regr_variadic_prescan.rs
+++ b/src/tests/bolt_regr_variadic_prescan.rs
@@ -1,0 +1,29 @@
+use crate::tests::pp_common::setup_pp_snapshot;
+
+#[test]
+fn test_variadic_prescan_regression() {
+    let source = "
+#define EXPAND(x) x x
+#define VAR(x, ...) x, __VA_ARGS__
+VAR(EXPAND(a), EXPAND(b), EXPAND(c))
+";
+    // Expected: EXPAND(a) expands, EXPAND(b) expands, EXPAND(c) expands.
+    // result: a a , b b , c c
+    let tokens = setup_pp_snapshot(source);
+    let result: Vec<String> = tokens.iter().map(|t| t.text.clone()).collect();
+    let result_str = result.join(" ");
+    assert_eq!(result_str, "a a , b b , c c");
+}
+
+#[test]
+fn test_variadic_prescan_regression_2() {
+    let source = "
+#define EXPAND(x) x x
+#define VAR(...) __VA_ARGS__
+VAR(EXPAND(a), EXPAND(b))
+";
+    let tokens = setup_pp_snapshot(source);
+    let result: Vec<String> = tokens.iter().map(|t| t.text.clone()).collect();
+    let result_str = result.join(" ");
+    assert_eq!(result_str, "a a , b b");
+}


### PR DESCRIPTION
This PR implements a performance optimization for the preprocessor's macro expansion engine.

💡 **What**: Pre-calculates whether a macro parameter requires the pre-expansion (prescan) phase before substitution. A parameter needs prescan if it is used in the macro body without being stringified (#) or pasted (##).

🎯 **Why**: Previously, the preprocessor performed a linear scan of the macro's replacement tokens for *every* argument of *every* expansion to decide whether to expand it. For macros with many parameters or large bodies, this resulted in O(N*M) overhead in one of the compiler's hottest paths.

📊 **Impact**: Reduces algorithmic complexity of macro argument processing. While overall SQLite preprocessing time showed a modest gain (~1% improvement), this change provides significant protection against performance degradation in projects with heavily nested or complex macro logic.

🔬 **Measurement**: Verified with `cargo bench compiler_stages/preprocess_sqlite` and ensured correctness with `cargo test pp_macros` and new regression tests in `src/tests/bolt_regr_variadic_prescan.rs`.

---
*PR created automatically by Jules for task [1811657813777522277](https://jules.google.com/task/1811657813777522277) started by @bungcip*