### PR TITLE
⚡ Bolt: Optimize hashing with FxHashMap/FxHashSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
+ "rustc-hash",
  "serde",
  "serde_yaml",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 hashbrown = { version = "0.17", features = ["serde"] }
+rustc-hash = "2.1"
 thiserror = "2.0"
 log = "0.4"
 env_logger = "0.11"

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -3,7 +3,7 @@ use crate::diagnostic::{Diagnostic, DiagnosticEngine, DiagnosticLevel};
 use crate::lang_options::CStandard;
 use crate::source_manager::{FileKind, SourceId, SourceLoc, SourceManager, SourceSpan};
 use chrono::{DateTime, Datelike, Timelike, Utc};
-use hashbrown::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::Arc;
 
 use super::pp_lexer::PPLexer;
@@ -28,12 +28,12 @@ pub struct Preprocessor<'src> {
     pub(crate) keywords: PPKeywordTable,
 
     // Macro management
-    pub(crate) macros: HashMap<StringId, MacroInfo>,
+    pub(crate) macros: FxHashMap<StringId, MacroInfo>,
     pub(crate) hide_sets: HideSetTable,
-    pub(crate) macro_stack: HashMap<StringId, Vec<Option<MacroInfo>>>,
+    pub(crate) macro_stack: FxHashMap<StringId, Vec<Option<MacroInfo>>>,
 
     // Include management
-    pub(crate) once_included: HashSet<SourceId>,
+    pub(crate) once_included: FxHashSet<SourceId>,
 
     // Conditional compilation state
     pub(crate) conditional_stack: Vec<PPConditionalInfo>,
@@ -41,8 +41,8 @@ pub struct Preprocessor<'src> {
     // Include handling
     pub(crate) include_stack: Vec<IncludeStackInfo>,
     pub(crate) header_search: HeaderSearch,
-    pub(crate) built_in_headers: HashMap<&'static str, &'static str>,
-    pub(crate) built_in_file_ids: HashMap<String, SourceId>,
+    pub(crate) built_in_headers: FxHashMap<&'static str, &'static str>,
+    pub(crate) built_in_file_ids: FxHashMap<String, SourceId>,
 
     // Token management
     pub(crate) lexer_stack: Vec<PPLexer>,
@@ -59,7 +59,7 @@ pub struct Preprocessor<'src> {
     pub(crate) counter: u32,
     pub(crate) in_macro_argument_parsing: usize,
     eof_emitted: bool,
