### PR TITLE
test: increase coverage for complex binary conversion

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -156,6 +156,6 @@ pub mod regr_struct_bitfield;
 
 // Test Helpers
 pub mod guardian_pointer_assignment_nested_qualifiers;
+pub mod semantic_binary_conversion;
 pub mod semantic_types_compatible;
 pub mod test_utils;
-pub mod semantic_binary_conversion;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -158,3 +158,4 @@ pub mod regr_struct_bitfield;
 pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod semantic_binary_conversion;

--- a/src/tests/semantic_binary_conversion.rs
+++ b/src/tests/semantic_binary_conversion.rs
@@ -1,5 +1,5 @@
-use crate::tests::test_utils::run_pass;
 use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_pass;
 
 #[test]
 fn test_binary_conversion_complex_cast() {

--- a/src/tests/semantic_binary_conversion.rs
+++ b/src/tests/semantic_binary_conversion.rs
@@ -1,0 +1,20 @@
+use crate::tests::test_utils::run_pass;
+use crate::driver::artifact::CompilePhase;
+
+#[test]
+fn test_binary_conversion_complex_cast() {
+    run_pass(
+        r#"
+        void foo() {
+            _Complex float a = 1.0;
+            _Complex double b = 2.0;
+            a + b;
+
+            _Complex double c = 1.0;
+            _Complex float d = 2.0;
+            c + d; // check rhs conversion too
+        }
+        "#,
+        CompilePhase::SemanticLowering,
+    );
+}


### PR DESCRIPTION
Increases code coverage by targeting `Conversion::ComplexCast` match arms in `analyze_binary_operation` inside `src/semantic/analyzer.rs`. Adds exactly one new unit test without modifying production code.

---
*PR created automatically by Jules for task [3396299314450166200](https://jules.google.com/task/3396299314450166200) started by @bungcip*