### PR TITLE
feat: Add support for C23 relaxed labels

### DIFF
--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -275,8 +275,13 @@ fn parse_case_statement(parser: &mut Parser) -> Result<ParsedNodeRef, ParseDiag>
         .accept(TokenKind::Ellipsis)
         .map(|_| parser.parse_expr_min())
         .transpose()?;
-    parser.expect(TokenKind::Colon)?;
-    let stmt = parse_statement(parser)?;
+    let colon_span = parser.expect(TokenKind::Colon)?.span;
+    let stmt = if parser.is_token(TokenKind::RightBrace) || parser.starts_declaration() {
+        let dummy = parser.push_dummy();
+        parser.replace_node(dummy, ParsedNodeKind::EmptyStmt, colon_span)
+    } else {
+        parse_statement(parser)?
+    };
     let span = start.merge(parser.ast.get_node(stmt).span);
     let kind = match end_expr {
         Some(end) => ParsedNodeKind::CaseRange(start_expr, end, stmt),
@@ -287,16 +292,26 @@ fn parse_case_statement(parser: &mut Parser) -> Result<ParsedNodeRef, ParseDiag>
 
 fn parse_default_statement(parser: &mut Parser) -> Result<ParsedNodeRef, ParseDiag> {
     let start = parser.expect(TokenKind::Default)?.span;
-    parser.expect(TokenKind::Colon)?;
-    let stmt = parse_statement(parser)?;
+    let colon_span = parser.expect(TokenKind::Colon)?.span;
+    let stmt = if parser.is_token(TokenKind::RightBrace) || parser.starts_declaration() {
+        let dummy = parser.push_dummy();
+        parser.replace_node(dummy, ParsedNodeKind::EmptyStmt, colon_span)
+    } else {
+        parse_statement(parser)?
+    };
     let span = start.merge(parser.ast.get_node(stmt).span);
     Ok(parser.push_node(ParsedNodeKind::Default(stmt), span))
 }
 
 fn parse_label_statement(parser: &mut Parser, name: NameId) -> Result<ParsedNodeRef, ParseDiag> {
     let start = parser.advance().unwrap().span;
-    parser.expect(TokenKind::Colon)?;
-    let stmt = parse_statement(parser)?;
+    let colon_span = parser.expect(TokenKind::Colon)?.span;
+    let stmt = if parser.is_token(TokenKind::RightBrace) || parser.starts_declaration() {
+        let dummy = parser.push_dummy();
+        parser.replace_node(dummy, ParsedNodeKind::EmptyStmt, colon_span)
+    } else {
+        parse_statement(parser)?
+    };
     let span = start.merge(parser.ast.get_node(stmt).span);
     Ok(parser.push_node(ParsedNodeKind::Label(name, stmt), span))
 }

--- a/src/tests/semantic_c23.rs
+++ b/src/tests/semantic_c23.rs
@@ -341,3 +341,23 @@ fn test_c23_vla_empty_init_fail_c11() {
         CStandard::C11,
     );
 }
+
+#[test]
+fn test_c23_labels() {
+    // Labels before declarations and at the end of a block
+    check_semantic_valid(
+        "
+        void f() {
+            int a = 1;
+            switch(a) {
+                case 1:
+                    int b = 2;
+                default:
+                    int c = 3;
+            }
+            L1: int d = 4;
+            L2:
+        }
+        ",
+    );
+}


### PR DESCRIPTION
This PR adds parser support for C23's relaxed label rules, which permit placing labels immediately before declarations and at the end of compound blocks without a trailing null statement.

Changes:
- Modified `parse_case_statement`, `parse_default_statement`, and `parse_label_statement` in `src/parser/statements.rs` to synthesize an `EmptyStmt` when the token following the colon is a right brace (`}`) or starts a declaration.
- Added a `test_c23_labels` unit test to verify that the C23 label placement works correctly in `switch` cases and standard `goto` labels.

---
*PR created automatically by Jules for task [7132846713094746056](https://jules.google.com/task/7132846713094746056) started by @bungcip*