### PR TITLE
🛡️ Guardian: Parameter Storage Class Constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -268,3 +268,8 @@ Learning: C11 6.5.16.1p1 requires that operands for assignment are pointers to q
 
 Learning: A `switch` statement can correctly contain zero or one `default` label. However, the parser and semantic analyzer must properly isolate `default` label checks to the innermost enclosing `switch`. The `switch_stack` needs to track `default_seen` correctly for nested switches without bleeding the state outward or inward across boundaries.
 Action: Add tests using `run_fail_with_diagnostic` targeting `CompilePhase::Mir` (since the lowering validates switch structure) to ensure a single `switch` rejects multiple `default` labels while properly allowing a nested `switch` to also define its own `default` label. Ensure the precise span (line, column) of the secondary `default` label is validated.
+
+2024-06-05 - [Parameter Storage Class Constraints]
+
+Learning: C11 §6.7.6.3p2 specifies that the only storage-class specifier that shall occur in a parameter declaration is `register`. The compiler correctly enforced this in lowering via `SemanticError::InvalidStorageClassForParameter`, but lacked dedicated integration tests to verify this exact rejection for `static`, `extern`, and `auto`. We implemented a dedicated test file to guarantee this semantic rule is always enforced properly.
+Action: Implement specific targeted tests for all invalid combinations of parameter storage classes to ensure regressions don't occur when refactoring the semantic analyzer or function parameter parsing logic.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -145,6 +145,7 @@ pub mod guardian_static_array_constraints;
 pub mod guardian_ternary_pointer_constraints;
 pub mod guardian_typedef_member_function;
 pub mod guardian_typedef_redefinition;
+pub mod guardian_storage_class_parameter;
 pub mod guardian_vla;
 pub mod guardian_vm_linkage_constraints;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -142,10 +142,10 @@ pub mod guardian_parameter_completeness;
 pub mod guardian_register_constraints;
 pub mod guardian_sizeof_alignof;
 pub mod guardian_static_array_constraints;
+pub mod guardian_storage_class_parameter;
 pub mod guardian_ternary_pointer_constraints;
 pub mod guardian_typedef_member_function;
 pub mod guardian_typedef_redefinition;
-pub mod guardian_storage_class_parameter;
 pub mod guardian_vla;
 pub mod guardian_vm_linkage_constraints;
 

--- a/src/tests/guardian_storage_class_parameter.rs
+++ b/src/tests/guardian_storage_class_parameter.rs
@@ -1,0 +1,56 @@
+use crate::{
+    driver::artifact::CompilePhase,
+    tests::test_utils::{run_fail_with_diagnostic, run_pass},
+};
+
+#[test]
+fn test_register_allowed_for_parameter() {
+    run_pass(
+        r#"
+        void f(register int x);
+        int main() {
+            return 0;
+        }
+        "#,
+        CompilePhase::SemanticLowering,
+    );
+}
+
+#[test]
+fn test_static_prohibited_for_parameter() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(static int x);
+        "#,
+        CompilePhase::SemanticLowering,
+        "invalid storage class for function parameter",
+        2,
+        16,
+    );
+}
+
+#[test]
+fn test_extern_prohibited_for_parameter() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(extern int x);
+        "#,
+        CompilePhase::SemanticLowering,
+        "invalid storage class for function parameter",
+        2,
+        16,
+    );
+}
+
+#[test]
+fn test_auto_prohibited_for_parameter() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(auto int x);
+        "#,
+        CompilePhase::SemanticLowering,
+        "invalid storage class for function parameter",
+        2,
+        16,
+    );
+}

--- a/test.c
+++ b/test.c
@@ -1,1 +1,0 @@
-void f(static int x);

--- a/test.c
+++ b/test.c
@@ -1,0 +1,1 @@
+void f(static int x);


### PR DESCRIPTION
- 🧪 What: Added negative tests to verify `static`, `extern`, and `auto` are rejected on function parameters, and `register` is allowed.
- 🎯 Why: C11 §6.7.6.3p2 requires that the only storage-class specifier allowed in a parameter declaration is `register`.
- 🛠️ Phase: Semantic Lowering.
- 🔬 Verify: Run `cargo test guardian_storage_class_parameter`.

---
*PR created automatically by Jules for task [2251894569118657567](https://jules.google.com/task/2251894569118657567) started by @bungcip*