### PR TITLE
⚡ Bolt: Lexer Hot Path Optimizations

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -782,7 +782,10 @@ impl<'src> Lexer<'src> {
             }
 
             let mut prefix = "";
-            let mut content = String::new();
+            // ⚡ Bolt: Pre-allocate content buffer using the total raw length of all adjacent literals
+            // as an upper bound to avoid multiple reallocations during concatenation.
+            let total_raw_len: usize = string_tokens.iter().map(|t| t.length as usize).sum();
+            let mut content = String::with_capacity(total_raw_len);
             let mut merged_span = span;
 
             for (i, t) in string_tokens.iter().enumerate() {

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -346,6 +346,22 @@ impl PPLexer {
 
     /// Check if the next character matches, and consume it if it does.
     fn consume_if(&mut self, ch: u8) -> bool {
+        // ⚡ Bolt: Fast-path for common non-splice characters.
+        // This avoids the overhead of peek_char/next_char for simple punctuation.
+        let pos = self.position as usize;
+        if pos < self.buffer.len() {
+            let next = self.buffer[pos];
+            if next == ch && next != b'\\' {
+                self.position += 1;
+                // Operators never contain newlines in practice, but we maintain
+                // at_start_of_line correctly just in case.
+                if next == b'\n' {
+                    self.at_start_of_line = true;
+                }
+                return true;
+            }
+        }
+
         if self.peek_char() == Some(ch) {
             self.next_char();
             true


### PR DESCRIPTION
💡 What: Optimized lexer hot paths in the preprocessor and parser.
🎯 Why: 
1. `PPLexer::consume_if` is called frequently to identify multi-character operators. The previous implementation always called `peek_char`, which has significant overhead due to state management (saving/restoring position for potential backtracks).
2. String literal concatenation in the parser's lexer was building a `String` without an initial capacity hint, leading to multiple reallocations for multi-line or expanded literals.

📊 Impact: Reduces overhead in the lexer's hot path for punctuation and operators, and minimizes heap churn during string concatenation.
🔬 Measurement: Verified correctness via `cargo test`. Micro-benchmarks confirm the bypass of `peek_char` logic for simple ASCII tokens.


---
*PR created automatically by Jules for task [2155915918812806990](https://jules.google.com/task/2155915918812806990) started by @bungcip*