### PR TITLE
🧹 Rendi: Refactor clippy bool-comparison warnings

### DIFF
--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1216,7 +1216,7 @@ impl<'a> MirGen<'a> {
         self.visit_node(body);
 
         // If body falls through, go to merge
-        if self.current_block_has_terminator() == false {
+        if !self.current_block_has_terminator() {
             // Check if terminator is Unreachable (default) - if so, we can replace it or just leave it?
             // `current_block_has_terminator` returns false if it is Unreachable.
             // But if we are in body_entry_dummy and it's empty, we shouldn't jump to merge.

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -1235,7 +1235,7 @@ impl<'a> MirGen<'a> {
             obj_qt.ty()
         };
 
-        if record_ty.is_record() == false {
+        if !record_ty.is_record() {
             panic!("ICE: Member access on non-record type");
         }
 

--- a/src/tests/semantic_types.rs
+++ b/src/tests/semantic_types.rs
@@ -262,7 +262,7 @@ fn test_typeregistry_inline_logic() {
     let p4 = reg.pointer_to(QualType::unqualified(p3));
     assert_eq!(p4.class(), TypeClass::Pointer);
     assert_eq!(p4.pointer_depth(), 0); // Registry pointer
-    assert!(p4.is_inline_pointer() == false);
+    assert!(!p4.is_inline_pointer());
     // Base of p4 is the index in registry where Type::Pointer{pointee: int***} is stored.
     // We can't easily assert the index value, but it should differ from int_ty.base().
     assert_ne!(p4.base(), int_ty.base());
@@ -290,7 +290,7 @@ fn test_typeregistry_array_logic() {
     let a2 = reg.array_of(int_ty, ArraySizeType::Constant(100));
     assert_eq!(a2.class(), TypeClass::Array);
     assert_eq!(a2.array_len(), None); // Registry array
-    assert!(a2.is_inline_array() == false);
+    assert!(!a2.is_inline_array());
     assert_ne!(a2.base(), int_ty.base());
 
     // int*[5] (Registry - because int* doesn't have an index)
@@ -298,7 +298,7 @@ fn test_typeregistry_array_logic() {
     let ap1 = reg.array_of(p1, ArraySizeType::Constant(5));
     assert_eq!(ap1.class(), TypeClass::Array);
     assert_eq!(ap1.array_len(), None); // Registry array
-    assert!(ap1.is_inline_array() == false);
+    assert!(!ap1.is_inline_array());
 
     // int[10]* (Registry Pointer)
     // int[10] is Inline Array (Base=Int, Arr=10). Not Simple.
@@ -306,7 +306,7 @@ fn test_typeregistry_array_logic() {
     let pa1 = reg.pointer_to(QualType::unqualified(a1));
     assert_eq!(pa1.class(), TypeClass::Pointer);
     assert_eq!(pa1.pointer_depth(), 0); // Registry pointer
-    assert!(pa1.is_inline_pointer() == false);
+    assert!(!pa1.is_inline_pointer());
 }
 
 #[test]


### PR DESCRIPTION
Fixed `clippy::bool-comparison` warnings by changing `x == false` to `!x`. No dead code was removed as `use_variadic_hack` is actually used. Evaluated the codebase for other redundancies and it appears clean.

---
*PR created automatically by Jules for task [6945546398382050912](https://jules.google.com/task/6945546398382050912) started by @bungcip*