### PR TITLE
Increase coverage for `symbol_table` BuiltinFunctionKind and SymbolRef

### DIFF
--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -1066,3 +1066,31 @@ pub struct SymbolTableState {
     current_scope_id: ScopeId,
     next_scope_id: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*; use super::BuiltinFunctionKind;
+
+    #[test]
+    fn test_symbol_table_coverage() {
+        assert_eq!(BuiltinFunctionKind::AtomicLoadN.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::LoadN));
+        assert_eq!(BuiltinFunctionKind::AtomicStoreN.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::StoreN));
+        assert_eq!(BuiltinFunctionKind::AtomicExchangeN.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::ExchangeN));
+        assert_eq!(BuiltinFunctionKind::AtomicCompareExchangeN.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::CompareExchangeN));
+        assert_eq!(BuiltinFunctionKind::AtomicFetchAdd.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchAdd));
+        assert_eq!(BuiltinFunctionKind::AtomicFetchSub.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchSub));
+        assert_eq!(BuiltinFunctionKind::AtomicFetchAnd.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchAnd));
+        assert_eq!(BuiltinFunctionKind::AtomicFetchOr.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchOr));
+        assert_eq!(BuiltinFunctionKind::AtomicFetchXor.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchXor));
+        assert_eq!(BuiltinFunctionKind::AtomicAddFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::AddFetch));
+        assert_eq!(BuiltinFunctionKind::AtomicSubFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::SubFetch));
+        assert_eq!(BuiltinFunctionKind::AtomicAndFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::AndFetch));
+        assert_eq!(BuiltinFunctionKind::AtomicOrFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::OrFetch));
+        assert_eq!(BuiltinFunctionKind::AtomicXorFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::XorFetch));
+        assert_eq!(BuiltinFunctionKind::AtomicThreadFence.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::ThreadFence));
+        assert_eq!(BuiltinFunctionKind::Popcount.to_atomic_op(), None);
+        assert!(SymbolRef::new_with_class(0, SymbolClass::Variable).is_none());
+        assert!(SymbolRef::new_with_class((1 << 29) + 1, SymbolClass::Variable).is_none());
+        assert!(SymbolRef::new_with_class(1, SymbolClass::Variable).is_some());
+    }
+}

--- a/src/semantic/symbol_table.rs
+++ b/src/semantic/symbol_table.rs
@@ -1069,25 +1069,71 @@ pub struct SymbolTableState {
 
 #[cfg(test)]
 mod tests {
-    use super::*; use super::BuiltinFunctionKind;
+    use super::BuiltinFunctionKind;
+    use super::*;
 
     #[test]
     fn test_symbol_table_coverage() {
-        assert_eq!(BuiltinFunctionKind::AtomicLoadN.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::LoadN));
-        assert_eq!(BuiltinFunctionKind::AtomicStoreN.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::StoreN));
-        assert_eq!(BuiltinFunctionKind::AtomicExchangeN.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::ExchangeN));
-        assert_eq!(BuiltinFunctionKind::AtomicCompareExchangeN.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::CompareExchangeN));
-        assert_eq!(BuiltinFunctionKind::AtomicFetchAdd.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchAdd));
-        assert_eq!(BuiltinFunctionKind::AtomicFetchSub.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchSub));
-        assert_eq!(BuiltinFunctionKind::AtomicFetchAnd.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchAnd));
-        assert_eq!(BuiltinFunctionKind::AtomicFetchOr.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchOr));
-        assert_eq!(BuiltinFunctionKind::AtomicFetchXor.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::FetchXor));
-        assert_eq!(BuiltinFunctionKind::AtomicAddFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::AddFetch));
-        assert_eq!(BuiltinFunctionKind::AtomicSubFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::SubFetch));
-        assert_eq!(BuiltinFunctionKind::AtomicAndFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::AndFetch));
-        assert_eq!(BuiltinFunctionKind::AtomicOrFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::OrFetch));
-        assert_eq!(BuiltinFunctionKind::AtomicXorFetch.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::XorFetch));
-        assert_eq!(BuiltinFunctionKind::AtomicThreadFence.to_atomic_op(), Some(crate::ast::nodes::AtomicOp::ThreadFence));
+        assert_eq!(
+            BuiltinFunctionKind::AtomicLoadN.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::LoadN)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicStoreN.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::StoreN)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicExchangeN.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::ExchangeN)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicCompareExchangeN.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::CompareExchangeN)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicFetchAdd.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::FetchAdd)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicFetchSub.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::FetchSub)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicFetchAnd.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::FetchAnd)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicFetchOr.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::FetchOr)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicFetchXor.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::FetchXor)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicAddFetch.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::AddFetch)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicSubFetch.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::SubFetch)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicAndFetch.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::AndFetch)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicOrFetch.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::OrFetch)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicXorFetch.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::XorFetch)
+        );
+        assert_eq!(
+            BuiltinFunctionKind::AtomicThreadFence.to_atomic_op(),
+            Some(crate::ast::nodes::AtomicOp::ThreadFence)
+        );
         assert_eq!(BuiltinFunctionKind::Popcount.to_atomic_op(), None);
         assert!(SymbolRef::new_with_class(0, SymbolClass::Variable).is_none());
         assert!(SymbolRef::new_with_class((1 << 29) + 1, SymbolClass::Variable).is_none());


### PR DESCRIPTION
A. Coverage increased

* Uncovered path: Several match arms in `BuiltinFunctionKind::to_atomic_op` mapping builtins to `AtomicOp`s, and the initial check for zero or out-of-bound indexes in `SymbolRef::new_with_class` were not executed by existing tests.
* Added Test: Appended `test_symbol_table_coverage` under `src/semantic/symbol_table.rs`.
* Coverage improvement: These additions increased execution coverage for `to_atomic_op` and `SymbolRef` construction bounds checks within `src/semantic/symbol_table.rs`.

---
*PR created automatically by Jules for task [13854060682628567704](https://jules.google.com/task/13854060682628567704) started by @bungcip*