### PR TITLE
Increase code coverage in `usual_arithmetic_conversions`

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -167,3 +167,4 @@ pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod semantic_binary_conversion;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod semantic_conversions_uncovered;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -165,6 +165,6 @@ pub mod regr_union_cast;
 // Test Helpers
 pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod semantic_binary_conversion;
+pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
-pub mod semantic_conversions_uncovered;

--- a/src/tests/semantic_conversions_uncovered.rs
+++ b/src/tests/semantic_conversions_uncovered.rs
@@ -1,0 +1,13 @@
+use crate::tests::test_utils::run_fail_with_message;
+
+#[test]
+fn test_usual_arithmetic_conversions_non_arithmetic() {
+    let source = r#"
+        int main() {
+            struct A { int x; } a;
+            1 ? a : 5;
+            return 0;
+        }
+    "#;
+    run_fail_with_message(source, "type mismatch: expected struct A, found int");
+}


### PR DESCRIPTION
This commit increases the statement and branch coverage in `src/semantic/conversions.rs` by adding a test case that specifically exercises the early return block in `usual_arithmetic_conversions`. By using a ternary operator with mismatched non-arithmetic types (a struct and an int), the analyzer reaches the fallback path that calls this function, correctly resulting in a type mismatch error and fully covering the previously missed line.

---
*PR created automatically by Jules for task [16223548707102304386](https://jules.google.com/task/16223548707102304386) started by @bungcip*