### PR TITLE
⚡ Bolt: optimize SymbolTable with undo log

### DIFF
--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -407,6 +407,20 @@ pub(crate) struct Function {
     pub builtin_kind: Option<BuiltinFunctionKind>,
 }
 
+#[derive(Debug)]
+enum UndoOp {
+    MapInsertion {
+        scope_id: ScopeId,
+        namespace: Namespace,
+        name: NameId,
+        prev_symbol: Option<SymbolRef>,
+    },
+    SymbolModified {
+        index: SymbolRef,
+        old_symbol: Box<Symbol>,
+    },
+}
+
 /// Symbol table using flattened storage
 #[derive(Debug)]
 pub struct SymbolTable {
@@ -414,6 +428,7 @@ pub struct SymbolTable {
     pub scopes: Vec<Scope>,
     current_scope_id: ScopeId,
     next_scope_id: u32,
+    undo_log: Vec<UndoOp>,
 }
 
 impl SymbolTable {
@@ -425,6 +440,7 @@ impl SymbolTable {
             scopes: Vec::with_capacity(32),
             current_scope_id: ScopeId::GLOBAL,
             next_scope_id: 2, // Start after GLOBAL
+            undo_log: Vec::with_capacity(512),
         };
 
         // Initialize global scope
@@ -485,10 +501,20 @@ impl SymbolTable {
         &mut self.scopes[scope_id.get() as usize - 1]
     }
 
+    fn record_map_insertion(&mut self, scope_id: ScopeId, ns: Namespace, name: NameId, prev: Option<SymbolRef>) {
+        self.undo_log.push(UndoOp::MapInsertion {
+            scope_id,
+            namespace: ns,
+            name,
+            prev_symbol: prev,
+        });
+    }
+
     fn add_symbol_in_scope(&mut self, name: NameId, entry: Symbol, scope_id: ScopeId) -> SymbolRef {
         let sym = self.push_symbol(entry);
         let scope = self.get_scope_mut(scope_id);
-        scope.symbols.insert(name, sym);
+        let prev = scope.symbols.insert(name, sym);
+        self.record_map_insertion(scope_id, Namespace::Ordinary, name, prev);
         sym
     }
 
@@ -498,12 +524,14 @@ impl SymbolTable {
 
     fn add_symbol_in_namespace(&mut self, name: NameId, entry: Symbol, ns: Namespace) -> SymbolRef {
         let sym = self.push_symbol(entry);
-        let current_scope = self.get_scope_mut(self.current_scope_id);
-        match ns {
+        let scope_id = self.current_scope_id;
+        let current_scope = self.get_scope_mut(scope_id);
+        let prev = match ns {
             Namespace::Ordinary => current_scope.symbols.insert(name, sym),
             Namespace::Tag => current_scope.tags.insert(name, sym),
             Namespace::Label => current_scope.labels.insert(name, sym),
         };
+        self.record_map_insertion(scope_id, ns, name, prev);
         sym
     }
 
@@ -610,7 +638,9 @@ impl SymbolTable {
         let ty = QualType::unqualified(TypeRef::dummy());
         let symbol = self.create_symbol(name, SymbolKind::Typedef { aliased_type: ty }, ty, span);
         let sym_ref = self.push_symbol(symbol);
-        self.get_scope_mut(self.current_scope_id).symbols.insert(name, sym_ref);
+        let scope_id = self.current_scope_id;
+        let prev = self.get_scope_mut(scope_id).symbols.insert(name, sym_ref);
+        self.record_map_insertion(scope_id, Namespace::Ordinary, name, prev);
     }
 
     /// Define a non-typedef in the parser (used for type disambiguation).
@@ -626,7 +656,9 @@ impl SymbolTable {
         };
         let symbol = self.create_symbol(name, SymbolKind::Variable(var), ty, span);
         let sym_ref = self.push_symbol(symbol);
-        self.get_scope_mut(self.current_scope_id).symbols.insert(name, sym_ref);
+        let scope_id = self.current_scope_id;
+        let prev = self.get_scope_mut(scope_id).symbols.insert(name, sym_ref);
+        self.record_map_insertion(scope_id, Namespace::Ordinary, name, prev);
     }
 
     /// Define a new variable in the current scope.
@@ -675,7 +707,9 @@ impl SymbolTable {
         };
 
         // Link the local name to the target symbol
-        self.get_scope_mut(self.current_scope_id).symbols.insert(name, target);
+        let scope_id = self.current_scope_id;
+        let prev = self.get_scope_mut(scope_id).symbols.insert(name, target);
+        self.record_map_insertion(scope_id, Namespace::Ordinary, name, prev);
         Ok(target)
     }
 
@@ -721,7 +755,9 @@ impl SymbolTable {
             // Create global entry for the function
             symbol.scope_id = ScopeId::GLOBAL;
             let global = self.merge_global_symbol(name, symbol)?;
-            self.get_scope_mut(self.current_scope_id).symbols.insert(name, global);
+            let scope_id = self.current_scope_id;
+            let prev = self.get_scope_mut(scope_id).symbols.insert(name, global);
+            self.record_map_insertion(scope_id, Namespace::Ordinary, name, prev);
             Ok(global)
         }
     }
@@ -823,6 +859,9 @@ impl SymbolTable {
             return Ok(self.add_symbol_in_scope(name, new_entry, ScopeId::GLOBAL));
         };
 
+        let old_symbol = Box::new(self.get_symbol(sym).clone());
+        self.undo_log.push(UndoOp::SymbolModified { index: sym, old_symbol });
+
         let existing = self.get_symbol_mut(sym);
 
         // 1. Verify kinds match and check variable-specific constraints
@@ -869,15 +908,43 @@ impl SymbolTable {
     pub(crate) fn save_state(&self) -> SymbolTableState {
         SymbolTableState {
             entries_len: self.entries.len(),
-            scopes: self.scopes.clone(),
+            scopes_len: self.scopes.len(),
+            undo_log_len: self.undo_log.len(),
             current_scope_id: self.current_scope_id,
             next_scope_id: self.next_scope_id,
         }
     }
 
     pub(crate) fn restore_state(&mut self, state: SymbolTableState) {
+        while self.undo_log.len() > state.undo_log_len {
+            let op = self.undo_log.pop().unwrap();
+            match op {
+                UndoOp::MapInsertion {
+                    scope_id,
+                    namespace,
+                    name,
+                    prev_symbol,
+                } => {
+                    let scope = self.get_scope_mut(scope_id);
+                    let map = match namespace {
+                        Namespace::Ordinary => &mut scope.symbols,
+                        Namespace::Tag => &mut scope.tags,
+                        Namespace::Label => &mut scope.labels,
+                    };
+                    if let Some(prev) = prev_symbol {
+                        map.insert(name, prev);
+                    } else {
+                        map.remove(&name);
+                    }
+                }
+                UndoOp::SymbolModified { index, old_symbol } => {
+                    self.entries[(index.get() - 1) as usize] = *old_symbol;
+                }
+            }
+        }
+
         self.entries.truncate(state.entries_len);
-        self.scopes = state.scopes;
+        self.scopes.truncate(state.scopes_len);
         self.current_scope_id = state.current_scope_id;
         self.next_scope_id = state.next_scope_id;
     }
@@ -889,6 +956,7 @@ impl SymbolTable {
             scope.tags.clear();
             scope.labels.clear();
         }
+        self.undo_log.clear();
         self.current_scope_id = ScopeId::GLOBAL;
     }
 }
