### PR TITLE
Add test coverage for invalid atomic specifiers

### DIFF
--- a/src/tests/parser_errors.rs
+++ b/src/tests/parser_errors.rs
@@ -130,6 +130,14 @@ fn test_parser_errors() {
         ("void foo() { (", "found end of file"),
         ("void foo() { { int x = +; } }", "found ;"),
         ("[[maybe_unused]]", "found ["),
+        ("int _Atomic(int[5]) x;", "array"),
+        ("int _Atomic(int(void)) x;", "function"),
+("int _Atomic(int[5]) x;", "array"),
+("int _Atomic(int(void)) x;", "function"),
+("int _Atomic(int[5]) x;", "specifier cannot be used with array type"),
+("int _Atomic(int(void)) x;", "specifier cannot be used with function type"),
+("int _Atomic(_Atomic(int)) x;", "specifier cannot be used with atomic type"),
+("int _Atomic(int(void)) x;", "specifier cannot be used with function type"),
     ];
 
     for (source, message) in cases {

--- a/src/tests/parser_errors.rs
+++ b/src/tests/parser_errors.rs
@@ -132,12 +132,21 @@ fn test_parser_errors() {
         ("[[maybe_unused]]", "found ["),
         ("int _Atomic(int[5]) x;", "array"),
         ("int _Atomic(int(void)) x;", "function"),
-("int _Atomic(int[5]) x;", "array"),
-("int _Atomic(int(void)) x;", "function"),
-("int _Atomic(int[5]) x;", "specifier cannot be used with array type"),
-("int _Atomic(int(void)) x;", "specifier cannot be used with function type"),
-("int _Atomic(_Atomic(int)) x;", "specifier cannot be used with atomic type"),
-("int _Atomic(int(void)) x;", "specifier cannot be used with function type"),
+        ("int _Atomic(int[5]) x;", "array"),
+        ("int _Atomic(int(void)) x;", "function"),
+        ("int _Atomic(int[5]) x;", "specifier cannot be used with array type"),
+        (
+            "int _Atomic(int(void)) x;",
+            "specifier cannot be used with function type",
+        ),
+        (
+            "int _Atomic(_Atomic(int)) x;",
+            "specifier cannot be used with atomic type",
+        ),
+        (
+            "int _Atomic(int(void)) x;",
+            "specifier cannot be used with function type",
+        ),
     ];
 
     for (source, message) in cases {


### PR DESCRIPTION
Adding unit tests to increase coverage of error handling paths for `_Atomic` type specifiers.

---
*PR created automatically by Jules for task [4271897038845997802](https://jules.google.com/task/4271897038845997802) started by @bungcip*