### PR TITLE
⚡ Bolt: preprocessor stringification and collection optimizations

### DIFF
--- a/src/pp/directives.rs
+++ b/src/pp/directives.rs
@@ -319,10 +319,7 @@ impl<'src> Preprocessor<'src> {
 
     fn do_handle_include(&mut self, is_next: bool) -> Result<(), PPDiag> {
         let first_token = self.expect_token()?;
-
-        let mut tokens = std::iter::once(first_token)
-            .chain(self.collect_tokens_until_eod())
-            .collect::<Vec<_>>();
+        let mut tokens = self.collect_tokens_until_eod_with_initial(first_token);
 
         let (path_str, is_angled) = match tokens[0].kind {
             PPTokenKind::StringLiteral | PPTokenKind::Less => {
@@ -408,10 +405,7 @@ impl<'src> Preprocessor<'src> {
 
     fn handle_embed(&mut self) -> Result<(), PPDiag> {
         let first_token = self.expect_token()?;
-
-        let mut tokens = std::iter::once(first_token)
-            .chain(self.collect_tokens_until_eod())
-            .collect::<Vec<_>>();
+        let mut tokens = self.collect_tokens_until_eod_with_initial(first_token);
 
         if !matches!(tokens[0].kind, PPTokenKind::StringLiteral | PPTokenKind::Less) {
             self.expand_tokens(&mut tokens, false)?;

--- a/src/pp/macros.rs
+++ b/src/pp/macros.rs
@@ -87,12 +87,26 @@ impl<'src> Preprocessor<'src> {
         result.map(Some)
     }
 
-    /// Helper to convert tokens to their string representation
+    /// Helper to convert tokens to their string representation.
+    /// Preserves LEADING_SPACE between tokens.
     pub(super) fn tokens_to_string(&self, tokens: &[PPToken]) -> String {
+        if tokens.is_empty() {
+            return String::new();
+        }
+
         // Bolt ⚡: Pre-calculate capacity to avoid redundant reallocations.
-        let mut result = String::with_capacity(tokens.iter().map(|t| t.length as usize).sum());
-        for token in tokens {
-            result.push_str(&self.get_token_text(token));
+        // We add tokens.len() as an upper bound for extra spaces.
+        let capacity = tokens.iter().map(|t| t.length as usize).sum::<usize>() + tokens.len();
+        let mut result = String::with_capacity(capacity);
+
+        let mut cache = SourceBufferCache::new(self.sm);
+
+        for (i, token) in tokens.iter().enumerate() {
+            // Bolt ⚡: Preserve leading spaces between tokens.
+            if i > 0 && token.flags.contains(PPTokenFlags::LEADING_SPACE) {
+                result.push(' ');
+            }
+            result.push_str(&cache.get_token_text(token));
         }
         result
     }
@@ -1070,7 +1084,10 @@ impl<'src> Preprocessor<'src> {
             return Vec::new();
         }
 
-        let mut buffer = Vec::with_capacity(tokens.iter().map(|t| t.length as usize).sum());
+        // Bolt ⚡: Pre-calculate capacity to include potential spaces.
+        // This avoids reallocations during buffer construction.
+        let capacity = tokens.iter().map(|t| t.length as usize).sum::<usize>() + tokens.len();
+        let mut buffer = Vec::with_capacity(capacity);
         let mut metadata = Vec::with_capacity(tokens.len());
 
         {
@@ -1108,20 +1125,19 @@ impl<'src> Preprocessor<'src> {
             FileKind::MacroExpansion,
         );
 
-        tokens
-            .iter()
-            .zip(metadata)
-            .map(|(t, (preserve, offset, len))| {
-                let loc = if preserve {
-                    t.location
-                } else {
-                    SourceLoc::new(virtual_id, offset)
-                };
-                let mut token = PPToken::new(t.kind, t.flags | PPTokenFlags::MACRO_EXPANDED, loc, len);
-                token.hide_set = t.hide_set;
-                token
-            })
-            .collect()
+        // Bolt ⚡: Use Vec::with_capacity and extend for the final token list.
+        let mut result = Vec::with_capacity(tokens.len());
+        for (t, (preserve, offset, len)) in tokens.iter().zip(metadata) {
+            let loc = if preserve {
+                t.location
+            } else {
+                SourceLoc::new(virtual_id, offset)
+            };
+            let mut token = PPToken::new(t.kind, t.flags | PPTokenFlags::MACRO_EXPANDED, loc, len);
+            token.hide_set = t.hide_set;
+            result.push(token);
+        }
+        result
     }
 
     pub(super) fn parse_macro_definition_params(

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -942,6 +942,20 @@ impl<'src> Preprocessor<'src> {
         tokens
     }
 
+    /// Collect tokens until Eod, including an already consumed initial token.
+    /// Bolt ⚡: This avoids redundant Vec allocations and copies from chaining.
+    pub(super) fn collect_tokens_until_eod_with_initial(&mut self, initial: PPToken) -> Vec<PPToken> {
+        let mut tokens = Vec::with_capacity(32);
+        tokens.push(initial);
+        while let Some(token) = self.lex_token() {
+            if token.kind == PPTokenKind::Eod {
+                break;
+            }
+            tokens.push(token);
+        }
+        tokens
+    }
+
     /// Check if we are currently skipping tokens
     pub(super) fn is_currently_skipping(&self) -> bool {
         // Bolt ⚡: Optimized to O(1) by checking only the top of the stack.


### PR DESCRIPTION
I've optimized the preprocessor's token stringification and directive collection paths. 

Key improvements:
- **`tokens_to_string`**: Now correctly preserves whitespace between tokens in directives like `#warning` and `#error`, while using `SourceBufferCache` and precise capacity pre-calculation to avoid reallocations.
- **`create_virtual_buffer_tokens`**: Optimized the virtual buffer capacity calculation to include spaces, preventing a guaranteed reallocation for multi-token macro expansions.
- **Directive Collection**: Replaced expensive iterator chaining and redundant `Vec` allocations in `#include` and `#embed` with a specialized `collect_tokens_until_eod_with_initial` helper.

Verified with 1561 passing tests and a manual check of `#warning` output.

---
*PR created automatically by Jules for task [5702284305274459864](https://jules.google.com/task/5702284305274459864) started by @bungcip*