### PR TITLE
🛡️ Guardian: Protect against incompatible nested pointer assignment

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -260,3 +260,7 @@ Action: When testing semantic constraints involving complex derived types (like 
 2024-05-25 - [Block-scope Thread-Local Validation]
 
 Learning: C11 §6.7.1p3 requires that `_Thread_local` variables in block scope must also be specified with either `static` or `extern` storage-class specifiers. Without explicitly testing this invariant, the compiler could easily accept automatic `_Thread_local` variables, breaking compilation or runtime assumptions as thread-local semantics do not apply to automatic storage. Action: Ensure storage class modifier combinations are robustly checked, especially for nested scopes and specific thread-local semantics.
+
+2024-05-31 - [Nested Pointer Qualifiers]
+
+Learning: C11 6.5.16.1p1 requires that operands for assignment are pointers to qualified or unqualified versions of compatible types. For nested pointers, `int **` and `const int **` are NOT compatible types. The compiler correctly prevents implicit conversion for these assignments and returns a type mismatch rather than just emitting a "discards qualifiers" warning. We need to test to ensure we don't accidentally enable this type conversion implicitly because the outer qualifiers would silently be added, which breaks C11 safety assumptions around pointer aliasing. Action: Add tests specifically verifying that type conversions fail outright for incompatible nested pointers like `int **` assigned to `const int **`.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -156,3 +156,4 @@ pub mod regr_struct_bitfield;
 
 // Test Helpers
 pub mod test_utils;
+pub mod guardian_pointer_assignment_nested_qualifiers;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -155,5 +155,5 @@ pub mod regr_shadowing;
 pub mod regr_struct_bitfield;
 
 // Test Helpers
-pub mod test_utils;
 pub mod guardian_pointer_assignment_nested_qualifiers;
+pub mod test_utils;

--- a/src/tests/guardian_pointer_assignment_nested_qualifiers.rs
+++ b/src/tests/guardian_pointer_assignment_nested_qualifiers.rs
@@ -1,0 +1,56 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+
+#[test]
+fn test_pointer_assignment_nested_qualifiers_prohibited() {
+    // C11 6.5.16.1p1: "...both operands are pointers to qualified or unqualified versions of
+    // compatible types, and the type pointed to by the left has all the qualifiers of
+    // the type pointed to by the right;"
+    // For nested pointers, `int **` and `const int **` are NOT compatible types.
+    // The type pointed to by the left is `const int *`. The type pointed to by the right is `int *`.
+    // These are not qualified/unqualified versions of compatible types.
+    run_fail_with_message(
+        r#"
+        int main() {
+            int **p;
+            const int **q;
+            q = p; // Invalid!
+        }
+        "#,
+        "type mismatch", // We expect a type mismatch, not just a discards qualifier warning
+    );
+}
+
+#[test]
+fn test_pointer_assignment_nested_qualifiers_multiple_levels() {
+    run_fail_with_message(
+        r#"
+        int main() {
+            int ***p;
+            const int ***q;
+            q = p; // Invalid!
+        }
+        "#,
+        "type mismatch",
+    );
+}
+
+#[test]
+fn test_pointer_assignment_nested_qualifiers_valid() {
+    // Left: pointer to const pointer to int
+    // Right: pointer to pointer to int
+    // Compatible: Yes. The type pointed to by left is `const pointer to int`.
+    // The type pointed to by right is `pointer to int`.
+    // They are qualified/unqualified versions of compatible types.
+    run_pass(
+        r#"
+        int main() {
+            int *p;
+            int * const *q;
+            q = &p; // Valid!
+            return 0;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
Adds `guardian_pointer_assignment_nested_qualifiers.rs` to strictly test the C11 6.5.16.1p1 constraint which dictates that implicit assignments between incompatible nested pointers (e.g., `int **` to `const int **`) are rejected as type mismatches, preventing dangerous implicit qualifier additions. Also updates the guardian journal.

---
*PR created automatically by Jules for task [2650733635004343098](https://jules.google.com/task/2650733635004343098) started by @bungcip*