### PR TITLE
Tuti: Increase char8_t type specifier parsing coverage

### DIFF
--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -296,6 +296,7 @@ pub(crate) fn parse_decl_specs(parser: &mut Parser) -> Result<ThinVec<DeclSpec>,
 
             TokenKind::Void
             | TokenKind::Char
+            | TokenKind::Char8
             | TokenKind::Short
             | TokenKind::Int
             | TokenKind::Long

--- a/src/tests/parser_types.rs
+++ b/src/tests/parser_types.rs
@@ -132,3 +132,15 @@ fn test_type_spec_combinations() {
         check_type(source, expected);
     }
 }
+#[test]
+fn test_char8_type_specifier() {
+    let source = "char8_t x;";
+    let decl = super::parser_utils::setup_declaration_with_std(source, crate::lang_options::CStandard::C23);
+    insta::assert_yaml_snapshot!(decl, @"
+    Declaration:
+      specifiers:
+        - Char8
+      init_declarators:
+        - name: x
+    ");
+}


### PR DESCRIPTION
A. Coverage increased

The parser lacked the mapping and matching block handling of `TokenKind::Char8` down to `DeclSpec::TypeSpec` within the parser's match blocks, leaving C23 `char8_t` AST resolution dead code internally on the primary variable declaration pipeline.

```rust
#[test]
fn test_char8_type_specifier() {
    let source = "char8_t x;";
    let decl = super::parser_utils::setup_declaration_with_std(source, crate::lang_options::CStandard::C23);
    insta::assert_yaml_snapshot!(decl, @"
    Declaration:
      specifiers:
        - Char8
      init_declarators:
        - name: x
    ");
}
```

The change updates `src/parser/declarations.rs` to allow the `TokenKind::Char8` match arm handling to properly reach previously dead parsing path execution code blocks, effectively increasing AST type specifier parsing coverage.

---
*PR created automatically by Jules for task [13931888548253963105](https://jules.google.com/task/13931888548253963105) started by @bungcip*