### PR TITLE
🛡️ Guardian: Protect continue statement validity constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -273,3 +273,7 @@ Action: Add tests using `run_fail_with_diagnostic` targeting `CompilePhase::Mir`
 
 Learning: C11 §6.7.6.3p2 specifies that the only storage-class specifier that shall occur in a parameter declaration is `register`. The compiler correctly enforced this in lowering via `SemanticError::InvalidStorageClassForParameter`, but lacked dedicated integration tests to verify this exact rejection for `static`, `extern`, and `auto`. We implemented a dedicated test file to guarantee this semantic rule is always enforced properly.
 Action: Implement specific targeted tests for all invalid combinations of parameter storage classes to ensure regressions don't occur when refactoring the semantic analyzer or function parameter parsing logic.
+2025-05-18 - [Validate continue outside loops]
+
+Learning: A `continue` statement is only allowed inside loop statements (`while`, `do`, `for`). It is an easy mistake to forget that `continue` is not allowed directly inside a `switch` statement unless that `switch` statement is itself enclosed within a loop. The semantic analyzer correctly tracked `loop_depth`, but this needed explicit verification because switch statements have their own jump tracking mechanics for `break` (via `switch_stack`). Ensuring `if` and `switch` context doesn't improperly swallow or misreport invalid `continue` locations ensures that loop invariants are upheld during lowering.
+Action: Explicitly separate the negative testing of `break` and `continue` inside and outside of `switch`/loop permutations. Added `guardian_continue_not_in_loop` tests.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -171,3 +171,4 @@ pub mod semantic_binary_invalid_operands;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_continue_not_in_loop;

--- a/src/tests/guardian_continue_not_in_loop.rs
+++ b/src/tests/guardian_continue_not_in_loop.rs
@@ -1,0 +1,89 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_continue_in_switch_rejected() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            switch (x) {
+                case 1: continue;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        4,
+        25,
+    );
+}
+
+#[test]
+fn test_continue_in_nested_switch_rejected() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x, int y) {
+            switch (x) {
+                case 1:
+                    switch (y) {
+                        case 2: continue;
+                    }
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        6,
+        33,
+    );
+}
+
+#[test]
+fn test_continue_in_if_rejected() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            if (x) {
+                continue;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        4,
+        17,
+    );
+}
+
+#[test]
+fn test_continue_valid_in_loop_in_switch() {
+    crate::tests::test_utils::run_pass(
+        r#"
+        void f(int x) {
+            switch (x) {
+                case 1:
+                    while (1) {
+                        continue;
+                    }
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}
+
+#[test]
+fn test_continue_valid_in_switch_in_loop() {
+    crate::tests::test_utils::run_pass(
+        r#"
+        void f(int x) {
+            while (1) {
+                switch (x) {
+                    case 1: continue;
+                }
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
This PR adds tests to ensure that the compiler correctly enforces C11 constraints regarding `continue` statements. Specifically, it tests that `continue` is rejected if it is not inside a loop statement, even if it is placed inside a `switch` statement (where `break` is allowed) or an `if` statement. Conversely, it tests that `continue` is allowed when inside a loop that is nested inside a `switch`, or inside a `switch` that is nested inside a loop. This helps guarantee that the `loop_depth` logic works independently and correctly with the `switch_stack` logic.

---
*PR created automatically by Jules for task [5089217538710148563](https://jules.google.com/task/5089217538710148563) started by @bungcip*