### PR TITLE
Refactor: Remove redundant clone() on LitVal::String

### DIFF
--- a/src/ast/dumper.rs
+++ b/src/ast/dumper.rs
@@ -306,7 +306,7 @@ impl AstDumper {
             PNK::StaticAssert(cond, msg) => {
                 let message_str = match msg.map(|m| &ast.get_node(m).kind) {
                     Some(PNK::Literal(lit)) => match lit.get_val() {
-                        LitVal::String { value, .. } => value.clone(),
+                        LitVal::String { value, .. } => value,
                         _ => "<invalid>".to_string(),
                     },
                     Some(_) => "<invalid>".to_string(),
@@ -441,7 +441,7 @@ impl AstDumper {
             NodeKind::StaticAssert(cond, msg) => {
                 let message_str = match msg.map(|m| ast.get_kind(m)) {
                     Some(NodeKind::Literal(lit)) => match lit.get_val() {
-                        LitVal::String { value, .. } => value.clone(),
+                        LitVal::String { value, .. } => value,
                         _ => "<not-a-string-literal>".to_string(),
                     },
                     Some(_) => "<invalid>".to_string(),


### PR DESCRIPTION
In `src/ast/dumper.rs`, the `match lit.get_val()` expression matches on an owned `LitVal` returned by value. The `LitVal::String { value, .. }` pattern therefore binds `value` as an owned `String`. Calling `.clone()` on this owned `String` is redundant and triggers the `clippy::redundant_clone` warning.

This commit removes the redundant `.clone()` calls, improving code clarity and slightly reducing unnecessary allocations.

No changes in observable behavior.

---
*PR created automatically by Jules for task [11254314017659760860](https://jules.google.com/task/11254314017659760860) started by @bungcip*