### PR TITLE
🛡️ Guardian: Add tests for `_Noreturn` function returning value constraints

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -322,3 +322,8 @@ Action: Add `guardian_lvalue_assignment.rs` to validate that these constructs ar
 
 Learning: C11 6.7.4p1 requires that function specifiers ('inline' and '_Noreturn') only be used in the declaration of an identifier that is a function. This means they must be rejected for typedefs, struct/union members, and tag declarations (forward decls or definitions), even if the underlying type is a function pointer.
 Action: Centralize function specifier validation in semantic lowering to ensure all non-function declaration paths (variables, typedefs, members, tags) correctly enforce these constraints.
+
+2026-07-28 - [C11 §6.7.4p8: _Noreturn function contains a return statement]
+
+Learning: A function declared with `_Noreturn` shall not return to its caller. The semantic phase correctly checks for explicit `return` statements in functions marked as `_Noreturn` and emits `SemanticError::NoreturnFunctionHasReturn`. To fully ensure this invariant is strictly checked with precise spans and diagnostics, dedicated tests were required to assert that both void and non-void returns correctly trigger the diagnostic on the specific `return` keyword.
+Action: Add `guardian_noreturn_has_return.rs` to validate that any `return` statement within a `_Noreturn` function triggers the exact error during `CompilePhase::Mir` with accurate line/column diagnostic spans.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -184,3 +184,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod guardian_noreturn_has_return;

--- a/src/tests/guardian_noreturn_has_return.rs
+++ b/src/tests/guardian_noreturn_has_return.rs
@@ -1,0 +1,32 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_noreturn_has_return() {
+    run_fail_with_diagnostic(
+        r#"
+        _Noreturn void f(void) {
+            return;
+        }
+        "#,
+        CompilePhase::Mir,
+        "function 'f' declared '_Noreturn' contains a return statement",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_noreturn_has_return_value() {
+    run_fail_with_diagnostic(
+        r#"
+        _Noreturn int f(void) {
+            return 1;
+        }
+        "#,
+        CompilePhase::Mir,
+        "function 'f' declared '_Noreturn' contains a return statement",
+        3,
+        13,
+    );
+}


### PR DESCRIPTION
This PR adds dedicated testing to protect the compiler invariant that functions marked as `_Noreturn` cannot contain explicit return statements (C11 6.7.4p8).

It adds the `guardian_noreturn_has_return.rs` test suite which verifies:
* The compiler catches explicit void returns (`return;`) inside a `_Noreturn` function.
* The compiler catches explicit value returns (`return 1;`) inside a `_Noreturn` function.
* Both emit the correct error (`SemanticError::NoreturnFunctionHasReturn`) with the correct message.
* The diagnostic exactly points to the `return` statement's span (line/column) in `CompilePhase::Mir`.

The Guardian's journal was updated with these precise learnings.

---
*PR created automatically by Jules for task [15099098619126145351](https://jules.google.com/task/15099098619126145351) started by @bungcip*