### PR TITLE
🧹 Rendi: remove redundant map_err conversion in mir dumper

### DIFF
--- a/.jules/rendi.md
+++ b/.jules/rendi.md
@@ -1,0 +1,6 @@
+
+## 2026-07-07 - [Cleanup redundant map_err in mir/dumper.rs]
+
+**Learning:** The clippy warning `clippy::useless_conversion` highlighted an unnecessary `.map_err(Into::into)` call in `src/mir/dumper.rs` because the `write!` macro already returned an `std::fmt::Error`, making the conversion redundant.
+
+**Action:** Removed `.map_err(Into::into)` to clean up the code and resolve the warning. Confirmed tests and clippy still pass successfully.

--- a/src/mir/dumper.rs
+++ b/src/mir/dumper.rs
@@ -320,7 +320,7 @@ impl<'a> MirDumper<'a> {
                 &[
                     &|out| self.write_operand(out, ptr),
                     &|out| self.write_operand(out, val),
-                    &|out| write!(out, "{:?}", order).map_err(Into::into),
+                    &|out| write!(out, "{:?}", order),
                 ],
             ),
             MirStmt::InlineAsm {


### PR DESCRIPTION
Removed `.map_err(Into::into)` in `src/mir/dumper.rs` since the error type was already `std::fmt::Error`, resolving a `clippy::useless_conversion` warning.

---
*PR created automatically by Jules for task [2695673637336210810](https://jules.google.com/task/2695673637336210810) started by @bungcip*