### PR TITLE
🧹 Rendi: Fix clippy warnings (`bool_comparison` and `collapsible_if`)

### DIFF
--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1210,7 +1210,7 @@ impl<'a> MirGen<'a> {
         self.visit_node(body);
 
         // If body falls through, go to merge
-        if self.current_block_has_terminator() == false {
+        if !self.current_block_has_terminator() {
             // Check if terminator is Unreachable (default) - if so, we can replace it or just leave it?
             // `current_block_has_terminator` returns false if it is Unreachable.
             // But if we are in body_entry_dummy and it's empty, we shouldn't jump to merge.

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -1238,7 +1238,7 @@ impl<'a> MirGen<'a> {
             obj_qt.ty()
         };
 
-        if record_ty.is_record() == false {
+        if !record_ty.is_record() {
             panic!("ICE: Member access on non-record type");
         }
 

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -393,10 +393,8 @@ impl<'a> SemanticAnalyzer<'a> {
         match task {
             Task::Array(element_type, vla_expr) => {
                 if let Some(expr) = vla_expr {
-                    if let Some(qt) = self.visit_node(expr) {
-                        if !qt.is_integer() {
-                            self.report_error(expr, SemanticError::ArraySizeNotInteger);
-                        }
+                    if self.visit_node(expr).is_some_and(|qt| !qt.is_integer()) {
+                        self.report_error(expr, SemanticError::ArraySizeNotInteger);
                     }
                     if let Some(val) = self.const_ctx().eval_int(expr) {
                         if val < 0 {


### PR DESCRIPTION
I have completed the codebase cleanup as requested.

### What was removed/refactored
1.  **Redundant Code (`clippy::bool-comparison`)**:
    *   In `src/codegen/mir_gen.rs`, `if self.current_block_has_terminator() == false` was refactored to `if !self.current_block_has_terminator()`.
    *   In `src/codegen/mir_gen_expression.rs`, `if record_ty.is_record() == false` was refactored to `if !record_ty.is_record()`.
2.  **Over-engineered abstractions/Redundant logic (`clippy::collapsible-if`)**:
    *   In `src/semantic/analyzer.rs`, a nested `if let Some(qt) = self.visit_node(expr)` combined with `if !qt.is_integer()` was collapsed into a cleaner, single `if self.visit_node(expr).is_some_and(|qt| !qt.is_integer())`.

### Why it was redundant or useless
1.  Comparing boolean values explicitly against `false` is non-idiomatic in Rust and adds unnecessary verbosity without adding clarity. The `!` operator is the standard approach.
2.  Nested `if` statements that only perform a single logical check (in this case, checking if the result of a function call is `Some` and if that inner value meets a condition) can be flattened using Rust's `Option` combinators (`is_some_and`), resulting in cleaner, more readable code without changing the observable behavior.

All tests passed and no new issues were introduced. No other safe, high-value refactor opportunities were found during the scan.

---
*PR created automatically by Jules for task [4495863145547421716](https://jules.google.com/task/4495863145547421716) started by @bungcip*