-    pub(crate) poisoned_identifiers: HashSet<StringId>,
+    pub(crate) poisoned_identifiers: FxHashSet<StringId>,
 }
 
 impl<'src> Preprocessor<'src> {
@@ -90,7 +90,7 @@ impl<'src> Preprocessor<'src> {
             header_search.add_framework_path(path.clone());
         }
 
-        let mut built_in_headers = HashMap::new();
+        let mut built_in_headers = FxHashMap::default();
         built_in_headers.insert("stddef.h", include_str!("../../custom-include/stddef.h"));
         built_in_headers.insert("stdint.h", include_str!("../../custom-include/stdint.h"));
         built_in_headers.insert("stdarg.h", include_str!("../../custom-include/stdarg.h"));
@@ -105,15 +105,15 @@ impl<'src> Preprocessor<'src> {
             diag,
             c_standard: config.c_standard,
             keywords: PPKeywordTable::new(),
-            macros: HashMap::new(),
+            macros: FxHashMap::default(),
             hide_sets: HideSetTable::new(),
-            macro_stack: HashMap::new(),
-            once_included: HashSet::new(),
+            macro_stack: FxHashMap::default(),
+            once_included: FxHashSet::default(),
             conditional_stack: Vec::new(),
             include_stack: Vec::new(),
             header_search,
             built_in_headers,
-            built_in_file_ids: HashMap::new(),
+            built_in_file_ids: FxHashMap::default(),
             lexer_stack: Vec::new(),
             pending_tokens: Vec::new(),
             include_depth: 0,
@@ -124,7 +124,7 @@ impl<'src> Preprocessor<'src> {
             counter: 0,
             in_macro_argument_parsing: 0,
             eof_emitted: false,
-            poisoned_identifiers: HashSet::new(),
+            poisoned_identifiers: FxHashSet::default(),
         };
 
         // Initialize built-in headers

--- a/src/pp/types.rs
+++ b/src/pp/types.rs
@@ -3,7 +3,7 @@ use crate::lang_options::CStandard;
 use crate::pp::pp_lexer::PPToken;
 use crate::source_manager::{SourceId, SourceLoc};
 use chrono::{DateTime, Utc};
-use hashbrown::HashMap;
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -27,9 +27,9 @@ bitflags::bitflags! {
 #[derive(Debug, Clone)]
 pub(crate) struct HideSetTable {
     pub(crate) sets: Vec<Arc<[StringId]>>,
-    pub(crate) map: HashMap<Arc<[StringId]>, u32>,
-    pub(crate) intersection_cache: HashMap<(u32, u32), u32>,
-    pub(crate) insert_cache: HashMap<(u32, StringId), u32>,
+    pub(crate) map: FxHashMap<Arc<[StringId]>, u32>,
+    pub(crate) intersection_cache: FxHashMap<(u32, u32), u32>,
+    pub(crate) insert_cache: FxHashMap<(u32, StringId), u32>,
 }
 
 impl Default for HideSetTable {
@@ -42,13 +42,13 @@ impl HideSetTable {
     pub(super) fn new() -> Self {
         // Index 0 is the empty hide set
         let empty: Arc<[StringId]> = Arc::from([]);
-        let mut map = HashMap::new();
+        let mut map = FxHashMap::default();
         map.insert(empty.clone(), 0);
         Self {
             sets: vec![empty],
             map,
-            intersection_cache: HashMap::new(),
-            insert_cache: HashMap::new(),
+            intersection_cache: FxHashMap::default(),
+            insert_cache: FxHashMap::default(),
         }
     }
     pub(crate) fn intern(&mut self, set: SmallVec<[StringId; 4]>) -> u32 {

--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -4,7 +4,7 @@
 //! symbols and scopes during semantic analysis. It maintains a hierarchical
 //! scope structure and provides efficient symbol lookup and storage.
 
-use hashbrown::HashMap;
+use rustc_hash::FxHashMap;
 use serde::Serialize;
 use std::num::NonZeroU32;
 use std::sync::Arc;
@@ -381,9 +381,9 @@ pub enum Namespace {
 #[derive(Debug, Default, Clone)]
 pub struct Scope {
     pub parent: Option<ScopeId>,
-    pub symbols: HashMap<NameId, SymbolRef>, // Ordinary identifiers
-    pub tags: HashMap<NameId, SymbolRef>,    // Struct/union/enum tags
-    pub labels: HashMap<NameId, SymbolRef>,  // Goto labels
+    pub symbols: FxHashMap<NameId, SymbolRef>, // Ordinary identifiers
+    pub tags: FxHashMap<NameId, SymbolRef>,    // Struct/union/enum tags
+    pub labels: FxHashMap<NameId, SymbolRef>,  // Goto labels
     pub level: u32,
 }
 

--- a/src/semantic/type_registry.rs
+++ b/src/semantic/type_registry.rs
@@ -10,7 +10,7 @@ use crate::{
     ast::{NameId, NodeRef},
     semantic::QualType,
 };
-use hashbrown::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use target_lexicon::{PointerWidth, Triple};
 
@@ -90,13 +90,13 @@ pub struct TypeRegistry {
     pub types: Vec<Type>,
 
     // --- Canonicalization caches ---
-    pointer_cache: HashMap<QualType, TypeRef>,
-    array_cache: HashMap<(TypeRef, ArraySizeType), TypeRef>,
-    function_cache: HashMap<FnSigKey, TypeRef>,
-    complex_cache: HashMap<TypeRef, TypeRef>,
+    pointer_cache: FxHashMap<QualType, TypeRef>,
+    array_cache: FxHashMap<(TypeRef, ArraySizeType), TypeRef>,
+    function_cache: FxHashMap<FnSigKey, TypeRef>,
+    complex_cache: FxHashMap<TypeRef, TypeRef>,
 
     // --- Layout computation tracking ---
-    layout_in_progress: HashSet<TypeRef>,
+    layout_in_progress: FxHashSet<TypeRef>,
 
     // --- Common builtin types ---
     pub type_void: TypeRef,
@@ -169,11 +169,11 @@ impl TypeRegistry {
         let mut reg = TypeRegistry {
             target_triple,
             types: Vec::new(),
-            pointer_cache: HashMap::new(),
-            array_cache: HashMap::new(),
-            function_cache: HashMap::new(),
-            complex_cache: HashMap::new(),
-            layout_in_progress: HashSet::new(),
+            pointer_cache: FxHashMap::default(),
+            array_cache: FxHashMap::default(),
+            function_cache: FxHashMap::default(),
+            complex_cache: FxHashMap::default(),
+            layout_in_progress: FxHashSet::default(),
 
             // temporary placeholders - will be overwritten by create_builtin
             type_void: TypeRef::dummy(),


### PR DESCRIPTION
This PR implements a standard performance optimization for compilers by replacing the default cryptographically secure hasher in `hashbrown::HashMap` and `hashbrown::HashSet` with the faster `FxHash` from the `rustc-hash` crate.

### 💡 What
- Added `rustc-hash = "2.1"` to `Cargo.toml`.
- Updated `Preprocessor`, `HideSetTable`, `TypeRegistry`, and `SymbolTable` to use `FxHashMap` and `FxHashSet`.

### 🎯 Why
The compiler uses `u32` wrappers (like `StringId`, `NameId`, and `TypeRef`) as keys in many high-traffic maps. The default hasher in Rust is designed to be resistant to hash-flooding DOS attacks, which adds unnecessary overhead for non-malicious compiler workloads. `FxHash` is much faster for these small keys and is idiomatic in the Rust compiler ecosystem.

### 📊 Impact
Measurable reduction in hashing overhead during preprocessing and semantic analysis. This is particularly beneficial for Dave Prosser's macro expansion algorithm and recursive type canonicalization, where map lookups are extremely frequent.

### 🔬 Measurement
Verified via `cargo bench --bench compiler_benches` on the SQLite amalgamation. All functional tests passed with `cargo test`.


---
*PR created automatically by Jules for task [4981561780777921054](https://jules.google.com/task/4981561780777921054) started by @bungcip*