### PR TITLE
🛡️ Guardian: Restrict Qualifier Pointer Type Constraint

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -277,3 +277,7 @@ Action: Implement specific targeted tests for all invalid combinations of parame
 2025-02-14 - [C11 §6.8.6.3: Break not in loop or switch]
 
 Learning: Break statements are rejected outside of loop or switch statements. This is tricky because standalone `if` statements or simple function bodies are not valid targets for `break`. A dedicated test ensures that `SemanticError::BreakNotInLoop` is correctly thrown in these cases, preventing miscompilation. Action: Add `guardian_break_not_in_loop_or_switch.rs` to validate this invariant, asserting correct phase (`SemanticLowering`), message, and precise line/column spans.
+2024-06-25 - Guardian: Added test for restrict keyword
+
+Learning: Restrict must be limited to a pointer type, the Cendol compiler was accurately guarding against misuse, but the tests were incomplete and we needed test coverage specifically for diagnostic message and source span errors on this keyword.
+Action: Migrated/Added test cases from simple `run_fail_with_message` to `run_fail_with_diagnostic` for `restrict requires a pointer type`, verifying correct span reporting.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -173,3 +173,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_restrict_constraints;

--- a/src/tests/guardian_restrict_constraints.rs
+++ b/src/tests/guardian_restrict_constraints.rs
@@ -1,0 +1,28 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_restrict_on_function_pointer_prohibited() {
+    run_fail_with_diagnostic(
+        r#"
+        void (* restrict f)(void);
+        "#,
+        CompilePhase::SemanticLowering,
+        "restrict requires a pointer type",
+        2,
+        33,
+    );
+}
+
+#[test]
+fn test_restrict_on_non_pointer_prohibited() {
+    run_fail_with_diagnostic(
+        r#"
+        int restrict x;
+        "#,
+        CompilePhase::SemanticLowering,
+        "restrict requires a pointer type",
+        2,
+        9,
+    );
+}


### PR DESCRIPTION
🧪 What: Added `guardian_restrict_constraints.rs` with test cases to enforce that `restrict` requires a pointer type.
🎯 Why: To ensure that the compiler correctly prevents `restrict` from being applied to non-pointer types (e.g., `int restrict x;`) and function pointers (e.g., `void (* restrict f)(void);`), in compliance with C11 §6.7.3p2.
🛠️ Phase: SemanticLowering
🔬 Verify: Run `cargo test guardian_restrict_constraints`

---
*PR created automatically by Jules for task [14387398460632434056](https://jules.google.com/task/14387398460632434056) started by @bungcip*