### PR TITLE
test: Add coverage for C23 constexpr storage class conflicts

### DIFF
--- a/src/tests/semantic_c23.rs
+++ b/src/tests/semantic_c23.rs
@@ -81,6 +81,53 @@ fn test_c23_constexpr() {
         "conflicting storage class",
         CStandard::C23,
     );
+
+    // constexpr conflicting with static/auto/register
+    run_fail_with_message_and_std(
+        r#"
+        int main() {
+            constexpr register int x = 5;
+        }
+        "#,
+        "conflicting storage class",
+        CStandard::C23,
+    );
+
+    run_fail_with_message_and_std(
+        r#"
+        int main() {
+            constexpr auto int y = 5;
+        }
+        "#,
+        "conflicting storage class",
+        CStandard::C23,
+    );
+
+    // File scope conflicts
+    run_fail_with_message_and_std(
+        r#"
+        constexpr auto int y = 5;
+        "#,
+        "conflicting storage class",
+        CStandard::C23,
+    );
+
+    run_fail_with_message_and_std(
+        r#"
+        constexpr register int y = 5;
+        "#,
+        "conflicting storage class",
+        CStandard::C23,
+    );
+
+    // Test thread_local + constexpr
+    run_fail_with_message_and_std(
+        r#"
+        constexpr _Thread_local int z = 5;
+        "#,
+        "conflicting storage class",
+        CStandard::C23,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Added test coverage for C23 `constexpr` storage class constraints in `src/tests/semantic_c23.rs`. Specifically tests that `constexpr` combined with `auto`, `register`, or `_Thread_local` triggers a "conflicting storage class" error, increasing code coverage in `validate_specifier_combinations` (`src/semantic/lowering.rs`).

---
*PR created automatically by Jules for task [5620212533675415650](https://jules.google.com/task/5620212533675415650) started by @bungcip*