### PR TITLE
🛡️ Guardian: assert diagnostic spans for function returning array or function

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -322,3 +322,6 @@ Action: Add `guardian_lvalue_assignment.rs` to validate that these constructs ar
 
 Learning: C11 6.7.4p1 requires that function specifiers ('inline' and '_Noreturn') only be used in the declaration of an identifier that is a function. This means they must be rejected for typedefs, struct/union members, and tag declarations (forward decls or definitions), even if the underlying type is a function pointer.
 Action: Centralize function specifier validation in semantic lowering to ensure all non-function declaration paths (variables, typedefs, members, tags) correctly enforce these constraints.
+2024-05-18 - function_returning_array_function
+
+Learning: When reporting SemanticError::FunctionReturningArray or FunctionReturningFunction, the span points to the closing parenthesis of the function declarator, not the start of the function name. This is due to the structure of PDeclarator::Function and how scopes are resolved. Action: Future tests that check diagnostic spans for declarator-related errors should carefully check if the error is triggered by the inner declarator or the entire declarator (like the '()').

--- a/src/tests/guardian_function_return_type_constraints.rs
+++ b/src/tests/guardian_function_return_type_constraints.rs
@@ -1,27 +1,33 @@
 use crate::driver::artifact::CompilePhase;
-use crate::tests::test_utils::{run_fail_with_message, run_pass};
+use crate::tests::test_utils::{run_fail_with_diagnostic, run_pass};
 
 #[test]
 fn test_function_returning_array_rejected() {
     // C11 6.7.6.3p1: A function declarator shall not specify a return type that is a function type or an array type.
-    run_fail_with_message(
+    run_fail_with_diagnostic(
         r#"
         typedef int arr[10];
         arr f();
         "#,
+        CompilePhase::SemanticLowering,
         "function cannot return an array type",
+        3,
+        15,
     );
 }
 
 #[test]
 fn test_function_returning_function_rejected() {
     // C11 6.7.6.3p1: A function declarator shall not specify a return type that is a function type or an array type.
-    run_fail_with_message(
+    run_fail_with_diagnostic(
         r#"
         typedef int func();
         func f();
         "#,
+        CompilePhase::SemanticLowering,
         "function cannot return a function type",
+        3,
+        16,
     );
 }
 
@@ -46,5 +52,19 @@ fn test_function_returning_pointer_to_function_accepted() {
         int main() { return 0; }
         "#,
         CompilePhase::SemanticLowering,
+    );
+}
+
+#[test]
+fn test_function_returning_multidimensional_array_rejected() {
+    run_fail_with_diagnostic(
+        r#"
+        typedef int arr[10][20];
+        arr f();
+        "#,
+        CompilePhase::SemanticLowering,
+        "function cannot return an array type",
+        3,
+        15,
     );
 }


### PR DESCRIPTION
🧪 What: C code snippet + scenario testing functions returning an array or a function type, ensuring the correct diagnostic and source span.
🎯 Why: What bug or ambiguity this prevents: This prevents miscompilations where invalid return types (like an array or a function) might be implicitly accepted, and guarantees that the error is correctly localized to the closing parenthesis of the function declarator.
🛠️ Phase: SemanticLowering
🔬 Verify: Run `cargo test guardian_function_return_type_constraints`

---
*PR created automatically by Jules for task [18095552392121850395](https://jules.google.com/task/18095552392121850395) started by @bungcip*