### PR TITLE
🛡️ Guardian: Reject break statements outside loop or switch

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -273,3 +273,7 @@ Action: Add tests using `run_fail_with_diagnostic` targeting `CompilePhase::Mir`
 
 Learning: C11 §6.7.6.3p2 specifies that the only storage-class specifier that shall occur in a parameter declaration is `register`. The compiler correctly enforced this in lowering via `SemanticError::InvalidStorageClassForParameter`, but lacked dedicated integration tests to verify this exact rejection for `static`, `extern`, and `auto`. We implemented a dedicated test file to guarantee this semantic rule is always enforced properly.
 Action: Implement specific targeted tests for all invalid combinations of parameter storage classes to ensure regressions don't occur when refactoring the semantic analyzer or function parameter parsing logic.
+
+2025-02-14 - [C11 §6.8.6.3: Break not in loop or switch]
+
+Learning: Break statements are rejected outside of loop or switch statements. This is tricky because standalone `if` statements or simple function bodies are not valid targets for `break`. A dedicated test ensures that `SemanticError::BreakNotInLoop` is correctly thrown in these cases, preventing miscompilation. Action: Add `guardian_break_not_in_loop_or_switch.rs` to validate this invariant, asserting correct phase (`SemanticLowering`), message, and precise line/column spans.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -172,3 +172,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_break_not_in_loop_or_switch;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -164,6 +164,7 @@ pub mod regr_typeof_ternary;
 pub mod regr_union_cast;
 
 // Test Helpers
+pub mod guardian_break_not_in_loop_or_switch;
 pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod guardian_switch_multiple_default;
 pub mod semantic_binary_conversion;
@@ -172,4 +173,3 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
-pub mod guardian_break_not_in_loop_or_switch;

--- a/src/tests/guardian_break_not_in_loop_or_switch.rs
+++ b/src/tests/guardian_break_not_in_loop_or_switch.rs
@@ -1,0 +1,62 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_break_not_in_loop_or_switch() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(void) {
+            break;
+        }
+        "#,
+        CompilePhase::Mir,
+        "break statement not in loop or switch",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_break_in_if_not_in_loop() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            if (x) {
+                break;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "break statement not in loop or switch",
+        4,
+        17,
+    );
+}
+
+#[test]
+fn test_break_in_loop() {
+    crate::tests::test_utils::run_pass(
+        r#"
+        void f(void) {
+            while (1) {
+                break;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}
+
+#[test]
+fn test_break_in_switch() {
+    crate::tests::test_utils::run_pass(
+        r#"
+        void f(int x) {
+            switch (x) {
+                case 1: break;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
🧪 What: Added C code snippets validating that `break` statements are rejected outside loop or switch constructs.
🎯 Why: Prevents language miscompilation by guaranteeing that `break` cannot bypass control flow in invalid contexts (e.g., inside an `if` that is not contained in a loop).
🛠️ Phase: SemanticLowering
🔬 Verify: Run `cargo test guardian_break_not_in_loop_or_switch`

---
*PR created automatically by Jules for task [7787528877577454076](https://jules.google.com/task/7787528877577454076) started by @bungcip*