### PR TITLE
🛡️ Guardian: Reject function specifiers on non-function declarations

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -318,3 +318,7 @@ Action: Extend `SemanticAnalyzer::visit_return_stmt` to check if the returned va
 
 Learning: In C11 (unlike C++), expressions resulting from cast, ternary conditional (`?:`), comma (`,`), and assignment (`=`) operators do not yield modifiable lvalues. Arrays and functions are also not modifiable lvalues. Without tests covering these precise expressions, the compiler might implicitly allow assignments to them (like `(a = b) = c;`), which breaks fundamental C language constraints and causes invalid codegen or crashes downstream.
 Action: Add `guardian_lvalue_assignment.rs` to validate that these constructs are strictly rejected with `SemanticError::NotAnLvalue` at `CompilePhase::Mir`, and ensure the diagnostic spans are accurately tested.
+2024-05-24 - [Function Specifier Constraints]
+
+Learning: C11 6.7.4p1 requires that function specifiers ('inline' and '_Noreturn') only be used in the declaration of an identifier that is a function. This means they must be rejected for typedefs, struct/union members, and tag declarations (forward decls or definitions), even if the underlying type is a function pointer.
+Action: Centralize function specifier validation in semantic lowering to ensure all non-function declaration paths (variables, typedefs, members, tags) correctly enforce these constraints.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -169,6 +169,7 @@ pub mod codegen_alias;
 pub mod guardian_break_not_in_loop_or_switch;
 pub mod guardian_case_not_in_switch;
 pub mod guardian_continue_not_in_loop;
+pub mod guardian_invalid_function_specifier;
 mod guardian_invalid_number_of_arguments;
 pub mod guardian_invalid_storage_class_for_function;
 mod guardian_invalid_unary_operand;

--- a/src/tests/guardian_invalid_function_specifier.rs
+++ b/src/tests/guardian_invalid_function_specifier.rs
@@ -1,0 +1,54 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_fail_with_diagnostic, run_fail_with_message};
+
+#[test]
+fn test_inline_on_variable() {
+    run_fail_with_diagnostic(
+        "inline int x;",
+        CompilePhase::SemanticLowering,
+        "'inline' function specifier appears on non-function declaration",
+        1,
+        1,
+    );
+}
+
+#[test]
+fn test_noreturn_on_variable() {
+    run_fail_with_diagnostic(
+        "_Noreturn int x;",
+        CompilePhase::SemanticLowering,
+        "'_Noreturn' function specifier appears on non-function declaration",
+        1,
+        1,
+    );
+}
+
+#[test]
+fn test_inline_on_typedef() {
+    // A typedef defining a function type is still a typedef, not a function
+    run_fail_with_message(
+        "typedef inline void f(void);",
+        "'inline' function specifier appears on non-function declaration",
+    );
+}
+
+#[test]
+fn test_noreturn_on_function_pointer() {
+    // A function pointer variable is not a function
+    run_fail_with_diagnostic(
+        "_Noreturn void (*f)(void);",
+        CompilePhase::SemanticLowering,
+        "'_Noreturn' function specifier appears on non-function declaration",
+        1,
+        1,
+    );
+}
+
+#[test]
+fn test_inline_on_struct_member() {
+    // A struct member cannot have a function specifier
+    run_fail_with_message(
+        "struct S { inline int x; };",
+        "'inline' function specifier appears on non-function declaration",
+    );
+}


### PR DESCRIPTION
🧪 What: C code snippets attempting to apply `inline` or `_Noreturn` function specifiers to non-function declarations like variables, typedefs, struct members, and function pointers.
🎯 Why: C11 6.7.4p1 requires function specifiers to only be applied to declarations of an identifier that is a function. This prevents misusing these keywords on non-function types and protects the compiler from miscompilations on invalid syntax structures.
🛠️ Phase: SemanticLowering
🔬 Verify: `cargo test -p cendol guardian_invalid_function_specifier`

---
*PR created automatically by Jules for task [15175237479508940132](https://jules.google.com/task/15175237479508940132) started by @bungcip*