### PR TITLE
🛡️ Guardian: Add tests for switch duplicate case constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -277,3 +277,6 @@ Action: Implement specific targeted tests for all invalid combinations of parame
 2025-02-14 - [C11 §6.8.6.3: Break not in loop or switch]
 
 Learning: Break statements are rejected outside of loop or switch statements. This is tricky because standalone `if` statements or simple function bodies are not valid targets for `break`. A dedicated test ensures that `SemanticError::BreakNotInLoop` is correctly thrown in these cases, preventing miscompilation. Action: Add `guardian_break_not_in_loop_or_switch.rs` to validate this invariant, asserting correct phase (`SemanticLowering`), message, and precise line/column spans.
+2024-06-23 - [Duplicate Case Statement Testing]
+Learning: Cendol correctly checks for duplicate case values in switch statements but ensuring the test verifies the proper nested switch isolation is important for avoiding false positives. It uses SemanticError::DuplicateCase for this purpose.
+Action: Add a test guardian_duplicate_case.rs that checks both the rejection of duplicate cases within the same switch block and the allowance of identical case labels in nested switch blocks.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -173,3 +173,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_duplicate_case;

--- a/src/tests/guardian_duplicate_case.rs
+++ b/src/tests/guardian_duplicate_case.rs
@@ -1,0 +1,38 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_diagnostic, run_pass};
+
+#[test]
+fn test_duplicate_case_rejected() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            switch (x) {
+                case 1: break;
+                case 1: break;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "duplicate case value '1'",
+        5,
+        25,
+    );
+}
+
+#[test]
+fn test_nested_switch_duplicate_case_allowed() {
+    run_pass(
+        r#"
+        void f(int x, int y) {
+            switch (x) {
+                case 1:
+                    switch (y) {
+                        case 1: break;
+                    }
+                    break;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
🛡️ Guardian: Add tests for switch duplicate case constraints

🧪 What: Added new tests in `guardian_duplicate_case.rs` that explicitly check for duplicate case values inside switch statements.
🎯 Why: Ensuring the semantic analyzer correctly prevents multiple identical switch case labels from being compiled inside a single switch statement while allowing them if logically isolated inside nested ones, thus avoiding issues during MIR and target jump table generation.
🛠️ Phase: Semantic/MIR
🔬 Verify: Run `cargo test guardian_duplicate_case` to execute.

---
*PR created automatically by Jules for task [13223605562358119964](https://jules.google.com/task/13223605562358119964) started by @bungcip*