### PR TITLE
test(semantic): increase code coverage by adding CleanupNotAFunction test

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -168,7 +168,7 @@ pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod guardian_switch_multiple_default;
 pub mod semantic_binary_conversion;
 pub mod semantic_binary_invalid_operands;
+pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
-pub mod semantic_cleanup_coverage;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -171,3 +171,4 @@ pub mod semantic_binary_invalid_operands;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod semantic_cleanup_coverage;

--- a/src/tests/semantic_cleanup_coverage.rs
+++ b/src/tests/semantic_cleanup_coverage.rs
@@ -1,5 +1,5 @@
-use crate::tests::test_utils::run_fail_with_diagnostic;
 use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
 
 #[test]
 fn test_cleanup_not_a_function() {
@@ -9,5 +9,11 @@ fn test_cleanup_not_a_function() {
             int x __attribute__((cleanup(not_a_func)));
         }
     ";
-    run_fail_with_diagnostic(source, CompilePhase::SemanticLowering, "cleanup argument not a function", 4, 42);
+    run_fail_with_diagnostic(
+        source,
+        CompilePhase::SemanticLowering,
+        "cleanup argument not a function",
+        4,
+        42,
+    );
 }

--- a/src/tests/semantic_cleanup_coverage.rs
+++ b/src/tests/semantic_cleanup_coverage.rs
@@ -1,0 +1,13 @@
+use crate::tests::test_utils::run_fail_with_diagnostic;
+use crate::driver::artifact::CompilePhase;
+
+#[test]
+fn test_cleanup_not_a_function() {
+    let source = "
+        int not_a_func = 42;
+        void test() {
+            int x __attribute__((cleanup(not_a_func)));
+        }
+    ";
+    run_fail_with_diagnostic(source, CompilePhase::SemanticLowering, "cleanup argument not a function", 4, 42);
+}


### PR DESCRIPTION
Coverage increased from 85.10% to 85.12% with the newly added test testing the `CleanupNotAFunction` error in `src/semantic/errors.rs` and `src/semantic/lowering.rs`.

---
*PR created automatically by Jules for task [10257168866856254230](https://jules.google.com/task/10257168866856254230) started by @bungcip*