### PR TITLE
🛡️ Guardian: [C11 §6.8.6.3] break not in loop or switch

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -297,3 +297,8 @@ Action: Add `guardian_invalid_storage_class_for_function.rs` to explicitly valid
 Learning: The `SemanticAnalyzer` in Cendol failed to validate that a call to a variadic function passes at least the minimum number of arguments required by its non-variadic parameters. This allowed a call like `void f(int x, ...); f();` to pass semantic validation but later crash during MIR validation with an `IllegalOperation("Call to function f arg count mismatch")` because the argument count didn't match the required parameters.
 
 Action: Ensure semantic checks always enforce the minimum required argument count for variadic functions. Added tests to explicitly guard `SemanticError::InvalidNumberOfArguments` for variadic functions with too few arguments.
+
+2026-07-08 - [C11 §6.8.6.3: Break not in loop or switch]
+
+Learning: Break statements must be enclosed within a loop or switch statement. This constraint is properly validated during the `CompilePhase::Mir` by traversing the AST to detect breaks outside valid blocks. A standalone `break`, or one inside an `if` but outside a loop or switch, will throw `SemanticError::BreakNotInLoop`. Adding specific unit tests ensures that the phase correctly catches and rejects this invalid control flow structure.
+Action: Add `guardian_break_not_in_loop_or_switch.rs` to validate this invariant, ensuring the diagnostic triggers at `CompilePhase::Mir` with the correct error message and specific line/column spans.

--- a/src/tests/guardian_break_not_in_loop_or_switch.rs
+++ b/src/tests/guardian_break_not_in_loop_or_switch.rs
@@ -2,7 +2,7 @@ use crate::driver::artifact::CompilePhase;
 use crate::tests::test_utils::run_fail_with_diagnostic;
 
 #[test]
-fn test_break_not_in_loop_or_switch() {
+fn test_break_not_in_loop() {
     run_fail_with_diagnostic(
         r#"
         void f(void) {
@@ -53,7 +53,24 @@ fn test_break_in_switch() {
         r#"
         void f(int x) {
             switch (x) {
-                case 1: break;
+                case 1:
+                    break;
+            }
+        }
+        "#,
+        CompilePhase::Mir,
+    );
+}
+
+#[test]
+fn test_break_in_if_in_loop() {
+    crate::tests::test_utils::run_pass(
+        r#"
+        void f(int x) {
+            while (1) {
+                if (x) {
+                    break;
+                }
             }
         }
         "#,


### PR DESCRIPTION
🧪 What: Added `guardian_break_not_in_loop_or_switch.rs` which verifies that `break` statements outside of a valid loop or switch block are correctly rejected with `SemanticError::BreakNotInLoop`. It tests standalone `break`, `break` inside an `if` statement that isn't wrapped in a loop, and asserts that valid `break` constructions inside `while` and `switch` are accepted. Additionally, the `.jules/guardian.md` journal is updated to record this learning.

🎯 Why: C11 §6.8.6.3 requires that a `break` statement shall appear only in or as a switch body or loop body. Testing this explicitly protects the compiler from miscompilations where invalid control flow might be passed to the backend, especially around complex scopes or incorrectly managed loop contexts in the MIR generator.

🛠️ Phase: MIR phase (Semantic lowering and control flow graph validation during MIR generation correctly catches this).

🔬 Verify: Run `cargo test -p cendol guardian_break_not_in_loop_or_switch` to run the new test suite.

---
*PR created automatically by Jules for task [16008706360976716976](https://jules.google.com/task/16008706360976716976) started by @bungcip*