### PR TITLE
🧪 Tuti: Add test for ArraySizeType coverage in display_type

### DIFF
--- a/src/tests/semantic_types.rs
+++ b/src/tests/semantic_types.rs
@@ -775,11 +775,11 @@ fn test_attr_mode() {
 
 #[test]
 fn test_display_array_types() {
-    use crate::semantic::type_registry::TypeRegistry;
-    use target_lexicon::Triple;
-    use crate::semantic::types::BuiltinType;
-    use crate::semantic::ArraySizeType;
     use crate::ast::NodeRef;
+    use crate::semantic::ArraySizeType;
+    use crate::semantic::type_registry::TypeRegistry;
+    use crate::semantic::types::BuiltinType;
+    use target_lexicon::Triple;
 
     let mut reg = TypeRegistry::new(Triple::host());
     let int_ty = reg.get_builtin_type(BuiltinType::Int);

--- a/src/tests/semantic_types.rs
+++ b/src/tests/semantic_types.rs
@@ -772,3 +772,32 @@ fn test_attr_mode() {
     let output = run_c_code_with_output(source);
     assert_eq!(output, "1\n");
 }
+
+#[test]
+fn test_display_array_types() {
+    use crate::semantic::type_registry::TypeRegistry;
+    use target_lexicon::Triple;
+    use crate::semantic::types::BuiltinType;
+    use crate::semantic::ArraySizeType;
+    use crate::ast::NodeRef;
+
+    let mut reg = TypeRegistry::new(Triple::host());
+    let int_ty = reg.get_builtin_type(BuiltinType::Int);
+
+    // Constant size array
+    let arr_const = reg.array_of(int_ty, ArraySizeType::Constant(5));
+    assert_eq!(reg.display_type(arr_const), "int[5]");
+
+    // Incomplete array
+    let arr_incomplete = reg.array_of(int_ty, ArraySizeType::Incomplete);
+    assert_eq!(reg.display_type(arr_incomplete), "int[]");
+
+    // Star array
+    let arr_star = reg.array_of(int_ty, ArraySizeType::Star);
+    assert_eq!(reg.display_type(arr_star), "int[*]");
+
+    // VLA
+    let node_ref = NodeRef::new(1).unwrap();
+    let arr_vla = reg.array_of(int_ty, ArraySizeType::Variable(node_ref));
+    assert_eq!(reg.display_type(arr_vla), "int[*]");
+}


### PR DESCRIPTION
This PR increases code coverage for `ArraySizeType` formatting in `src/semantic/type_registry.rs`.

The `display_type` function had untested match arms for `ArraySizeType::Constant`, `ArraySizeType::Incomplete`, `ArraySizeType::Star`, and `ArraySizeType::Variable`. By adding exactly one test (`test_display_array_types` in `src/tests/semantic_types.rs`), we cover all variants and correctly assert their formatted strings. No production code was modified.

---
*PR created automatically by Jules for task [14499905328171305209](https://jules.google.com/task/14499905328171305209) started by @bungcip*