### PR TITLE
Cleanup unused import in tests

### DIFF
--- a/src/tests/parser_errors.rs
+++ b/src/tests/parser_errors.rs
@@ -1,4 +1,4 @@
-use crate::driver::artifact::CompilePhase;
+
 use crate::tests::test_utils::run_fail_with_message;
 
 /// all declarator/declaration/statement parser error is in here


### PR DESCRIPTION
I acted as the Rendi agent to audit the codebase for dead and redundant code. I found an unused import `CompilePhase` in `src/tests/parser_errors.rs` and removed it. I also explicitly printed "No safe refactor opportunities found at this time. Skipping." since no substantial safe refactors were available. Tests passed cleanly after this change.

---
*PR created automatically by Jules for task [16603742415156914263](https://jules.google.com/task/16603742415156914263) started by @bungcip*