### PR TITLE
🛡️ Guardian: Compiler behavior protected for `continue` outside loops

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -277,3 +277,7 @@ Action: Implement specific targeted tests for all invalid combinations of parame
 2025-02-14 - [C11 §6.8.6.3: Break not in loop or switch]
 
 Learning: Break statements are rejected outside of loop or switch statements. This is tricky because standalone `if` statements or simple function bodies are not valid targets for `break`. A dedicated test ensures that `SemanticError::BreakNotInLoop` is correctly thrown in these cases, preventing miscompilation. Action: Add `guardian_break_not_in_loop_or_switch.rs` to validate this invariant, asserting correct phase (`SemanticLowering`), message, and precise line/column spans.
+
+2024-06-25 - [Continue Not In Loop Validation]
+
+Learning: [Cendol correctly enforces C11 §6.8.6.2p1 by strictly rejecting `continue` statements that are not enclosed within a loop. This semantic check runs during the MIR generation phase (`CompilePhase::Mir`) since control flow checks are performed by the semantic analyzer alongside MIR construction. Spans and diagnostics correctly pinpoint the invalid `continue` token.] Action: [Ensure control flow checks like `break` and `continue` validation always use `CompilePhase::Mir` in test assertions instead of earlier phases, and explicitly test nested non-loop blocks (like `if` or `switch`) to avoid regressions where scoping logic might erroneously clear the "in loop" state.]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -173,3 +173,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_continue_not_in_loop;

--- a/src/tests/guardian_continue_not_in_loop.rs
+++ b/src/tests/guardian_continue_not_in_loop.rs
@@ -1,0 +1,65 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_continue_not_in_loop() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(void) {
+            continue;
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_continue_in_if_not_in_loop() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            if (x) {
+                continue;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        4,
+        17,
+    );
+}
+
+#[test]
+fn test_continue_in_switch_not_in_loop() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            switch (x) {
+                case 1: continue;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "continue statement not in loop statement",
+        4,
+        25,
+    );
+}
+
+#[test]
+fn test_continue_in_loop() {
+    crate::tests::test_utils::run_pass(
+        r#"
+        void f(void) {
+            while (1) {
+                continue;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
Added `guardian_continue_not_in_loop.rs` to validate the `ContinueNotInLoop` invariant, ensuring that continue statements outside of a loop block correctly trigger the expected compiler diagnostics and source spans. Verified compiler phase, diagnostic messages, and line/column source mapping inside nested non-loop blocks like `if` and `switch`.

---
*PR created automatically by Jules for task [18197439687888073207](https://jules.google.com/task/18197439687888073207) started by @bungcip*