### PR TITLE
🧹 Rendi: Remove redundant TODO for enum redefinition

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -139,12 +139,14 @@ impl DiagnosticEngine {
                 d.is_streamed = true;
             }
             engine.diagnostics.push(d.clone());
-            if !engine.is_testing && engine.stream_muted == 0
-                && let Ok(mut writer) = engine.writer.lock() {
-                    let mut fmt_writer = FmtToIoWrite(&mut **writer);
-                    let _ = engine.print_single(&d, sm, &mut fmt_writer);
-                    let _ = writeln!(writer);
-                }
+            if !engine.is_testing
+                && engine.stream_muted == 0
+                && let Ok(mut writer) = engine.writer.lock()
+            {
+                let mut fmt_writer = FmtToIoWrite(&mut **writer);
+                let _ = engine.print_single(&d, sm, &mut fmt_writer);
+                let _ = writeln!(writer);
+            }
         };
 
         match diag.level {
@@ -206,15 +208,16 @@ impl DiagnosticEngine {
             }
         }
         if !to_print.is_empty()
-            && let Ok(mut writer) = self.writer.lock() {
-                for diag in to_print {
-                    {
-                        let mut fmt_writer = FmtToIoWrite(&mut **writer);
-                        let _ = self.print_single(&diag, sm, &mut fmt_writer);
-                    }
-                    let _ = writeln!(writer);
+            && let Ok(mut writer) = self.writer.lock()
+        {
+            for diag in to_print {
+                {
+                    let mut fmt_writer = FmtToIoWrite(&mut **writer);
+                    let _ = self.print_single(&diag, sm, &mut fmt_writer);
                 }
+                let _ = writeln!(writer);
             }
+        }
     }
 
     pub(crate) fn report_semantic(

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -3283,9 +3283,7 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
                 has_fixed_underlying_type,
                 base_type: existing,
                 ..
-            } => {
-                (*has_fixed_underlying_type, *existing)
-            }
+            } => (*has_fixed_underlying_type, *existing),
             _ => (false, self.registry.type_int),
         };
 

--- a/src/semantic/lowering.rs
+++ b/src/semantic/lowering.rs
@@ -3282,13 +3282,8 @@ impl<'a, 'src> LowerCtx<'a, 'src> {
             TypeKind::Enum {
                 has_fixed_underlying_type,
                 base_type: existing,
-                is_complete,
-                enumerators: existing_enum,
                 ..
             } => {
-                if *is_complete && !enumerators.is_empty() && !existing_enum.is_empty() {
-                    // TODO: Both have enumerators -> Redefinition
-                }
                 (*has_fixed_underlying_type, *existing)
             }
             _ => (false, self.registry.type_int),


### PR DESCRIPTION
In `src/semantic/lowering.rs`, removed a redundant `TODO: Both have enumerators -> Redefinition` inside the `lower_enum` method. The condition surrounding the `TODO` was dead/redundant because the correct redefinition check and diagnostic for enums that both define an enumerator list is securely handled earlier in the same function around line 3236. Therefore, the empty `if` block and the `TODO` were removed to clean up the code.

---
*PR created automatically by Jules for task [4958944431989241664](https://jules.google.com/task/4958944431989241664) started by @bungcip*