### PR TITLE
🛡️ Guardian: Enforce C11 restrict qualifier constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -302,3 +302,8 @@ Action: Ensure semantic checks always enforce the minimum required argument coun
 
 Learning: Break statements must be enclosed within a loop or switch statement. This constraint is properly validated during the `CompilePhase::Mir` by traversing the AST to detect breaks outside valid blocks. A standalone `break`, or one inside an `if` but outside a loop or switch, will throw `SemanticError::BreakNotInLoop`. Adding specific unit tests ensures that the phase correctly catches and rejects this invalid control flow structure.
 Action: Add `guardian_break_not_in_loop_or_switch.rs` to validate this invariant, ensuring the diagnostic triggers at `CompilePhase::Mir` with the correct error message and specific line/column spans.
+
+## 2024-07-11 - Diagnosing Compiler Spans Safely
+
+Learning: When verifying diagnostic spans (lines and columns) for `run_fail_with_diagnostic` in Cendol, tests run by the lib test harness swallow standard output by default, making direct `println!` debugging difficult without `--nocapture`. Also, the `run_pass` and `run_fail` utilities from `test_utils` don't expose simple `get_diagnostics()` methods on the returned driver. Diagnostics must be accessed internally via `driver.de.diagnostics`, and line/column information mapped using `driver.sm.get_line_column(diag.span.start())`.
+Action: Future Guardian test creations will use temporary custom tests that print `driver.de.diagnostics` combined with `cargo test -p cendol [test_name] -- --nocapture` to accurately discover and verify correct token spans for failure conditions before hardcoding them into the assertion methods.

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -92,7 +92,7 @@ pub enum TokenKind {
     AutoType,
 
     // Reserved identifiers as keywords
-    Label,  // __label__
+    Label, // __label__
 
     // === OPERATORS ===
     // Arithmetic operators

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -142,6 +142,7 @@ pub mod guardian_offsetof;
 pub mod guardian_parameter_compatibility;
 pub mod guardian_parameter_completeness;
 pub mod guardian_register_constraints;
+pub mod guardian_restrict_constraints;
 pub mod guardian_sizeof_alignof;
 pub mod guardian_static_array_constraints;
 pub mod guardian_storage_class_parameter;

--- a/src/tests/guardian_restrict_constraints.rs
+++ b/src/tests/guardian_restrict_constraints.rs
@@ -1,0 +1,47 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_diagnostic, run_pass};
+
+#[test]
+fn test_restrict_non_pointer() {
+    run_fail_with_diagnostic(
+        r#"
+        int main() {
+            int restrict x;
+            return 0;
+        }
+        "#,
+        CompilePhase::SemanticLowering,
+        "restrict requires a pointer type",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_restrict_function_pointer() {
+    run_fail_with_diagnostic(
+        r#"
+        int main() {
+            void (* restrict f)(void);
+            return 0;
+        }
+        "#,
+        CompilePhase::SemanticLowering,
+        "restrict requires a pointer type",
+        3,
+        37,
+    );
+}
+
+#[test]
+fn test_restrict_pointer() {
+    run_pass(
+        r#"
+        int main() {
+            int * restrict p;
+            return 0;
+        }
+        "#,
+        CompilePhase::SemanticLowering,
+    );
+}


### PR DESCRIPTION
🧪 What: Added `src/tests/guardian_restrict_constraints.rs` with C code snippets to verify that the `restrict` type qualifier constraints are correctly enforced.
🎯 Why: C11 §6.7.3p2 requires that `restrict` only qualify pointer types pointing to an object or incomplete type. This test ensures that the compiler properly rejects `restrict` on non-pointers and function pointers with `SemanticError::InvalidRestrict` while maintaining correct span diagnostics.
🛠️ Phase: Semantic Lowering
🔬 Verify: Run `cargo test -p cendol guardian_restrict_constraints` to execute the new test suite.

---
*PR created automatically by Jules for task [7868730323742801720](https://jules.google.com/task/7868730323742801720) started by @bungcip*