### PR TITLE
🧹 Rendi: Consolidate duplicate logic in SemanticAnalyzer

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -2243,15 +2243,9 @@ impl<'a> SemanticAnalyzer<'a> {
                             },
                         );
                     }
-                } else if !is_variadic && arg_count != parameters.len() {
-                    self.report_error(
-                        call_expr.callee,
-                        SemanticError::InvalidNumberOfArguments {
-                            expected: parameters.len(),
-                            found: arg_count,
-                        },
-                    );
-                } else if is_variadic && arg_count < parameters.len() {
+                } else if (!is_variadic && arg_count != parameters.len())
+                    || (is_variadic && arg_count < parameters.len())
+                {
                     self.report_error(
                         call_expr.callee,
                         SemanticError::InvalidNumberOfArguments {


### PR DESCRIPTION
- Identified identical block bodies in `if/else` for variadic and non-variadic function argument count checks.
- Merged the conditions using `||`.
- Resolves `clippy::if_same_then_else` warning and removes duplicate logic while preserving exact behavior.

---
*PR created automatically by Jules for task [4848180531139868100](https://jules.google.com/task/4848180531139868100) started by @bungcip*