### PR TITLE
🧹 Rendi: Fix clippy collapsible_if warning in SemanticAnalyzer

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -2927,10 +2927,8 @@ impl<'a> SemanticAnalyzer<'a> {
             NodeKind::ComputedGoto(expr) => {
                 self.goto_vla_state.push((node, self.active_vlas.clone()));
                 let ty = self.visit_node(*expr);
-                if let Some(t) = ty {
-                    if !t.is_pointer() {
-                        self.report_error(node, SemanticError::ExpectedPointerType { found: t });
-                    }
+                if let Some(t) = ty.filter(|t| !t.is_pointer()) {
+                    self.report_error(node, SemanticError::ExpectedPointerType { found: t });
                 }
                 None
             }


### PR DESCRIPTION
Audit the codebase for cleanup opportunities. Found a `clippy::collapsible_if` warning in `src/semantic/analyzer.rs`. Simplified the nested conditions securely using `Option::filter` which keeps the syntax stable and avoids unstable `let_chains`.

---
*PR created automatically by Jules for task [11922545423610931511](https://jules.google.com/task/11922545423610931511) started by @bungcip*