### PR TITLE
Increase coverage in usual_arithmetic_conversions

### DIFF
--- a/src/tests/semantic_usual_arithmetic_conversions.rs
+++ b/src/tests/semantic_usual_arithmetic_conversions.rs
@@ -46,3 +46,18 @@ fn test_usual_arithmetic_conversions() {
     let (_, result_long_long_unsigned_long) = run_pipeline(source_long_long_unsigned_long, CompilePhase::Mir);
     assert!(result_long_long_unsigned_long.is_ok());
 }
+
+#[test]
+fn test_usual_arithmetic_conversions_reject_struct_int_ternary() {
+    let source = r#"
+        struct S { int a; };
+        int main() {
+            struct S s;
+            int a;
+            1 ? a : s;
+            return 0;
+        }
+    "#;
+    let (_, result) = run_pipeline(source, CompilePhase::Mir);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Adds a test for an uncovered early exit path in `usual_arithmetic_conversions` inside `src/semantic/conversions.rs`. The code exits early when encountering non-arithmetic operands (e.g., struct types). We triggered this by evaluating a ternary expression `1 ? a : s;` where `a` is an int and `s` is a struct, verifying the expected compilation error.

---
*PR created automatically by Jules for task [13494744712977277880](https://jules.google.com/task/13494744712977277880) started by @bungcip*