### PR TITLE
🛡️ Guardian: Protect C11 §6.5.16.1p1 nested pointer qualifier constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -260,3 +260,8 @@ Action: When testing semantic constraints involving complex derived types (like 
 2024-05-25 - [Block-scope Thread-Local Validation]
 
 Learning: C11 §6.7.1p3 requires that `_Thread_local` variables in block scope must also be specified with either `static` or `extern` storage-class specifiers. Without explicitly testing this invariant, the compiler could easily accept automatic `_Thread_local` variables, breaking compilation or runtime assumptions as thread-local semantics do not apply to automatic storage. Action: Ensure storage class modifier combinations are robustly checked, especially for nested scopes and specific thread-local semantics.
+
+2024-06-01 - [Pointer Assignment and Nested Qualifiers]
+
+Learning: C11 §6.5.16.1p1 requires that operands for assignment are pointers to qualified or unqualified versions of compatible types. For nested pointers, `int **` and `const int **` are not compatible types, and assignments between them are strictly rejected as type mismatches. This strict enforcement prevents implicit qualifier conversions which could allow indirect modification of const data.
+Action: Add tests to enforce that nested pointer assignment correctly rejects incompatible qualifier permutations (e.g. `int **` assigned to `const int **`), ensuring semantic correctness in lvalue conversion and type compatibility.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -152,6 +152,7 @@ pub mod regr_init_range;
 pub mod regr_mixed_sign_comp;
 pub mod regr_pp_short_circuit;
 pub mod regr_shadowing;
+pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod regr_struct_bitfield;
 
 // Test Helpers

--- a/src/tests/guardian_pointer_assignment_nested_qualifiers.rs
+++ b/src/tests/guardian_pointer_assignment_nested_qualifiers.rs
@@ -1,0 +1,51 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+
+#[test]
+fn test_pointer_assignment_nested_qualifiers() {
+    // C11 6.5.16.1p1 requires that operands for assignment are pointers to qualified or unqualified versions of compatible types.
+    // For nested pointers, `int **` and `const int **` are not compatible types, and assignments between them
+    // are strictly rejected as type mismatches, preventing implicit qualifier conversions.
+
+    // 1. Assigning int** to const int**
+    run_fail_with_message(
+        r#"
+        int main() {
+            int **p = 0;
+            const int **q = p;
+            return 0;
+        }
+        "#,
+        "type mismatch: expected const int**, found int**",
+    );
+
+    // 2. Assigning const int** to int**
+    run_fail_with_message(
+        r#"
+        int main() {
+            const int **q = 0;
+            int **p = q;
+            return 0;
+        }
+        "#,
+        "type mismatch: expected int**, found const int**",
+    );
+}
+
+#[test]
+fn test_pointer_assignment_top_level_qualifiers() {
+    // Top-level pointer qualifier conversions are permitted with a warning.
+    // (A warning is standard behavior for implicit discarding of qualifiers).
+    // Here we ensure it doesn't fail with a hard "type mismatch" error.
+    run_pass(
+        r#"
+        int main() {
+            int *p = 0;
+            const int *q = p;
+            p = (int*)q; // cast to avoid warning on exact match if we were strictly testing pass
+            return 0;
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
🧪 What: Added `src/tests/guardian_pointer_assignment_nested_qualifiers.rs` to enforce C11 §6.5.16.1p1 constraints for nested pointer assignments and updated `.jules/guardian.md`.
🎯 Why: To prevent the compiler from accepting invalid implicit qualifier conversions on nested pointers which could allow indirect modification of const-qualified data. `int **` and `const int **` are incompatible types in C11.
🛠️ Phase: Semantic Analysis.
🔬 Verify: Run `cargo test guardian_pointer_assignment_nested_qualifiers`.

---
*PR created automatically by Jules for task [15302429590447415457](https://jules.google.com/task/15302429590447415457) started by @bungcip*