### PR TITLE
Add unit test for literal parsing edge cases to increase code coverage

### DIFF
--- a/src/ast/literal_parsing.rs
+++ b/src/ast/literal_parsing.rs
@@ -511,4 +511,19 @@ mod tests {
         // Covers line 196, 197 (digit separator in hex float exponent)
         assert_eq!(super::parse_hex_float_literal("0x1.0p1'0"), Some(1024.0));
     }
+
+    #[test]
+    fn test_float_literal_edge_cases() {
+        assert_eq!(super::parse_float_literal(""), None);
+        assert_eq!(super::parse_float_literal("0x1.0.."), None);
+        assert_eq!(super::parse_float_literal("0x1.0z"), None);
+        assert_eq!(super::parse_float_literal("0x.p1"), None);
+
+        // Also test integer literal edge cases
+        assert_eq!(super::parse_integer_literal(""), None);
+        assert_eq!(super::parse_integer_literal("0x"), None);
+
+        // Also test char literal edge cases
+        assert_eq!(super::parse_char_literal(""), None);
+    }
 }


### PR DESCRIPTION
Added a new unit test `test_float_literal_edge_cases` in `src/ast/literal_parsing.rs` to cover error pathways (returning `None`) for `parse_float_literal`, `parse_integer_literal`, and `parse_char_literal` with invalid string inputs. This successfully increased code coverage.

---
*PR created automatically by Jules for task [5651798472970519307](https://jules.google.com/task/5651798472970519307) started by @bungcip*