### PR TITLE
test: cover const eval unresolved typeof for builtin types compatible p

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -156,5 +156,5 @@ pub mod regr_struct_bitfield;
 
 // Test Helpers
 pub mod guardian_pointer_assignment_nested_qualifiers;
-pub mod test_utils;
 pub mod semantic_types_compatible;
+pub mod test_utils;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,3 +157,4 @@ pub mod regr_struct_bitfield;
 // Test Helpers
 pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod test_utils;
+pub mod semantic_types_compatible;

--- a/src/tests/semantic_types_compatible.rs
+++ b/src/tests/semantic_types_compatible.rs
@@ -1,0 +1,16 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_pass;
+
+#[test]
+fn test_types_compatible_unresolved_typeof() {
+    run_pass(
+        "
+        int main() {
+            int a = 1;
+            int x = __builtin_types_compatible_p(typeof(({ a; })), typeof(1));
+            return x;
+        }
+        ",
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
Adds a test to cover `has_unresolved_typeof` guard when evaluating `__builtin_types_compatible_p` inside `const_eval.rs`.

---
*PR created automatically by Jules for task [54414521971823426](https://jules.google.com/task/54414521971823426) started by @bungcip*