### PR TITLE
docs: update README and design documents to reflect custom CLI parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,16 @@ cargo run -- -o <output_file> <input_file>
 #### Other Options
 
 - `-E`: Preprocess only, output preprocessed source to stdout
+- `-c`: Compile only, output object file
+- `-g`: Generate debug information
+- `-s`: Strip symbol information
 - `-P`: Suppress line markers in preprocessor output
 - `-C`: Retain comments in preprocessor output
 - `-I <path>`: Add include search path
 - `-D <name>[=<value>]`: Define preprocessor macro
-- `--verbose`: Enable verbose diagnostic output
+- `-v, --verbose`: Enable verbose diagnostic output
+- `-w`: Suppress all warnings
+- `-pedantic`: Issue all warnings demanded by strict ISO C
 
 #### Examples
 

--- a/design-document/compiler_driver_design.md
+++ b/design-document/compiler_driver_design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Cendol compiler driver orchestrates the entire compilation pipeline, from source file input through native code generation and linking. It provides a command-line interface using `clap` and manages the transition between different data representations (Source -> PPToken -> Token -> ParsedAst -> Ast -> MIR -> Object).
+The Cendol compiler driver orchestrates the entire compilation pipeline, from source file input through native code generation and linking. It provides a command-line interface using a custom parser that natively supports GCC/Clang-style single-dash long options and manages the transition between different data representations (Source -> PPToken -> Token -> ParsedAst -> Ast -> MIR -> Object).
 
 ## Responsibilities
 
@@ -14,12 +14,11 @@ The Cendol compiler driver orchestrates the entire compilation pipeline, from so
 
 ## CLI Interface
 
-The driver uses `clap` to provide a GCC/Clang-like interface. Key options include:
+The driver uses a custom parser to provide a GCC/Clang-like interface. Key options include:
 
 - `-o <file>`: Specify output path.
 - `-E`: Preprocess only.
 - `-c`: Compile only (emit object file).
-- `-S`: Emit assembly (Cranelift IR dump).
 - `-I <dir>`: Add include search path.
 - `-D <macro>`: Define preprocessor macro.
 - `--std=<std>`: Select C standard (defaults to C23).

--- a/design-document/rust_environment_design.md
+++ b/design-document/rust_environment_design.md
@@ -11,7 +11,6 @@ The project carefully selects high-quality crates to handle specialized tasks:
 | Crate | Purpose |
 | :--- | :--- |
 | **Cranelift** | High-performance backend for code generation. |
-| **clap** | Robust command-line argument parsing. |
 | **symbol_table** | Fast and thread-safe string interning. |
 | **bitflags** | Efficient bit-field representation for flags (e.g., storage classes). |
 | **thiserror** | Minimalist error deriving for internal errors. |


### PR DESCRIPTION
This updates the compiler's documentation to reflect the recent removal of the `clap` dependency.

Specifically, it updates `design-document/compiler_driver_design.md` to mention the custom CLI parser instead of `clap`, removes `clap` from the key dependencies list in `design-document/rust_environment_design.md`, and updates the "Other Options" section in `README.md` to match the actual flags available in `src/driver/cli.rs`.

---
*PR created automatically by Jules for task [1916975498376281617](https://jules.google.com/task/1916975498376281617) started by @bungcip*