### PR TITLE
chore: remove unused CompilePhase import in parser_errors.rs

### DIFF
--- a/src/tests/parser_errors.rs
+++ b/src/tests/parser_errors.rs
@@ -1,4 +1,3 @@
-use crate::driver::artifact::CompilePhase;
 use crate::tests::test_utils::run_fail_with_message;
 
 /// all declarator/declaration/statement parser error is in here


### PR DESCRIPTION
Removes the unused import `use crate::driver::artifact::CompilePhase;` from `src/tests/parser_errors.rs`, resolving a `cargo clippy` warning. This is a safe, incremental refactor that improves code quality without changing observable behavior.

---
*PR created automatically by Jules for task [92822547417105362](https://jules.google.com/task/92822547417105362) started by @bungcip*