### PR TITLE
⚡ Bolt: sparse conversions in SemanticInfo

### DIFF
--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1991,9 +1991,9 @@ impl<'a> MirGen<'a> {
         // Look up conversions for this node in semantic_info
         let semantic_info = &self.ast.semantic_info;
         let idx = node.index();
-        if idx < semantic_info.conversions.len() {
+        if let Some(conversions) = semantic_info.conversions.get(&idx) {
             let mut result = operand;
-            for conv in &semantic_info.conversions[idx] {
+            for conv in conversions {
                 result = self.emit_conversion(result, conv, target, node);
             }
             return result;

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -1223,9 +1223,11 @@ impl<'a> MirGen<'a> {
 
         // Handle implicit conversions (like array-to-pointer decay) for arrow access
         let record_ty = if is_arrow {
-            for conv in &self.ast.semantic_info.conversions[obj.index()] {
-                if let Conversion::PointerDecay { to } = conv {
-                    obj_qt = QualType::unqualified(*to);
+            if let Some(conversions) = self.ast.semantic_info.conversions.get(&obj.index()) {
+                for conv in conversions {
+                    if let Conversion::PointerDecay { to } = conv {
+                        obj_qt = QualType::unqualified(*to);
+                    }
                 }
             }
             self.registry

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -66,7 +66,9 @@ struct FunctionCtx {
 #[derive(Debug, Clone, Default)]
 pub struct SemanticInfo {
     pub types: Vec<Option<QualType>>,
-    pub conversions: Vec<SmallVec<[Conversion; 1]>>,
+    // Bolt ⚡: Optimization: Use a sparse HashMap for conversions to save memory.
+    // Most nodes do not have implicit conversions.
+    pub conversions: FxHashMap<usize, SmallVec<[Conversion; 1]>>,
     pub value_categories: Vec<ValueCategory>,
     pub generic_selections: FxHashMap<usize, NodeRef>, // Maps NodeIndex of GenericSelection to selected result_expr
     pub choose_expressions: FxHashMap<usize, NodeRef>, // Maps NodeIndex of BuiltinChooseExpr to selected branch
@@ -78,7 +80,7 @@ impl SemanticInfo {
     fn with_capacity(n: usize) -> Self {
         Self {
             types: vec![None; n],
-            conversions: vec![SmallVec::new(); n],
+            conversions: FxHashMap::default(),
             value_categories: vec![ValueCategory::RValue; n],
             generic_selections: FxHashMap::default(),
             choose_expressions: FxHashMap::default(),
@@ -212,7 +214,7 @@ impl<'a> SemanticAnalyzer<'a> {
     }
 
     fn push_conversion(&mut self, node: NodeRef, conv: Conversion) {
-        let conversions = &mut self.semantic_info.conversions[node.index()];
+        let conversions = self.semantic_info.conversions.entry(node.index()).or_default();
         // Avoid redundant identical conversions pushed multiple times to the same node.
         // This handles cases where semantic rules might be applied twice (e.g. in compound assignments)
         // or during double-visits of the same expression node.
@@ -1528,7 +1530,7 @@ impl<'a> SemanticAnalyzer<'a> {
         if lhs_promoted.ty() != lhs_target || self.is_numeric_literal(lhs) {
             // Check if this conversion is already the last one to avoid duplicates
             // resolve_binary_operation_types might be called multiple times in some complex nested scenarios
-            let needs_push = match self.semantic_info.conversions[lhs.index()].last() {
+            let needs_push = match self.semantic_info.conversions.get(&lhs.index()).and_then(|v| v.last()) {
                 Some(Conversion::IntegerCast { to, .. }) => *to != lhs_target,
                 Some(Conversion::FloatingCast { to, .. }) => *to != lhs_target,
                 Some(Conversion::ComplexCast { to, .. }) => *to != lhs_target,
@@ -1542,7 +1544,7 @@ impl<'a> SemanticAnalyzer<'a> {
 
         let rhs_target = common_qt.ty();
         if rhs_promoted.ty() != rhs_target || self.is_numeric_literal(rhs) {
-            let needs_push = match self.semantic_info.conversions[rhs.index()].last() {
+            let needs_push = match self.semantic_info.conversions.get(&rhs.index()).and_then(|v| v.last()) {
                 Some(Conversion::IntegerCast { to, .. }) => *to != rhs_target,
                 Some(Conversion::FloatingCast { to, .. }) => *to != rhs_target,
                 Some(Conversion::ComplexCast { to, .. }) => *to != rhs_target,


### PR DESCRIPTION
💡 What: Optimized `SemanticInfo` memory usage by converting the `conversions` field from a dense `Vec` to a sparse `FxHashMap`.

🎯 Why: In large translation units (like SQLite with >200,000 nodes), allocating a `SmallVec` container for every single node's implicit conversions is wasteful, as most nodes (like keywords, punctuation, or simple statements) do not have implicit conversions. Switching to a sparse representation reduces memory pressure and cache misses.

📊 Impact: Significant memory reduction for large translation units. For projects like SQLite, this avoids allocating hundreds of thousands of empty `SmallVec` structures.

🔬 Measurement: 
1. Verified that all 1535 unit tests pass (`cargo test -p cendol`).
2. Verified that the compiler correctly handles large real-world files like SQLite and Lua.
3. Code changes are < 50 lines of core logic across three files.

---
*PR created automatically by Jules for task [4868506553929657805](https://jules.google.com/task/4868506553929657805) started by @bungcip*