### PR TITLE
Guardian: alignment specifier constraints validation

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -64,12 +64,12 @@ pub mod parser_stmt;
 pub mod parser_types;
 pub mod parser_utils;
 
+pub mod guardian_alignas_constraints;
 pub mod guardian_increment_completeness;
 pub mod guardian_modifiable_lvalue;
 pub mod guardian_pointer_arithmetic_completeness;
 pub mod guardian_struct_member;
 pub mod parser_gcc_extensions;
-pub mod guardian_alignas_constraints;
 pub mod semantic_composite;
 pub mod test_utils;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -69,6 +69,7 @@ pub mod guardian_modifiable_lvalue;
 pub mod guardian_pointer_arithmetic_completeness;
 pub mod guardian_struct_member;
 pub mod parser_gcc_extensions;
+pub mod guardian_alignas_constraints;
 pub mod semantic_composite;
 pub mod test_utils;
 

--- a/src/tests/guardian_alignas_constraints.rs
+++ b/src/tests/guardian_alignas_constraints.rs
@@ -1,0 +1,54 @@
+use crate::tests::test_utils::run_fail_with_message;
+
+#[test]
+fn test_alignas_on_typedef_prohibited() {
+    // C11 6.7.5p2: An alignment specifier shall not be used in the declaration of a typedef
+    run_fail_with_message(
+        "typedef _Alignas(16) int aligned_int;",
+        "alignment specifier cannot be used in a typedef",
+    );
+}
+
+#[test]
+fn test_alignas_on_bitfield_prohibited() {
+    // C11 6.7.5p2: An alignment specifier shall not be used in the declaration of a bit-field
+    run_fail_with_message(
+        r#"
+        struct S {
+            _Alignas(8) int x : 4;
+        };
+        "#,
+        "alignment specifier cannot be used in a bit-field",
+    );
+}
+
+#[test]
+fn test_alignas_on_function_prohibited() {
+    // C11 6.7.5p2: An alignment specifier shall not be used in the declaration of a function
+    run_fail_with_message(
+        "_Alignas(16) void f(void);",
+        "alignment specifier cannot be used in a function",
+    );
+}
+
+#[test]
+fn test_alignas_on_parameter_prohibited() {
+    // C11 6.7.5p2: An alignment specifier shall not be used in the declaration of a parameter
+    run_fail_with_message(
+        "void f(_Alignas(16) int x) {}",
+        "alignment specifier cannot be used in a function parameter",
+    );
+}
+
+#[test]
+fn test_alignas_on_register_prohibited() {
+    // C11 6.7.5p2: An alignment specifier shall not be used in the declaration of a register
+    run_fail_with_message(
+        r#"
+        void f(void) {
+            register _Alignas(16) int x;
+        }
+        "#,
+        "alignment specifier cannot be used in a register object",
+    );
+}


### PR DESCRIPTION
Added `guardian_alignas_constraints.rs` with C code snippets and scenarios testing C11 6.7.5p2 constraints. Prevents bugs and ambiguities around using the `_Alignas` specifier in invalid contexts (typedefs, bit-fields, functions, parameters, and register objects).

---
*PR created automatically by Jules for task [11785570158797255781](https://jules.google.com/task/11785570158797255781) started by @bungcip*