### PR TITLE
🛡️ Guardian: [Conflicting storage class specifier rejection]

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -273,3 +273,7 @@ Action: Add tests using `run_fail_with_diagnostic` targeting `CompilePhase::Mir`
 
 Learning: C11 §6.7.6.3p2 specifies that the only storage-class specifier that shall occur in a parameter declaration is `register`. The compiler correctly enforced this in lowering via `SemanticError::InvalidStorageClassForParameter`, but lacked dedicated integration tests to verify this exact rejection for `static`, `extern`, and `auto`. We implemented a dedicated test file to guarantee this semantic rule is always enforced properly.
 Action: Implement specific targeted tests for all invalid combinations of parameter storage classes to ensure regressions don't occur when refactoring the semantic analyzer or function parameter parsing logic.
+
+2024-11-20 - [Conflicting Storage Classes]
+Learning: Cendol correctly rejects multiple mutually exclusive storage classes (C11 §6.7.1) via `SemanticError::ConflictingStorageClasses`. `_Thread_local` is appropriately allowed alongside `static` and `extern`, but conflicts with `auto`, `register`, and `typedef`. The spans emitted for the conflict align with the start of the declaration.
+Action: Add dedicated regression test (`guardian_conflicting_storage_classes.rs`) covering standard collisions and `_Thread_local` specific exceptions.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -171,3 +171,4 @@ pub mod semantic_binary_invalid_operands;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_conflicting_storage_classes;

--- a/src/tests/guardian_conflicting_storage_classes.rs
+++ b/src/tests/guardian_conflicting_storage_classes.rs
@@ -1,0 +1,50 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_diagnostic, run_pass};
+
+#[test]
+fn conflicting_storage_classes() {
+    let source = "static extern int x;";
+    run_fail_with_diagnostic(source, CompilePhase::SemanticLowering, "conflicting storage class specifiers", 1, 1);
+}
+
+#[test]
+fn conflicting_storage_classes_auto() {
+    let source = "void foo() { auto register int y; }";
+    run_fail_with_diagnostic(source, CompilePhase::SemanticLowering, "conflicting storage class specifiers", 1, 14);
+}
+
+#[test]
+fn conflicting_storage_classes_typedef() {
+    let source = "typedef static int z;";
+    run_fail_with_diagnostic(source, CompilePhase::SemanticLowering, "conflicting storage class specifiers", 1, 1);
+}
+
+#[test]
+fn thread_local_allows_static() {
+    let source = "_Thread_local static int a;";
+    run_pass(source, CompilePhase::SemanticLowering);
+}
+
+#[test]
+fn thread_local_allows_extern() {
+    let source = "_Thread_local extern int a;";
+    run_pass(source, CompilePhase::SemanticLowering);
+}
+
+#[test]
+fn thread_local_conflicts_with_auto() {
+    let source = "void foo() { _Thread_local auto int a; }";
+    run_fail_with_diagnostic(source, CompilePhase::SemanticLowering, "conflicting storage class specifiers", 1, 14);
+}
+
+#[test]
+fn thread_local_conflicts_with_register() {
+    let source = "void foo() { _Thread_local register int a; }";
+    run_fail_with_diagnostic(source, CompilePhase::SemanticLowering, "conflicting storage class specifiers", 1, 14);
+}
+
+#[test]
+fn thread_local_conflicts_with_typedef() {
+    let source = "_Thread_local typedef int a;";
+    run_fail_with_diagnostic(source, CompilePhase::SemanticLowering, "conflicting storage class specifiers", 1, 1);
+}


### PR DESCRIPTION
🧪 What: Added new tests in `src/tests/guardian_conflicting_storage_classes.rs` verifying compiler rejection of multiple mutually exclusive storage class specifiers (e.g., `static extern`), while allowing correct usage of `_Thread_local`.
🎯 Why: Ensures compliance with C11 §6.7.1, preventing miscompilation or silent acceptance of invalid C code with contradicting storage classes. Validates correct `ConflictingStorageClasses` error and span emission.
🛠️ Phase: SemanticLowering
🔬 Verify: Run `cargo test guardian_conflicting_storage_classes`

---
*PR created automatically by Jules for task [17486859357431117553](https://jules.google.com/task/17486859357431117553) started by @bungcip*