### PR TITLE
test: increase coverage for invalid function pointer comparisons

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -169,3 +169,4 @@ pub mod semantic_binary_conversion;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod semantic_binary_invalid_operands;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -166,7 +166,7 @@ pub mod regr_union_cast;
 pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod guardian_switch_multiple_default;
 pub mod semantic_binary_conversion;
+pub mod semantic_binary_invalid_operands;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
-pub mod semantic_binary_invalid_operands;

--- a/src/tests/semantic_binary_invalid_operands.rs
+++ b/src/tests/semantic_binary_invalid_operands.rs
@@ -1,0 +1,16 @@
+use crate::tests::test_utils::run_fail_with_message;
+
+#[test]
+fn test_invalid_binary_operands_comparison() {
+    run_fail_with_message(
+        r#"
+        int main() {
+            int (*f)(void);
+            void *p;
+            f < p;
+            return 0;
+        }
+        "#,
+        "Invalid operands for binary operation: have 'int()*' and 'void*'",
+    );
+}


### PR DESCRIPTION
This PR adds a unit test in `src/tests/semantic_binary_invalid_operands.rs` to cover the previously untested error path in `src/semantic/analyzer.rs` where the compiler rejects a relational comparison between a function pointer and an incompatible data pointer (`void*`). This change strictly increases code coverage as requested without modifying any production code.

---
*PR created automatically by Jules for task [4639419074267653365](https://jules.google.com/task/4639419074267653365) started by @bungcip*