### PR TITLE
🧹 Rendi: Remove unused `get_token_span` method

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -206,12 +206,6 @@ impl<'arena, 'src, 'lexer> Parser<'arena, 'src, 'lexer> {
             .map(|t| t.span)
     }
 
-    /// Get the span of a token at a specific index
-    pub(super) fn get_token_span(&mut self, index: usize) -> Option<SourceSpan> {
-        self.ensure_cached(index);
-        self.token_cache.get(index).map(|token| token.span)
-    }
-
     /// Peek at the next token without consuming it
     fn peek_token(&mut self, next_index: u32) -> Option<Token> {
         let target_idx = self.current_idx + 1 + next_index as usize;


### PR DESCRIPTION
Removed the unused `get_token_span` method from `src/parser.rs` as identified by `cargo clippy`. This is an internal helper that is no longer needed, reducing clutter and technical debt without affecting external public APIs.

---
*PR created automatically by Jules for task [13264269984109690825](https://jules.google.com/task/13264269984109690825) started by @bungcip*