### PR TITLE
⚡ Bolt: allocation-free access to literals via LitRef

### DIFF
--- a/src/ast/literal.rs
+++ b/src/ast/literal.rs
@@ -388,11 +388,43 @@ impl LitRef {
                 let suffix = FloatSuffix::from_u8(((p >> FLOAT_SUFFIX_SHIFT) & 0xF) as u8);
                 LitVal::from_f64(f32::from_bits(bits) as f64, suffix)
             }
-            TAG_INTERNED => {
-                let id = (self.payload() & INTERN_INDEX_MASK) as u32;
-                global_literal_table().read().unwrap().get(id).clone()
-            }
+            TAG_INTERNED => self.with_val(|v| v.clone()),
             _ => unreachable!(),
+        }
+    }
+
+    /// Access the literal value without always cloning (for interned values).
+    /// Bolt ⚡: Optimization: providing direct access to the global literal table via a closure
+    /// avoids expensive clones of large string literals in the hot path.
+    pub(crate) fn with_val<R>(self, f: impl FnOnce(&LitVal) -> R) -> R {
+        if self.tag() == TAG_INTERNED {
+            let id = (self.payload() & INTERN_INDEX_MASK) as u32;
+            let table = global_literal_table().read().unwrap();
+            f(table.get(id))
+        } else {
+            f(&self.get_val())
+        }
+    }
+
+    /// Retrieve metadata about a string literal without full value retrieval.
+    /// Bolt ⚡: Optimization: metadata-only access avoids heap allocations and RwLock
+    /// overhead for small literals, and avoids String clones for interned ones.
+    pub(crate) fn get_string_metadata(self) -> Option<(usize, StrPrefix)> {
+        match self.tag() {
+            TAG_SMALL_STR => {
+                let p = self.payload();
+                let len = ((p >> STR_LEN_SHIFT) & STR_LEN_MASK) as usize;
+                let prefix = StrPrefix::from_u8(((p >> STR_PREFIX_SHIFT) & STR_PREFIX_MASK) as u8);
+                Some((len + 1, prefix))
+            }
+            TAG_INTERNED => self.with_val(|val| {
+                if let LitVal::String { value, prefix } = val {
+                    Some((get_string_literal_size(value, *prefix), *prefix))
+                } else {
+                    None
+                }
+            }),
+            _ => None,
         }
     }
 
@@ -422,6 +454,23 @@ impl LitRef {
             TAG_FLOAT32 => LitKind::Float,
             TAG_INTERNED => LitKind::from_u8(((self.payload() >> INTERN_KIND_SHIFT) & INTERN_KIND_MASK) as u8),
             _ => unreachable!(),
+        }
+    }
+}
+
+/// Calculate the number of elements in the string literal, including the null terminator.
+/// Bolt ⚡: Optimized metadata-only calculation to avoid full literal lowering.
+/// Standard string literals (None/Utf8) provide O(1) size via content.len().
+pub fn get_string_literal_size(content: &str, prefix: StrPrefix) -> usize {
+    match prefix {
+        StrPrefix::None | StrPrefix::Utf8 => content.len() + 1,
+        StrPrefix::Wide | StrPrefix::Utf32 => content.chars().count() + 1,
+        StrPrefix::Utf16 => {
+            let mut len = 0;
+            for c in content.chars() {
+                len += c.len_utf16();
+            }
+            len + 1
         }
     }
 }

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -505,27 +505,28 @@ impl<'a> MirGen<'a> {
             return None;
         };
 
