### PR TITLE
⚡ Bolt: optimize token stringification and de-splicing

### DIFF
--- a/src/pp/macros.rs
+++ b/src/pp/macros.rs
@@ -106,7 +106,7 @@ impl<'src> Preprocessor<'src> {
             if i > 0 && token.flags.contains(PPTokenFlags::LEADING_SPACE) {
                 result.push(' ');
             }
-            result.push_str(&cache.get_token_text(token));
+            cache.append_token_to_string(token, &mut result);
         }
         result
     }
@@ -596,9 +596,8 @@ impl<'src> Preprocessor<'src> {
                 result.push(b' ');
             }
 
-            let text = cache.get_token_text(token);
-
             if matches!(token.kind, PPTokenKind::StringLiteral | PPTokenKind::CharLiteral(_)) {
+                let text = cache.get_token_text(token);
                 // Bolt ⚡: High-speed byte-based iteration for escaping.
                 for &b in text.as_bytes() {
                     if b == b'"' || b == b'\\' {
@@ -607,7 +606,7 @@ impl<'src> Preprocessor<'src> {
                     result.push(b);
                 }
             } else {
-                result.extend_from_slice(text.as_bytes());
+                cache.append_token_to_bytes(token, &mut result);
             }
         }
 
@@ -1219,5 +1218,61 @@ impl<'a> SourceBufferCache<'a> {
     fn get_token_text<'b>(&'b mut self, token: &'b PPToken) -> Cow<'b, str> {
         let buffer = self.get_buffer(token.location.source_id()).unwrap_or(&[]);
         token.get_text_from_buffer(buffer)
+    }
+
+    /// ⚡ Bolt: Appends token text directly to a String, avoiding intermediate allocations for splices.
+    fn append_token_to_string(&mut self, token: &PPToken, result: &mut String) {
+        if let PPTokenKind::Identifier(sym) = &token.kind {
+            result.push_str(sym.as_str());
+            return;
+        }
+
+        if let Some(fixed) = token.kind.get_fixed_text() {
+            result.push_str(fixed);
+            return;
+        }
+
+        let buffer = self.get_buffer(token.location.source_id()).unwrap_or(&[]);
+        let start = token.location.offset() as usize;
+        let end = start + token.length as usize;
+        let raw = if end <= buffer.len() {
+            unsafe { std::str::from_utf8_unchecked(&buffer[start..end]) }
+        } else {
+            ""
+        };
+
+        if token.flags.contains(PPTokenFlags::HAS_SPLICES) {
+            crate::pp::pp_lexer::de_splice_into(raw, result);
+        } else {
+            result.push_str(raw);
+        }
+    }
+
+    /// ⚡ Bolt: Appends token text directly to a byte vector.
+    fn append_token_to_bytes(&mut self, token: &PPToken, result: &mut Vec<u8>) {
+        if let PPTokenKind::Identifier(sym) = &token.kind {
+            result.extend_from_slice(sym.as_str().as_bytes());
+            return;
+        }
+
+        if let Some(fixed) = token.kind.get_fixed_text() {
+            result.extend_from_slice(fixed.as_bytes());
+            return;
+        }
+
+        let buffer = self.get_buffer(token.location.source_id()).unwrap_or(&[]);
+        let start = token.location.offset() as usize;
+        let end = start + token.length as usize;
+        let raw = if end <= buffer.len() {
+            unsafe { std::str::from_utf8_unchecked(&buffer[start..end]) }
+        } else {
+            ""
+        };
+
+        if token.flags.contains(PPTokenFlags::HAS_SPLICES) {
+            crate::pp::pp_lexer::de_splice_into_bytes(raw, result);
+        } else {
+            result.extend_from_slice(raw.as_bytes());
+        }
     }
 }

--- a/src/pp/pp_lexer.rs
+++ b/src/pp/pp_lexer.rs
@@ -1321,26 +1321,28 @@ impl Iterator for PPLexer {
 /// This uses memchr to fast-scan for backslashes and appends slices of the original
 /// string, which is both faster and correctly preserves multi-byte UTF-8 sequences.
 pub(crate) fn de_splice(raw: &str) -> String {
-    let bytes = raw.as_bytes();
-
     let mut result = String::with_capacity(raw.len());
+    de_splice_into(raw, &mut result);
+    result
+}
+
+/// ⚡ Bolt: Appends de-spliced text to an existing String.
+pub(crate) fn de_splice_into(raw: &str, result: &mut String) {
+    let bytes = raw.as_bytes();
     let mut last_end = 0;
     let mut i = 0;
 
     while let Some(pos) = memchr::memchr(b'\\', &bytes[i..]) {
         let backslash_pos = i + pos;
 
-        // Check if it's a splice: \ [ws] \n or \ [ws] \r [\n]
         let mut j = backslash_pos + 1;
         while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
             j += 1;
         }
 
         if j < bytes.len() && (bytes[j] == b'\n' || bytes[j] == b'\r') {
-            // Found a splice! Append the text before the backslash.
             result.push_str(&raw[last_end..backslash_pos]);
 
-            // Skip the backslash and the newline (and optional whitespace)
             if bytes[j] == b'\r' && j + 1 < bytes.len() && bytes[j + 1] == b'\n' {
                 i = j + 2;
             } else {
@@ -1348,15 +1350,41 @@ pub(crate) fn de_splice(raw: &str) -> String {
             }
             last_end = i;
         } else {
-            // Not a splice, just a regular backslash.
-            // Continue scanning after this backslash.
             i = backslash_pos + 1;
         }
     }
-
-    // Append the remaining part
     result.push_str(&raw[last_end..]);
-    result
+}
+
+/// ⚡ Bolt: Appends de-spliced text to an existing byte vector.
+/// This avoids intermediate String allocations when building a byte buffer.
+pub(crate) fn de_splice_into_bytes(raw: &str, result: &mut Vec<u8>) {
+    let bytes = raw.as_bytes();
+    let mut last_end = 0;
+    let mut i = 0;
+
+    while let Some(pos) = memchr::memchr(b'\\', &bytes[i..]) {
+        let backslash_pos = i + pos;
+
+        let mut j = backslash_pos + 1;
+        while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
+            j += 1;
+        }
+
+        if j < bytes.len() && (bytes[j] == b'\n' || bytes[j] == b'\r') {
+            result.extend_from_slice(&bytes[last_end..backslash_pos]);
+
+            if bytes[j] == b'\r' && j + 1 < bytes.len() && bytes[j + 1] == b'\n' {
+                i = j + 2;
+            } else {
+                i = j + 1;
+            }
+            last_end = i;
+        } else {
+            i = backslash_pos + 1;
+        }
+    }
+    result.extend_from_slice(&bytes[last_end..]);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
💡 What: Implemented `de_splice_into` helpers and optimized token stringification in the preprocessor.
🎯 Why: Avoid redundant intermediate String allocations and copies when processing tokens containing line splices.
📊 Impact: Reduces heap pressure in the macro expansion hot path by allowing direct appending to destination buffers.
🔬 Measurement: Verified with SQLite benchmark and full test suite. No regressions detected.

---
*PR created automatically by Jules for task [12329448454659954947](https://jules.google.com/task/12329448454659954947) started by @bungcip*