### PR TITLE
🛡️ Guardian: Validate rejection of invalid unary operations

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -286,3 +286,9 @@ Action: Add `guardian_continue_not_in_loop.rs` to validate this invariant, asser
 
 Learning: `case` and `default` statements must be enclosed within a `switch` statement. A dedicated test ensures that `SemanticError::CaseNotInSwitch` is correctly thrown in these cases (like standalone or nested inside an `if` but outside a `switch`), preventing miscompilation. We also fixed a span issue where the diagnostic previously pointed to the inner statement instead of the actual `case` or `default` keyword.
 Action: Add `guardian_case_not_in_switch.rs` to validate this invariant, asserting correct phase (`Mir`), message, and precise line/column spans.
+
+## 2024-07-02 - Invalid Unary Operand Analysis
+
+Learning: The `SemanticError::InvalidUnaryOperand` diagnostic is correctly emitted by `SemanticAnalyzer` during `CompilePhase::Mir` (where semantic analysis executes). It effectively guards against invalid unary operations like bitwise NOT on floats, unary plus/minus on non-arithmetic types (like pointers), and increment/decrement on non-scalar types or pointers to incomplete/function types. The diagnostic formatting uses `f.display_qual_type(*ty)`, which results in string representations like `"void*"` or `"void()*"` rather than the exact source spelling `"void *"`.
+
+Action: When asserting `SemanticError::InvalidUnaryOperand`, always use `CompilePhase::Mir` and expect the diagnostic text to use the compiler's normalized type representation. I have created `guardian_invalid_unary_operand.rs` to ensure these behaviors remain strictly enforced.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -176,3 +176,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_invalid_unary_operand;

--- a/src/tests/guardian_invalid_unary_operand.rs
+++ b/src/tests/guardian_invalid_unary_operand.rs
@@ -1,0 +1,86 @@
+use crate::{
+    driver::artifact::CompilePhase,
+    tests::test_utils::{run_fail_with_diagnostic},
+};
+
+#[test]
+fn test_invalid_unary_operand_bitnot_float() {
+    run_fail_with_diagnostic(
+        r#"
+        void test() {
+            float f = 1.0f;
+            ~f;
+        }
+        "#,
+        CompilePhase::Mir,
+        "Invalid operand for unary operation: have 'float'",
+        4,
+        13,
+    );
+}
+
+#[test]
+fn test_invalid_unary_operand_not_arithmetic() {
+    run_fail_with_diagnostic(
+        r#"
+        void test() {
+            void *p = 0;
+            +p;
+        }
+        "#,
+        CompilePhase::Mir,
+        "Invalid operand for unary operation: have 'void*'",
+        4,
+        13,
+    );
+}
+
+#[test]
+fn test_invalid_unary_operand_increment_not_scalar() {
+    run_fail_with_diagnostic(
+        r#"
+        struct S { int a; };
+        void test() {
+            struct S s;
+            ++s;
+        }
+        "#,
+        CompilePhase::Mir,
+        "Invalid operand for unary operation: have 'struct S'",
+        5,
+        13,
+    );
+}
+
+#[test]
+fn test_invalid_unary_operand_decrement_function_pointer() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(void);
+        void test() {
+            void (*p)(void) = f;
+            --p;
+        }
+        "#,
+        CompilePhase::Mir,
+        "Invalid operand for unary operation: have 'void()*'",
+        5,
+        13,
+    );
+}
+
+#[test]
+fn test_invalid_unary_operand_increment_incomplete_pointer() {
+    run_fail_with_diagnostic(
+        r#"
+        void test() {
+            void *p = 0;
+            p++;
+        }
+        "#,
+        CompilePhase::Mir,
+        "Invalid operand for unary operation: have 'void*'",
+        4,
+        13,
+    );
+}


### PR DESCRIPTION
🧪 What: Added `guardian_invalid_unary_operand.rs` test file asserting proper diagnostic and span generation for invalid unary operations.
🎯 Why: Prevents miscompilation that might allow non-arithmetic and non-scalar types to be compiled in invalid unary operations.
🛠️ Phase: Mir
🔬 Verify: Executed `cargo test -p cendol guardian_invalid_unary_operand`. Tests pass ensuring C11 spec rules on valid scalars are enforced.

---
*PR created automatically by Jules for task [3955964814644222836](https://jules.google.com/task/3955964814644222836) started by @bungcip*