### PR TITLE
🛡️ Guardian: Warn when returning local array addresses

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -310,3 +310,6 @@ Learning: [The C standard sets specific rules regarding bit-fields. Validation p
 
 Learning: The _Atomic qualifier and _Atomic(type-name) specifier have specific restrictions in C11. They cannot be used with array, function, or void types. Furthermore, _Atomic(type-name) cannot be applied to an already atomic or qualified type.
 Action: Protect compiler invariants by validating that semantic errors for invalid atomic type specifiers and qualifiers are correctly generated.
+2024-05-18 - [Return Local Array Address]
+Learning: The compiler was correctly identifying returning the address of a local variable (e.g., `return &x`) but missed the case where `x` is a local array. Local arrays decay to pointers (e.g., `return x` is equivalent to `return &x[0]`). Thus, we should also emit the `ReturnLocalAddress` warning when returning a local array directly.
+Action: Extend `SemanticAnalyzer::visit_return_stmt` to check if the returned variable is a local array, not just an explicit `&x`. Added tests for both cases.

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -1141,7 +1141,9 @@ impl<'a> SemanticAnalyzer<'a> {
                         && v.storage != Some(StorageClass::Extern)
                         && v.storage != Some(StorageClass::ThreadLocal);
 
-                    if is_local && (symbol.type_info.is_array() || matches!(kind, NodeKind::UnaryOp(UnaryOp::AddrOf, _))) {
+                    if is_local
+                        && (symbol.type_info.is_array() || matches!(kind, NodeKind::UnaryOp(UnaryOp::AddrOf, _)))
+                    {
                         self.report_warning(node, SemanticError::ReturnLocalAddress { name: *name });
                     }
                 }

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -1118,20 +1118,32 @@ impl<'a> SemanticAnalyzer<'a> {
             self.validate_assignment(node, target_ty, expr_ty, *expr);
         }
 
-        if let Some(expr) = value_expr
-            && let NodeKind::UnaryOp(UnaryOp::AddrOf, operand) = self.ast.get_kind(*expr)
-            && let NodeKind::Ident(name, sym) = self.ast.get_kind(*operand)
-        {
-            let symbol = self.symbol_table.get_symbol(*sym);
-            if let SymbolKind::Variable(v) = &symbol.kind {
-                // Check if it's a local variable (not static/extern)
-                let is_local = symbol.scope_id != crate::semantic::ScopeId::GLOBAL
-                    && v.storage != Some(StorageClass::Static)
-                    && v.storage != Some(StorageClass::Extern)
-                    && v.storage != Some(StorageClass::ThreadLocal);
+        if let Some(expr) = value_expr {
+            let kind = self.ast.get_kind(*expr);
 
-                if is_local {
-                    self.report_warning(node, SemanticError::ReturnLocalAddress { name: *name });
+            let mut ident_info = None;
+
+            if let NodeKind::UnaryOp(UnaryOp::AddrOf, operand) = kind {
+                if let NodeKind::Ident(name, sym) = self.ast.get_kind(*operand) {
+                    ident_info = Some((name, sym));
+                }
+            } else if let NodeKind::Ident(name, sym) = kind {
+                // Arrays decay to pointers, so returning 'x' when 'x' is an array is equivalent to '&x[0]'
+                ident_info = Some((name, sym));
+            }
+
+            if let Some((name, sym)) = ident_info {
+                let symbol = self.symbol_table.get_symbol(*sym);
+                if let SymbolKind::Variable(v) = &symbol.kind {
+                    // Check if it's a local variable (not static/extern)
+                    let is_local = symbol.scope_id != crate::semantic::ScopeId::GLOBAL
+                        && v.storage != Some(StorageClass::Static)
+                        && v.storage != Some(StorageClass::Extern)
+                        && v.storage != Some(StorageClass::ThreadLocal);
+
+                    if is_local && (symbol.type_info.is_array() || matches!(kind, NodeKind::UnaryOp(UnaryOp::AddrOf, _))) {
+                        self.report_warning(node, SemanticError::ReturnLocalAddress { name: *name });
+                    }
                 }
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -113,6 +113,7 @@ pub mod driver_source_manager;
 pub mod driver_warning_formatting;
 
 // Guardian
+pub mod guardian_return_local_address;
 pub mod guardian_alias_completeness;
 pub mod guardian_alignas_constraints;
 pub mod guardian_alignas_vla;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -113,7 +113,6 @@ pub mod driver_source_manager;
 pub mod driver_warning_formatting;
 
 // Guardian
-pub mod guardian_return_local_address;
 pub mod guardian_alias_completeness;
 pub mod guardian_alignas_constraints;
 pub mod guardian_alignas_vla;
@@ -141,6 +140,7 @@ pub mod guardian_offsetof;
 pub mod guardian_parameter_compatibility;
 pub mod guardian_parameter_completeness;
 pub mod guardian_register_constraints;
+pub mod guardian_return_local_address;
 pub mod guardian_sizeof_alignof;
 pub mod guardian_static_array_constraints;
 pub mod guardian_storage_class_parameter;

--- a/src/tests/guardian_return_local_address.rs
+++ b/src/tests/guardian_return_local_address.rs
@@ -9,7 +9,13 @@ fn diagnostic_return_local_address() {
             return &x;
         }
     "#;
-    run_pass_with_diagnostic(source, CompilePhase::Mir, "address of stack memory associated with local variable 'x' returned", 4, 13);
+    run_pass_with_diagnostic(
+        source,
+        CompilePhase::Mir,
+        "address of stack memory associated with local variable 'x' returned",
+        4,
+        13,
+    );
 }
 
 #[test]
@@ -20,5 +26,11 @@ fn diagnostic_return_local_array_address() {
             return x;
         }
     "#;
-    run_pass_with_diagnostic(source, CompilePhase::Mir, "address of stack memory associated with local variable 'x' returned", 4, 13);
+    run_pass_with_diagnostic(
+        source,
+        CompilePhase::Mir,
+        "address of stack memory associated with local variable 'x' returned",
+        4,
+        13,
+    );
 }

--- a/src/tests/guardian_return_local_address.rs
+++ b/src/tests/guardian_return_local_address.rs
@@ -1,0 +1,24 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_pass_with_diagnostic;
+
+#[test]
+fn diagnostic_return_local_address() {
+    let source = r#"
+        int* f() {
+            int x = 42;
+            return &x;
+        }
+    "#;
+    run_pass_with_diagnostic(source, CompilePhase::Mir, "address of stack memory associated with local variable 'x' returned", 4, 13);
+}
+
+#[test]
+fn diagnostic_return_local_array_address() {
+    let source = r#"
+        int* f() {
+            int x[10];
+            return x;
+        }
+    "#;
+    run_pass_with_diagnostic(source, CompilePhase::Mir, "address of stack memory associated with local variable 'x' returned", 4, 13);
+}


### PR DESCRIPTION
🧪 What: Extended the semantic analyzer to emit `ReturnLocalAddress` when returning a local array by value (which implicitly decays into a pointer to stack memory). Added relevant test scenarios checking both scalar reference `&x` and array reference `x`.
🎯 Why: C arrays inherently decay to pointers to their first element. Thus, `return local_array` is semantically equivalent to `return &local_array[0]`. Failing to catch this allows returning pointers to stack memory which will be invalidated after the function returns, leading to undefined behavior and potential security issues.
🛠️ Phase: Semantic (analyzer)
🔬 Verify: Run `cargo test -p cendol guardian_return_local_address` to execute the new test in isolation, and `cargo test -p cendol` to run the full suite.

---
*PR created automatically by Jules for task [11254151786233600805](https://jules.google.com/task/11254151786233600805) started by @bungcip*