### PR TITLE
🛡️ Guardian: allow structs with flexible array members to be nested

### DIFF
--- a/src/semantic/errors.rs
+++ b/src/semantic/errors.rs
@@ -435,6 +435,8 @@ impl SemanticError {
                 | SemanticError::GnuZeroLengthArray
                 | SemanticError::ExcessElements { .. }
                 | SemanticError::VoidReturnWithVoidExpr { .. }
+                | SemanticError::FlexibleArrayMemberInStruct
+                | SemanticError::FlexibleArrayElementInArray
         )
     }
 
@@ -462,6 +464,8 @@ impl SemanticError {
             SemanticError::AttributeCleanupOnType => Some("attributes"),
             SemanticError::AttributeCleanupOnNonLocal => Some("ignored-attributes"),
             SemanticError::VoidReturnWithVoidExpr { .. } => Some("pedantic"),
+            SemanticError::FlexibleArrayMemberInStruct => Some("pedantic"),
+            SemanticError::FlexibleArrayElementInArray => Some("pedantic"),
             _ => None,
         }
     }

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -224,7 +224,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
 
         // C11 6.7.2.1p3: If the containing record is a union, we allow struct-with-FMA members.
         if !is_union && self.registry.has_flexible_array_member(member_type.ty()) {
-            self.report_error(span, SemanticError::FlexibleArrayMemberInStruct);
+            self.report_warning(span, SemanticError::FlexibleArrayMemberInStruct);
         }
 
         if !is_explicitly_packed
@@ -293,7 +293,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
         }
 
         if self.registry.has_flexible_array_member(element_qt.ty()) {
-            self.report_error(span, SemanticError::FlexibleArrayElementInArray);
+            self.report_warning(span, SemanticError::FlexibleArrayElementInArray);
         }
 
         if size.is_star() && !self.in_prototype {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -129,6 +129,7 @@ pub mod guardian_choose_expr;
 pub mod guardian_compound_literal_constraints;
 pub mod guardian_const_eval_builtins;
 pub mod guardian_enum_compatibility;
+pub mod guardian_fam_struct_member;
 pub mod guardian_fam_union_constraints;
 pub mod guardian_function_return_type_constraints;
 pub mod guardian_generic;

--- a/src/tests/guardian_fam_struct_member.rs
+++ b/src/tests/guardian_fam_struct_member.rs
@@ -1,0 +1,32 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_pass;
+
+#[test]
+fn test_struct_can_contain_fam_struct() {
+    // C11 allows structs to contain structs with flexible array members (FAM).
+    // It's a GNU extension if they're not at the end, but the compiler should just emit a warning
+    // and successfully compile the code.
+    run_pass(
+        r#"
+        struct Inner {
+            int count;
+            char flex[];
+        };
+
+        struct Outer {
+            void* ptr;
+            struct Inner inner;
+        };
+
+        struct Outer2 {
+            struct Inner inner;
+            void* ptr;
+        };
+
+        int main() {
+            return 0;
+        }
+        "#,
+        CompilePhase::SemanticLowering,
+    );
+}

--- a/src/tests/guardian_fam_union_constraints.rs
+++ b/src/tests/guardian_fam_union_constraints.rs
@@ -1,5 +1,5 @@
 use crate::driver::artifact::CompilePhase;
-use crate::tests::test_utils::{run_fail_with_message, run_pass};
+use crate::tests::test_utils::{run_pass, run_pedantic_fail_with_message};
 
 #[test]
 fn test_union_can_contain_fam_struct() {
@@ -26,7 +26,7 @@ fn test_struct_cannot_contain_union_with_fam() {
     // Thus, it cannot be a member of another structure unless it's the last one.
 
     // 1. Union with FAM as non-last member
-    run_fail_with_message(
+    run_pedantic_fail_with_message(
         r#"
         struct s { int n; int a[]; };
         union u { int x; struct s s; };
@@ -36,7 +36,7 @@ fn test_struct_cannot_contain_union_with_fam() {
     );
 
     // 2. Union with FAM as array element
-    run_fail_with_message(
+    run_pedantic_fail_with_message(
         r#"
         struct s { int n; int a[]; };
         union u { int x; struct s s; };
@@ -49,7 +49,7 @@ fn test_struct_cannot_contain_union_with_fam() {
 #[test]
 fn test_nested_fam_constraints() {
     // Test multiple levels of nesting
-    run_fail_with_message(
+    run_pedantic_fail_with_message(
         r#"
         struct s { int n; int a[]; };
         union u1 { struct s s; };
@@ -66,7 +66,7 @@ fn test_union_with_fam_as_last_member_prohibited() {
     // It says "an incomplete array type", not "a type that has a flexible array member".
     // Strictly, only direct incomplete array types are allowed as the FAM of a struct.
     // GCC/Clang also reject structs/unions as the FAM.
-    run_fail_with_message(
+    run_pedantic_fail_with_message(
         r#"
         struct s { int n; int a[]; };
         union u { int x; struct s s; };


### PR DESCRIPTION
Downgrade the `FlexibleArrayMemberInStruct` and `FlexibleArrayElementInArray` errors to pedantic warnings to align with GCC and Clang behavior, which support this as a GNU extension. This allows compiling code like CPython that relies on nesting structures containing flexible array members.

- Changes `report_error` to `report_warning` for these cases in `src/semantic/lowering.rs`.
- Categorizes them as pedantic warnings in `src/semantic/errors.rs`.
- Updates `guardian_fam_union_constraints.rs` tests to use `run_pedantic_fail_with_message`.
- Adds a new regression test in `guardian_fam_struct_member.rs`.

---
*PR created automatically by Jules for task [14250492064690892533](https://jules.google.com/task/14250492064690892533) started by @bungcip*