@@ -896,7 +964,8 @@ impl SymbolTable {
 #[derive(Clone)]
 pub struct SymbolTableState {
     entries_len: usize,
-    scopes: Vec<Scope>,
+    scopes_len: usize,
+    undo_log_len: usize,
     current_scope_id: ScopeId,
     next_scope_id: u32,
 }


### PR DESCRIPTION
Implemented a high-performance undo log for the `SymbolTable` to optimize parser transactions.

### 💡 What
Replaced the `Vec<Scope>` clone in `SymbolTableState` with a fine-grained `undo_log: Vec<UndoOp>`. Every modification to the symbol table (symbol insertions into scope maps and mutations of existing global symbols) now records an entry in the log. `restore_state` replays these entries in reverse to revert changes efficiently.

### 🎯 Why
The Cendol parser uses frequent transactions for lookahead and disambiguation. Cloning the entire symbol table state on every transaction was a major performance bottleneck, especially for large files where the symbol table grows deep and wide.

### 📊 Impact
Eliminates $O(N)$ cloning overhead on every parser transaction. For large files like the SQLite amalgamation, this significantly reduces memory churn and improves parsing speed by moving from full-state snapshots to incremental change tracking.

### 🔬 Measurement
Verified correctness with the full unit test suite (`cargo test`). Performance impact can be observed via `cargo bench --bench compiler_benches -- parse_sqlite --quick`.


---
*PR created automatically by Jules for task [1580942090274165071](https://jules.google.com/task/1580942090274165071) started by @bungcip*