### PR TITLE
Tuti: Add unit test to cover missing get_type enum match arms

### DIFF
--- a/src/ast/literal.rs
+++ b/src/ast/literal.rs
@@ -577,3 +577,19 @@ mod tests {
         assert!(null_lit.is_integer_zero());
     }
 }
+
+#[cfg(test)]
+mod get_type_tests {
+    use super::{FloatSuffix, CharPrefix};
+    use crate::semantic::TypeRegistry;
+
+    #[test]
+    fn test_literal_get_type_coverage() {
+        let registry = TypeRegistry::new(target_lexicon::Triple::host());
+        assert_eq!(FloatSuffix::IL.get_type(&registry), registry.type_complex_long_double);
+        assert_eq!(CharPrefix::Utf8.get_type(&registry), registry.type_char_unsigned);
+        assert_eq!(CharPrefix::Wide.get_type(&registry), registry.type_signed);
+        assert_eq!(CharPrefix::Char16.get_type(&registry), registry.type_short_unsigned);
+        assert_eq!(CharPrefix::Char32.get_type(&registry), registry.type_int_unsigned);
+    }
+}

--- a/src/ast/literal.rs
+++ b/src/ast/literal.rs
@@ -580,7 +580,7 @@ mod tests {
 
 #[cfg(test)]
 mod get_type_tests {
-    use super::{FloatSuffix, CharPrefix};
+    use super::{CharPrefix, FloatSuffix};
     use crate::semantic::TypeRegistry;
 
     #[test]


### PR DESCRIPTION
Added exactly one new unit test to cover the missing `FloatSuffix::IL` and all non-`None` `CharPrefix` match arms in `get_type` methods.

---
*PR created automatically by Jules for task [9876008154229529](https://jules.google.com/task/9876008154229529) started by @bungcip*