### PR TITLE
🛡️ Guardian: [case and default label constraints protected]

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -281,3 +281,8 @@ Learning: Break statements are rejected outside of loop or switch statements. Th
 
 Learning: Continue statements are rejected outside of loop statements. This is tricky because standalone `if` statements, `switch` statements, or simple function bodies are not valid targets for `continue`. A dedicated test ensures that `SemanticError::ContinueNotInLoop` is correctly thrown in these cases, preventing miscompilation.
 Action: Add `guardian_continue_not_in_loop.rs` to validate this invariant, asserting correct phase (`Mir`), message, and precise line/column spans.
+
+2026-06-26 - [C11 §6.8.4.2: Case and Default not in Switch]
+
+Learning: `case` and `default` statements must be enclosed within a `switch` statement. A dedicated test ensures that `SemanticError::CaseNotInSwitch` is correctly thrown in these cases (like standalone or nested inside an `if` but outside a `switch`), preventing miscompilation. We also fixed a span issue where the diagnostic previously pointed to the inner statement instead of the actual `case` or `default` keyword.
+Action: Add `guardian_case_not_in_switch.rs` to validate this invariant, asserting correct phase (`Mir`), message, and precise line/column spans.

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -2858,8 +2858,8 @@ impl<'a> SemanticAnalyzer<'a> {
                 None
             }
             NodeKind::Switch(cond, body) => self.visit_switch_statement(*cond, *body, node),
-            NodeKind::Case(expr, stmt) => self.visit_case_statement(Some(*expr), None, *stmt),
-            NodeKind::CaseRange(start, end, stmt) => self.visit_case_statement(Some(*start), Some(*end), *stmt),
+            NodeKind::Case(expr, stmt) => self.visit_case_statement(Some(*expr), None, *stmt, node),
+            NodeKind::CaseRange(start, end, stmt) => self.visit_case_statement(Some(*start), Some(*end), *stmt, node),
             NodeKind::Default(stmt) => self.visit_default_statement(*stmt, node),
             NodeKind::Return(expr) => {
                 self.visit_return_statement(node, expr);
@@ -3000,9 +3000,10 @@ impl<'a> SemanticAnalyzer<'a> {
         start: Option<NodeRef>,
         end: Option<NodeRef>,
         stmt: NodeRef,
+        node: NodeRef,
     ) -> Option<QualType> {
         if self.switch_stack.is_empty() {
-            self.report_error(stmt, SemanticError::CaseNotInSwitch);
+            self.report_error(node, SemanticError::CaseNotInSwitch);
         }
 
         let mut start_val = start.and_then(|s| self.evaluate_case_value(s));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -174,3 +174,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_case_not_in_switch;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -165,6 +165,7 @@ pub mod regr_union_cast;
 
 // Test Helpers
 pub mod guardian_break_not_in_loop_or_switch;
+pub mod guardian_case_not_in_switch;
 pub mod guardian_continue_not_in_loop;
 pub mod guardian_pointer_assignment_nested_qualifiers;
 pub mod guardian_switch_multiple_default;
@@ -174,4 +175,3 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
-pub mod guardian_case_not_in_switch;

--- a/src/tests/guardian_case_not_in_switch.rs
+++ b/src/tests/guardian_case_not_in_switch.rs
@@ -1,0 +1,49 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_case_not_in_switch() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            case 1: x = 1;
+        }
+        "#,
+        CompilePhase::Mir,
+        "'case' or 'default' label not in switch statement",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_default_not_in_switch() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            default: x = 1;
+        }
+        "#,
+        CompilePhase::Mir,
+        "'case' or 'default' label not in switch statement",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_case_inside_if_but_not_switch() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int x) {
+            if (x) {
+                case 1: x = 1;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+        "'case' or 'default' label not in switch statement",
+        4,
+        17,
+    );
+}


### PR DESCRIPTION
🧪 What: C code snippets violating switch label constraints
🎯 Why: Ensures `case` and `default` statements report correct diagnostic spans when placed outside of a valid `switch` boundary.
🛠️ Phase: Mir
🔬 Verify: `cargo test guardian_case_not_in_switch`

---
*PR created automatically by Jules for task [979769703566818191](https://jules.google.com/task/979769703566818191) started by @bungcip*