### PR TITLE
🛡️ Guardian: Reject continue statements not inside loops

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -277,3 +277,7 @@ Action: Implement specific targeted tests for all invalid combinations of parame
 2025-02-14 - [C11 §6.8.6.3: Break not in loop or switch]
 
 Learning: Break statements are rejected outside of loop or switch statements. This is tricky because standalone `if` statements or simple function bodies are not valid targets for `break`. A dedicated test ensures that `SemanticError::BreakNotInLoop` is correctly thrown in these cases, preventing miscompilation. Action: Add `guardian_break_not_in_loop_or_switch.rs` to validate this invariant, asserting correct phase (`SemanticLowering`), message, and precise line/column spans.
+2026-06-22 - [C11 §6.8.6.2: Continue not in loop]
+
+Learning: Continue statements are rejected outside of loop statements. This is tricky because standalone `if` statements, `switch` statements, or simple function bodies are not valid targets for `continue`. A dedicated test ensures that `SemanticError::ContinueNotInLoop` is correctly thrown in these cases, preventing miscompilation.
+Action: Add `guardian_continue_not_in_loop.rs` to validate this invariant, asserting correct phase (`Mir`), message, and precise line/column spans.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -165,6 +165,7 @@ pub mod regr_union_cast;
 
 // Test Helpers
 pub mod guardian_break_not_in_loop_or_switch;
+pub mod guardian_continue_not_in_loop;
 pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod guardian_switch_multiple_default;
 pub mod semantic_binary_conversion;

--- a/src/tests/guardian_continue_not_in_loop.rs
+++ b/src/tests/guardian_continue_not_in_loop.rs
@@ -1,0 +1,83 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_continue_not_in_loop() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(void) {
+            continue;
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_continue_in_if_not_in_loop() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            if (x) {
+                continue;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        4,
+        17,
+    );
+}
+
+#[test]
+fn test_continue_in_switch_not_in_loop() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            switch (x) {
+                case 1:
+                    continue;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        5,
+        21,
+    );
+}
+
+#[test]
+fn test_continue_in_loop() {
+    crate::tests::test_utils::run_pass(
+        r#"
+        void f(void) {
+            while (1) {
+                continue;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}
+
+#[test]
+fn test_continue_in_switch_in_loop() {
+    crate::tests::test_utils::run_pass(
+        r#"
+        void f(int x) {
+            while (1) {
+                switch (x) {
+                    case 1:
+                        continue;
+                }
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}

--- a/src/tests/semantic_control_flow.rs
+++ b/src/tests/semantic_control_flow.rs
@@ -208,18 +208,6 @@ fn test_break_outside_loop() {
 }
 
 #[test]
-fn test_continue_outside_loop() {
-    run_fail_with_message(
-        r#"
-        int main() {
-            continue;
-        }
-        "#,
-        "continue statement not in loop",
-    );
-}
-
-#[test]
 fn test_noreturn_for_break_falls_through() {
     let source = r#"
         _Noreturn void die(void) {


### PR DESCRIPTION
Add guardian test `guardian_continue_not_in_loop.rs` to validate that `continue` statements are rejected if they are not within a loop statement.
Also add learning to `.jules/guardian.md`.

---
*PR created automatically by Jules for task [5779219950222791832](https://jules.google.com/task/5779219950222791832) started by @bungcip*