### PR TITLE
🛡️ Guardian: Protect multiple default label constraint in switch

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -264,3 +264,8 @@ Learning: C11 §6.7.1p3 requires that `_Thread_local` variables in block scope m
 2024-05-31 - [Nested Pointer Qualifiers]
 
 Learning: C11 6.5.16.1p1 requires that operands for assignment are pointers to qualified or unqualified versions of compatible types. For nested pointers, `int **` and `const int **` are NOT compatible types. The compiler correctly prevents implicit conversion for these assignments and returns a type mismatch rather than just emitting a "discards qualifiers" warning. We need to test to ensure we don't accidentally enable this type conversion implicitly because the outer qualifiers would silently be added, which breaks C11 safety assumptions around pointer aliasing. Action: Add tests specifically verifying that type conversions fail outright for incompatible nested pointers like `int **` assigned to `const int **`.
+
+2026-06-15 - [Multiple Default Labels Constraint]
+
+Learning: C11 §6.8.4.2p3 requires that a `switch` statement can have at most one `default` label. However, nested `switch` statements can each have their own `default` label. It is important to ensure that the compiler's tracking of `default` labels correctly resets or scopes per `switch` statement, allowing valid nested cases while rejecting multiple labels at the same level.
+Action: Add tests asserting both the rejection of multiple default labels in a single switch, and the correct acceptance of default labels in nested switch statements.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -167,3 +167,4 @@ pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod semantic_binary_conversion;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_switch_multiple_default;

--- a/src/tests/guardian_switch_multiple_default.rs
+++ b/src/tests/guardian_switch_multiple_default.rs
@@ -1,0 +1,34 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_message, run_pass};
+
+#[test]
+fn test_switch_multiple_default() {
+    let source = r#"
+        int main() {
+            int a = 1;
+            switch(a) {
+                default: break;
+                default: break;
+            }
+        }
+    "#;
+    run_fail_with_message(source, "multiple default labels in one switch");
+}
+
+#[test]
+fn test_switch_nested_default() {
+    // Nested switch statements should allow their own default labels
+    let source = r#"
+        int main() {
+            int a = 1;
+            switch(a) {
+                default:
+                    switch(a) {
+                        default: break;
+                    }
+                    break;
+            }
+        }
+    "#;
+    run_pass(source, CompilePhase::SemanticLowering);
+}


### PR DESCRIPTION
🧪 What: C code snippet + scenario testing C11 6.8.4.2p3 constraint.

🎯 Why: Protects against silent acceptance of invalid C code with multiple default labels within a single switch while allowing them correctly in nested switches.
🛠️ Phase: Semantic Analysis
🔬 Verify: `cargo test guardian_switch`

---
*PR created automatically by Jules for task [190185072317839868](https://jules.google.com/task/190185072317839868) started by @bungcip*