### PR TITLE
⚡ Bolt: Optimize keyword_map lookup using FxHashMap

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -553,10 +553,10 @@ fn special_keywords() -> &'static SpecialKeywords {
     })
 }
 
-fn keyword_map() -> &'static hashbrown::HashMap<StringId, TokenKind> {
-    static KEYWORDS: std::sync::OnceLock<hashbrown::HashMap<StringId, TokenKind>> = std::sync::OnceLock::new();
+fn keyword_map() -> &'static rustc_hash::FxHashMap<StringId, TokenKind> {
+    static KEYWORDS: std::sync::OnceLock<rustc_hash::FxHashMap<StringId, TokenKind>> = std::sync::OnceLock::new();
     KEYWORDS.get_or_init(|| {
-        let mut m = hashbrown::HashMap::new();
+        let mut m = rustc_hash::FxHashMap::default();
         m.insert(StringId::new("auto"), TokenKind::Auto);
         m.insert(StringId::new("break"), TokenKind::Break);
         m.insert(StringId::new("case"), TokenKind::Case);


### PR DESCRIPTION
Replaced the standard `hashbrown::HashMap` in `src/parser/lexer.rs` with `rustc_hash::FxHashMap` for the static keyword map. This provides a clean performance improvement for identifier classification, which runs on the hot path for every single identifier token in the source code. Tests and lint checks have been run and verified. No extra dependencies are added and no functionality is broken.

---
*PR created automatically by Jules for task [17948526660023848443](https://jules.google.com/task/17948526660023848443) started by @bungcip*