### PR TITLE
⚡ Bolt: optimize lex_token poisoned identifier check

### DIFF
--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -998,7 +998,11 @@ impl<'src> Preprocessor<'src> {
     /// Lex the next token
     pub(super) fn lex_token(&mut self) -> Option<PPToken> {
         let token = self.lex_token_internal()?;
+        // Bolt ⚡: Optimization: added fast-path check !self.poisoned_identifiers.is_empty()
+        // before calling contains. This avoids redundant hashing and set lookups for
+        // identifier tokens in projects that do not use #pragma GCC poison.
         if let PPTokenKind::Identifier(sym) = token.kind
+            && !self.poisoned_identifiers.is_empty()
             && self.poisoned_identifiers.contains(&sym)
         {
             let err = self.error(PPError::PoisonedIdentifier(sym), token.location);


### PR DESCRIPTION
⚡ Bolt: Added a fast-path check to avoid redundant hash set lookups for poisoned identifiers in the preprocessor's hot path. This improves efficiency for projects that do not use `#pragma GCC poison` by skipping an expensive hashing operation for every identifier token. Verified with full test suite and SQLite benchmarks.

---
*PR created automatically by Jules for task [5376876238691073061](https://jules.google.com/task/5376876238691073061) started by @bungcip*