-        let val = literal_id.get_val();
-        let const_kind = match val {
-            LitVal::Int { value, .. } => ConstValueKind::Int(value),
-            LitVal::Char(val, _) => ConstValueKind::Int(val as i64),
-            LitVal::Nullptr => ConstValueKind::Null,
-            LitVal::True => ConstValueKind::Bool(true),
-            LitVal::False => ConstValueKind::Bool(false),
-            lit @ LitVal::Float { suffix, .. } if suffix.is_imaginary() => {
-                let MirType::Record { field_types, .. } = self.mb.get_type(mir_ty) else {
-                    unreachable!("Complex float must lower to a record type");
-                };
-                let elem_ty = field_types[0];
-                let zero = self.create_constant(elem_ty, ConstValueKind::Float(0.0));
-                let imag = self.create_constant(elem_ty, ConstValueKind::Float(lit.as_f64()));
-                ConstValueKind::StructLiteral(vec![(0, zero), (1, imag)])
-            }
-            lit @ LitVal::Float { .. } => ConstValueKind::Float(lit.as_f64()),
-            LitVal::String { value, prefix } => return Some(self.visit_literal_string(value, prefix, ty)),
-        };
+        literal_id.with_val(|val| {
+            let const_kind = match val {
+                LitVal::Int { value, .. } => ConstValueKind::Int(*value),
+                LitVal::Char(val, _) => ConstValueKind::Int(*val as i64),
+                LitVal::Nullptr => ConstValueKind::Null,
+                LitVal::True => ConstValueKind::Bool(true),
+                LitVal::False => ConstValueKind::Bool(false),
+                lit @ LitVal::Float { suffix, .. } if suffix.is_imaginary() => {
+                    let MirType::Record { field_types, .. } = self.mb.get_type(mir_ty) else {
+                        unreachable!("Complex float must lower to a record type");
+                    };
+                    let elem_ty = field_types[0];
+                    let zero = self.create_constant(elem_ty, ConstValueKind::Float(0.0));
+                    let imag = self.create_constant(elem_ty, ConstValueKind::Float(lit.as_f64()));
+                    ConstValueKind::StructLiteral(vec![(0, zero), (1, imag)])
+                }
+                lit @ LitVal::Float { .. } => ConstValueKind::Float(lit.as_f64()),
+                LitVal::String { value, prefix } => return Some(self.visit_literal_string(value, *prefix, ty)),
+            };
 
-        Some(Operand::Constant(self.create_constant(mir_ty, const_kind)))
+            Some(Operand::Constant(self.create_constant(mir_ty, const_kind)))
+        })
     }
 
     fn visit_unary_op(&mut self, op: UnaryOp, expr: NodeRef, mir_ty: TypeId) -> Operand {

--- a/src/codegen/mir_gen_initializer.rs
+++ b/src/codegen/mir_gen_initializer.rs
@@ -558,22 +558,27 @@ impl<'a> MirGen<'a> {
         let NodeKind::Literal(lit) = self.ast.get_kind(lit_node) else {
             unreachable!()
         };
-        let (val, prefix) = if let LitVal::String { value, prefix } = lit.get_val() {
-            (value, prefix)
-        } else {
-            unreachable!()
-        };
+
         let fixed_size = if let ArraySizeType::Constant(s) = size {
             Some(*s)
         } else {
             None
         };
-        Operand::Constant(self.create_array_const_from_string(
-            val,
-            prefix,
-            fixed_size,
-            Some(QualType::unqualified(element_type)),
-        ))
+
+        lit.with_val(|val| {
+            let (content, prefix) = if let LitVal::String { value, prefix } = val {
+                (value, *prefix)
+            } else {
+                unreachable!()
+            };
+
+            Operand::Constant(self.create_array_const_from_string(
+                content,
+                prefix,
+                fixed_size,
+                Some(QualType::unqualified(element_type)),
+            ))
+        })
     }
 
     fn visit_list_init(&mut self, list: &InitializerList, target_qt: QualType, destination: Option<Place>) -> Operand {
@@ -633,12 +638,12 @@ impl<'a> MirGen<'a> {
 
     fn create_array_const_from_string(
         &mut self,
-        content: String,
+        content: &str,
         prefix: StrPrefix,
         fixed_size: Option<usize>,
         elem_ty: Option<QualType>,
     ) -> crate::mir::ConstValueId {
-        let parsed = lower_string_literal(&content, prefix);
+        let parsed = lower_string_literal(content, prefix);
         let size = fixed_size.unwrap_or(parsed.size);
 
         let (mir_elem_ty, layout) = if let Some(qt) = elem_ty {
@@ -672,7 +677,7 @@ impl<'a> MirGen<'a> {
         self.create_constant(array_ty, ConstValueKind::ArrayLiteral(constants))
     }
 
-    pub(super) fn visit_literal_string(&mut self, content: String, prefix: StrPrefix, qt: QualType) -> Operand {
+    pub(super) fn visit_literal_string(&mut self, content: &str, prefix: StrPrefix, qt: QualType) -> Operand {
         let mir_ty = self.lower_qual_type(qt);
         let elem_ty = self
             .registry

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -13,7 +13,7 @@ use crate::{
         const_eval::ConstEvalCtx,
         conversions::{integer_promotion, usual_arithmetic_conversions},
         errors::{SemanticDiag, SemanticError},
-        literal_utils::{get_string_builtin_type, get_string_literal_size},
+        literal_utils::get_string_builtin_type,
         types::TypeClass,
     },
 };
@@ -3445,10 +3445,26 @@ impl<'a> SemanticAnalyzer<'a> {
     }
 
     fn visit_literal(&mut self, lid: LitRef, node: NodeRef) -> Option<QualType> {
-        let val = lid.get_val();
-        match val {
+        // Bolt ⚡: Optimization: Using get_string_metadata for string literals allows
+        // determining their type and size without cloning the content string.
+        if let Some((size, prefix)) = lid.get_string_metadata() {
+            let builtin_type = get_string_builtin_type(prefix);
+            let element_type = self.registry.get_builtin_type(builtin_type);
+
+            let array_type = self.registry.array_of(element_type, ArraySizeType::Constant(size));
+            let _ = self.registry.ensure_layout(array_type);
+
+            // Bolt ⚡: Eagerly set value category to LValue for string literals.
+            self.semantic_info.value_categories[node.index()] = ValueCategory::LValue;
+
+            return Some(QualType::new(array_type, TypeQualifiers::empty()));
+        }
+
+        lid.with_val(|val| match val {
             LitVal::Int { value, suffix, radix } => {
-                let is_decimal = radix == 10;
+                let value = *value;
+                let suffix = *suffix;
+                let is_decimal = *radix == 10;
                 for ty in suffix.get_candidates(self.registry, is_decimal) {
                     let _ = self.registry.ensure_layout(ty);
                     if self.registry.is_literal_fitting(value, ty) {
@@ -3468,23 +3484,10 @@ impl<'a> SemanticAnalyzer<'a> {
                 let ty = prefix.get_type(self.registry);
                 Some(QualType::unqualified(ty))
             }
-            LitVal::String { value, prefix } => {
-                // Bolt ⚡: Use metadata-only accessors to avoid full literal lowering.
-                let builtin_type = get_string_builtin_type(prefix);
-                let size = get_string_literal_size(&value, prefix);
-                let element_type = self.registry.get_builtin_type(builtin_type);
-
-                let array_type = self.registry.array_of(element_type, ArraySizeType::Constant(size));
-                let _ = self.registry.ensure_layout(array_type);
-
-                // Bolt ⚡: Eagerly set value category to LValue for string literals.
-                self.semantic_info.value_categories[node.index()] = ValueCategory::LValue;
-
-                Some(QualType::new(array_type, TypeQualifiers::empty()))
-            }
+            LitVal::String { .. } => unreachable!("Handled by get_string_metadata above"),
             LitVal::Nullptr => Some(QualType::unqualified(self.registry.type_nullptr_t)),
             LitVal::True | LitVal::False => Some(QualType::unqualified(self.registry.type_bool)),
-        }
+        })
     }
     fn visit_node(&mut self, node: NodeRef) -> Option<QualType> {
         // Bolt ⚡: Memoization - skip analysis if node was already visited.

--- a/src/semantic/literal_utils.rs
+++ b/src/semantic/literal_utils.rs
@@ -20,22 +20,7 @@ pub(crate) fn get_string_builtin_type(prefix: StrPrefix) -> BuiltinType {
     }
 }
 
-/// Calculate the number of elements in the string literal, including the null terminator.
-/// Bolt ⚡: Optimized metadata-only calculation to avoid full literal lowering.
-/// Standard string literals (None/Utf8) provide O(1) size via content.len().
-pub(crate) fn get_string_literal_size(content: &str, prefix: StrPrefix) -> usize {
-    match prefix {
-        StrPrefix::None | StrPrefix::Utf8 => content.len() + 1,
-        StrPrefix::Wide | StrPrefix::Utf32 => content.chars().count() + 1,
-        StrPrefix::Utf16 => {
-            let mut len = 0;
-            for c in content.chars() {
-                len += c.len_utf16();
-            }
-            len + 1
-        }
-    }
-}
+pub use crate::ast::literal::get_string_literal_size;
 
 pub(crate) fn lower_string_literal(content: &str, prefix: StrPrefix) -> StringLiteralValue {
     let builtin_type = get_string_builtin_type(prefix);


### PR DESCRIPTION
💡 What: Added `with_val` and `get_string_metadata` to `LitRef` to provide borrowed access to interned literal values and metadata-only access to string literals. Refactored semantic analysis and MIR generation to use these methods.
🎯 Why: Bypasses expensive `LitRef::get_val()` clones of interned string literals during semantic analysis and code generation.
📊 Impact: Reduces heap allocations and `String` clones in the hot path of the compiler, particularly for translation units with many or large string literals.
🔬 Measurement: Can be verified by profiling memory usage and execution time on large C projects (e.g., SQLite), expecting a reduction in `String::clone` calls and overall peak memory.

---
*PR created automatically by Jules for task [8424885996757990992](https://jules.google.com/task/8424885996757990992) started by @bungcip*