### PR TITLE
🧹 Rendi: Refactor redundant boolean comparisons

### DIFF
--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1260,7 +1260,7 @@ impl<'a> MirGen<'a> {
         self.visit_node(body);
 
         // If body falls through, go to merge
-        if self.current_block_has_terminator() == false {
+        if !self.current_block_has_terminator() {
             // Check if terminator is Unreachable (default) - if so, we can replace it or just leave it?
             // `current_block_has_terminator` returns false if it is Unreachable.
             // But if we are in body_entry_dummy and it's empty, we shouldn't jump to merge.

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -1276,7 +1276,7 @@ impl<'a> MirGen<'a> {
             obj_qt.ty()
         };
 
-        if record_ty.is_record() == false {
+        if !record_ty.is_record() {
             panic!("ICE: Member access on non-record type");
         }
 

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -590,7 +590,7 @@ impl<'src> Preprocessor<'src> {
                     self.report_pp_warning(err);
                 }
                 return Some(token);
-            } else if self.pop_lexer() == false {
+            } else if !self.pop_lexer() {
                 return None;
             }
         }


### PR DESCRIPTION
Removed redundant `== false` checks in favor of `!` in `mir_gen.rs`, `mir_gen_expression.rs`, and `preprocessor.rs`. This cleans up `clippy::bool_comparison` warnings and improves code readability. No functional changes.

---
*PR created automatically by Jules for task [9267021653780949885](https://jules.google.com/task/9267021653780949885) started by @bungcip*