### PR TITLE
🧹 Rendi: refactor: replace == false with negation operator to satisfy clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ criterion = { version = "0.8", features = ["html_reports"] }
 insta = []
 
 [lints.clippy]
-bool_comparison = "allow" ## reason: `== false` is more readable in some cases
 
 [[bench]]
 name = "compiler_benches"

--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1260,7 +1260,7 @@ impl<'a> MirGen<'a> {
         self.visit_node(body);
 
         // If body falls through, go to merge
-        if self.current_block_has_terminator() == false {
+        if !self.current_block_has_terminator() {
             // Check if terminator is Unreachable (default) - if so, we can replace it or just leave it?
             // `current_block_has_terminator` returns false if it is Unreachable.
             // But if we are in body_entry_dummy and it's empty, we shouldn't jump to merge.

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -1243,7 +1243,7 @@ impl<'a> MirGen<'a> {
             obj_qt.ty()
         };
 
-        if record_ty.is_record() == false {
+        if !record_ty.is_record() {
             panic!("ICE: Member access on non-record type");
         }
 

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -590,7 +590,7 @@ impl<'src> Preprocessor<'src> {
                     self.report_pp_warning(err);
                 }
                 return Some(token);
-            } else if self.pop_lexer() == false {
+            } else if !self.pop_lexer() {
                 return None;
             }
         }


### PR DESCRIPTION
Removed the `bool_comparison = "allow"` override in `Cargo.toml` and refactored the corresponding `== false` checks to use the negation operator `!` in `mir_gen.rs`, `mir_gen_expression.rs`, and `preprocessor.rs`. This satisfies the clippy lint and adheres to more idiomatic Rust code.

---
*PR created automatically by Jules for task [2198051802747707283](https://jules.google.com/task/2198051802747707283) started by @bungcip*