### PR TITLE
🛡️ Guardian: Validate diagnostic for address of array always true

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -318,3 +318,8 @@ Action: Extend `SemanticAnalyzer::visit_return_stmt` to check if the returned va
 
 Learning: In C11 (unlike C++), expressions resulting from cast, ternary conditional (`?:`), comma (`,`), and assignment (`=`) operators do not yield modifiable lvalues. Arrays and functions are also not modifiable lvalues. Without tests covering these precise expressions, the compiler might implicitly allow assignments to them (like `(a = b) = c;`), which breaks fundamental C language constraints and causes invalid codegen or crashes downstream.
 Action: Add `guardian_lvalue_assignment.rs` to validate that these constructs are strictly rejected with `SemanticError::NotAnLvalue` at `CompilePhase::Mir`, and ensure the diagnostic spans are accurately tested.
+
+2024-05-18 - [Address of Array Always True Warning]
+
+Learning: When an array decays to a pointer and is used in a boolean context (like `if`, `while`, `for`, `? :`, `!`), its address is always evaluated as true. The compiler should warn about this tautological condition via `SemanticError::AddressOfArrayAlwaysTrue`. We must ensure the diagnostic points to the specific array identifier rather than the parent expression node, and that it correctly applies across all scalar-expecting constructs.
+Action: Ensure `SemanticAnalyzer::check_scalar_condition` correctly propagates the warning for all relevant control flow structures, and that explicit tests validating the correct span are maintained in `guardian_address_of_array_always_true.rs`. Ensure `visit_ternary_op` also calls `check_scalar_condition` instead of manual checking to maintain consistency.

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -1246,7 +1246,7 @@ impl<'a> SemanticAnalyzer<'a> {
                 if actual_qt.is_array()
                     && let NodeKind::Ident(name, _) = self.ast.get_kind(expr)
                 {
-                    self.report_warning(node, SemanticError::AddressOfArrayAlwaysTrue { name: *name });
+                    self.report_warning(expr, SemanticError::AddressOfArrayAlwaysTrue { name: *name });
                 }
 
                 if actual_qt.is_array() || actual_qt.is_function() {
@@ -3345,7 +3345,8 @@ impl<'a> SemanticAnalyzer<'a> {
     }
 
     fn visit_ternary_op(&mut self, cond: NodeRef, then: NodeRef, else_expr: NodeRef) -> Option<QualType> {
-        let cond_qt = self.visit_node(cond)?;
+        self.check_scalar_condition(cond);
+        let cond_qt = self.semantic_info.types[cond.index()].unwrap();
         self.apply_lvalue_conversion(cond);
         self.require_scalar(cond, cond_qt);
         let then_ty = self.visit_node(then);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -183,3 +183,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_address_of_array_always_true;

--- a/src/tests/guardian_address_of_array_always_true.rs
+++ b/src/tests/guardian_address_of_array_always_true.rs
@@ -1,0 +1,82 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_pass_with_diagnostic;
+
+#[test]
+fn test_address_of_array_always_true_warning_if() {
+    run_pass_with_diagnostic(
+        r#"
+        void f() {
+            int arr[10];
+            if (arr) {}
+        }
+        "#,
+        CompilePhase::Mir,
+        "address of array 'arr' will always evaluate to 'true'",
+        4,
+        17,
+    );
+}
+
+#[test]
+fn test_address_of_array_always_true_warning_while() {
+    run_pass_with_diagnostic(
+        r#"
+        void f() {
+            int arr[10];
+            while (arr) {}
+        }
+        "#,
+        CompilePhase::Mir,
+        "address of array 'arr' will always evaluate to 'true'",
+        4,
+        20,
+    );
+}
+
+#[test]
+fn test_address_of_array_always_true_warning_for() {
+    run_pass_with_diagnostic(
+        r#"
+        void f() {
+            int arr[10];
+            for (; arr;) {}
+        }
+        "#,
+        CompilePhase::Mir,
+        "address of array 'arr' will always evaluate to 'true'",
+        4,
+        20,
+    );
+}
+
+#[test]
+fn test_address_of_array_always_true_warning_ternary() {
+    run_pass_with_diagnostic(
+        r#"
+        void f() {
+            int arr[10];
+            int x = arr ? 1 : 0;
+        }
+        "#,
+        CompilePhase::Mir,
+        "address of array \'arr\' will always evaluate to \'true\'",
+        4,
+        21,
+    );
+}
+
+#[test]
+fn test_address_of_array_always_true_warning_logical_not() {
+    run_pass_with_diagnostic(
+        r#"
+        void f() {
+            int arr[10];
+            int x = !arr;
+        }
+        "#,
+        CompilePhase::Mir,
+        "address of array 'arr' will always evaluate to 'true'",
+        4,
+        22,
+    );
+}


### PR DESCRIPTION
🛡️ Guardian: Validate diagnostic for address of array always true

🧪 What: Added `guardian_address_of_array_always_true.rs` to test that using an array in a boolean context correctly emits a `SemanticError::AddressOfArrayAlwaysTrue` warning. Updated `visit_ternary_op` to use `check_scalar_condition` for consistency. Corrected the warning span for `UnaryOp::LogicNot` to point to the operand instead of the operator.
🎯 Why: Ensures that tautological pointer comparisons (where an array decays to a pointer and is inherently true) are consistently diagnosed across `if`, `while`, `for`, `? :`, and `!` constructs with accurate source spans.
🛠️ Phase: Semantic / MIR
🔬 Verify: `cargo test --lib -- tests::guardian_address_of_array_always_true`

---
*PR created automatically by Jules for task [16020226474378263092](https://jules.google.com/task/16020226474378263092) started by @bungcip*