### PR TITLE
Add coverage for duplicate GNU local label declarations

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -183,6 +183,6 @@ pub mod semantic_binary_conversion;
 pub mod semantic_binary_invalid_operands;
 pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
+pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
 pub mod test_utils;
-pub mod semantic_gnu_local_label;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -185,3 +185,4 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod semantic_gnu_local_label;

--- a/src/tests/semantic_gnu_local_label.rs
+++ b/src/tests/semantic_gnu_local_label.rs
@@ -1,0 +1,13 @@
+use crate::tests::test_utils::run_fail_with_message;
+
+#[test]
+fn test_gnu_local_label_duplicate() {
+    let source = r#"
+    int main() {
+        __label__ my_label;
+        __label__ my_label;
+        return 0;
+    }
+    "#;
+    run_fail_with_message(source, "duplicate label declaration 'my_label'");
+}


### PR DESCRIPTION
Adds a single unit test to cover the `SemanticError::DuplicateLabelDeclaration` error path when using the GNU C `__label__` extension, improving code coverage as requested.

---
*PR created automatically by Jules for task [45740936887990921](https://jules.google.com/task/45740936887990921) started by @bungcip*