### PR TITLE
Test invalid `_Alignas` constraints

### DIFF
--- a/src/tests/guardian_alignas_constraints.rs
+++ b/src/tests/guardian_alignas_constraints.rs
@@ -52,3 +52,19 @@ fn test_alignas_on_register_prohibited() {
         "alignment specifier cannot be used in a register object",
     );
 }
+
+#[test]
+fn test_alignas_invalid_values() {
+    run_fail_with_message(
+        "_Alignas(3) int x;",
+        "requested alignment is not a positive power of 2: 3",
+    );
+    run_fail_with_message(
+        "_Alignas(100000) int x;",
+        "requested alignment is not a positive power of 2: 100000",
+    );
+    run_fail_with_message(
+        "int a = 4; _Alignas(a) int x;",
+        "requested alignment is not a constant expression",
+    );
+}


### PR DESCRIPTION
Adds a new unit test in `src/tests/guardian_alignas_constraints.rs` to cover the execution paths where `_Alignas` produces an error (e.g. `_Alignas(3)`). This increases coverage on `src/semantic/lowering.rs` and `src/semantic/errors.rs`.

---
*PR created automatically by Jules for task [595524656097095480](https://jules.google.com/task/595524656097095480) started by @bungcip*