### PR TITLE
refactor: remove unused variable is_incomplete_enum

### DIFF
--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -3579,7 +3579,6 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             // Bolt ⚡: Extension: allow incomplete enums in declarations (per GCC/Clang).
             if !self.registry.is_complete(decayed_qt.ty()) {
                 let is_void_param_list = params.len() == 1 && decayed_qt.is_void() && pname.is_none();
-                let is_incomplete_enum = matches!(self.registry.get(decayed_qt.ty()).kind, TypeKind::Enum { .. });
 
                 let should_report = if decayed_qt.is_void() {
                     !is_void_param_list


### PR DESCRIPTION
This PR cleans up the codebase by removing an unused variable `is_incomplete_enum` in `src/semantic/lowering.rs`. The code was reviewed to ensure safety and no regressions were introduced. All tests pass successfully.

---
*PR created automatically by Jules for task [17327805473148174435](https://jules.google.com/task/17327805473148174435) started by @bungcip*