### PR TITLE
🛡️ Guardian: C11 _Atomic type specifier and qualifier constraints protected

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -305,3 +305,8 @@ Action: Add `guardian_break_not_in_loop_or_switch.rs` to validate this invariant
 2024-05-18 - [Bit-field width and type validation constraints]
 
 Learning: [The C standard sets specific rules regarding bit-fields. Validation points for bit-fields during the semantic lowering phase are extremely specific. For instance, C23 and earlier standards prohibit an `_Atomic` type in a bitfield entirely and explicitly prevent zero-width bit-fields from having an assigned name. Invalid types (like floats) and width declarations that are non-constant expressions or exceed the types underlying size will also error. To capture the full spectrum of restrictions, exhaustive combinations must be checked in the negative tests for these invariants.] Action: [Ensure that any validation for memory layouts heavily constrains its testing for corner cases—such as zero-width bit-fields versus named zero-width bit-fields. Semantic tests shouldn't just check 'does not compile'; they must explicitly verify the error spans and messages (e.g., 'zero-width bit-field shall not specify a declarator', 'bit-field shall not have an atomic type', and 'width of bit-field exceeds width of its type'). Tests added in `guardian_bitfield_constraints.rs` capture these diagnostic expectations safely.]
+
+2024-05-14 - [Invalid _Atomic Usage]
+
+Learning: The _Atomic qualifier and _Atomic(type-name) specifier have specific restrictions in C11. They cannot be used with array, function, or void types. Furthermore, _Atomic(type-name) cannot be applied to an already atomic or qualified type.
+Action: Protect compiler invariants by validating that semantic errors for invalid atomic type specifiers and qualifiers are correctly generated.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -135,6 +135,7 @@ pub mod guardian_function_return_type_constraints;
 pub mod guardian_generic;
 pub mod guardian_increment_completeness;
 pub mod guardian_index_completeness;
+pub mod guardian_invalid_atomic_specifier;
 pub mod guardian_modifiable_lvalue;
 pub mod guardian_noreturn_switch;
 pub mod guardian_npc_propagation;

--- a/src/tests/guardian_invalid_atomic_specifier.rs
+++ b/src/tests/guardian_invalid_atomic_specifier.rs
@@ -1,0 +1,72 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_guardian_invalid_atomic_specifier() {
+    run_fail_with_diagnostic(
+        "_Atomic(int [10]) b;",
+        CompilePhase::SemanticLowering,
+        "_Atomic(type-name) specifier cannot be used with array type",
+        1,
+        1,
+    );
+
+    run_fail_with_diagnostic(
+        "_Atomic(void(void)) f;",
+        CompilePhase::SemanticLowering,
+        "_Atomic(type-name) specifier cannot be used with function type",
+        1,
+        1,
+    );
+
+    run_fail_with_diagnostic(
+        "_Atomic(_Atomic int) d;",
+        CompilePhase::SemanticLowering,
+        "_Atomic(type-name) specifier cannot be used with atomic type",
+        1,
+        1,
+    );
+
+    run_fail_with_diagnostic(
+        "_Atomic(const int) c;",
+        CompilePhase::SemanticLowering,
+        "_Atomic(type-name) specifier cannot be used with qualified type",
+        1,
+        1,
+    );
+
+    run_fail_with_diagnostic(
+        "typedef _Atomic(void) av;",
+        CompilePhase::SemanticLowering,
+        "_Atomic(type-name) specifier cannot be used with void type",
+        1,
+        1,
+    );
+}
+
+#[test]
+fn test_guardian_invalid_atomic_qualifier() {
+    run_fail_with_diagnostic(
+        "typedef int A[10]; _Atomic A a;",
+        CompilePhase::SemanticLowering,
+        "_Atomic qualifier cannot be used with array type",
+        1,
+        20,
+    );
+
+    run_fail_with_diagnostic(
+        "typedef void F(void); _Atomic F f;",
+        CompilePhase::SemanticLowering,
+        "_Atomic qualifier cannot be used with function type",
+        1,
+        23,
+    );
+
+    run_fail_with_diagnostic(
+        "_Atomic void *p;",
+        CompilePhase::SemanticLowering,
+        "_Atomic qualifier cannot be used with void type",
+        1,
+        1,
+    );
+}


### PR DESCRIPTION
🧪 **What:** 
Added negative tests to verify that the C11 `_Atomic` type specifier and qualifier properly reject invalid usages on arrays, functions, void types, and already qualified/atomic types.
Included specific diagnostic checks to assert exact line/column spans.
Recorded deep compiler learning in the Guardian journal (`.jules/guardian.md`).

🎯 **Why:** 
To prevent miscompilation by explicitly enforcing semantic limitations on `_Atomic` per the C11 standard. This protects against regressions in type-checking logic where the compiler might incorrectly accept atomic arrays or double-atomic qualifiers.

🛠️ **Phase:** 
Semantic Lowering

🔬 **Verify:** 
`cargo test -p cendol guardian_invalid_atomic`

---
*PR created automatically by Jules for task [7730475916774253732](https://jules.google.com/task/7730475916774253732) started by @bungcip*