### PR TITLE
🧹 Rendi: Clean up unused code and unimplemented placeholders

### DIFF
--- a/src/codegen/clif_gen.rs
+++ b/src/codegen/clif_gen.rs
@@ -2396,7 +2396,7 @@ fn visit_statement(stmt: &MirStmt, ctx: &mut BodyEmitContext) {
             for (constraint, place) in outputs {
                 let constraint_str = match constraint.get_val() {
                     LitVal::String { value, .. } => String::from_utf8_lossy(&value).into_owned(),
-                    _ => unimplemented!(),
+                    _ => unreachable!("inline asm constraint must be a string literal"),
                 };
                 let asm_constraint = match constraint_str.as_str() {
                     "r" => AsmConstraintKind::GeneralReg,
@@ -2420,7 +2420,7 @@ fn visit_statement(stmt: &MirStmt, ctx: &mut BodyEmitContext) {
             for (constraint, operand) in inputs {
                 let constraint_str = match constraint.get_val() {
                     LitVal::String { value, .. } => String::from_utf8_lossy(&value).into_owned(),
-                    _ => unimplemented!(),
+                    _ => unreachable!("inline asm constraint must be a string literal"),
                 };
                 let asm_constraint = match constraint_str.as_str() {
                     "r" => AsmConstraintKind::GeneralReg,
@@ -2445,14 +2445,14 @@ fn visit_statement(stmt: &MirStmt, ctx: &mut BodyEmitContext) {
             for clobber in clobbers {
                 let clobber_str = match clobber.get_val() {
                     LitVal::String { value, .. } => String::from_utf8_lossy(&value).into_owned(),
-                    _ => unimplemented!(),
+                    _ => unreachable!("inline asm clobber must be a string literal"),
                 };
                 clobber_strings.push(clobber_str);
             }
 
             let template_str = match template.get_val() {
                 LitVal::String { value, .. } => String::from_utf8_lossy(&value).into_owned(),
-                _ => unimplemented!("Non-string asm template"),
+                _ => unreachable!("inline asm template must be a string literal"),
             };
 
             let asm_data = InlineAsmData {

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -15,8 +15,10 @@ fn setup_driver(source: &str, phase: CompilePhase) -> CompilerDriver {
 /// provide default SourceManager & DiagnosticEngine
 pub(crate) fn setup_sm_and_de() -> (SourceManager, DiagnosticEngine) {
     let sm = SourceManager::new();
-    let mut de = DiagnosticEngine::default();
-    de.is_testing = true;
+    let de = DiagnosticEngine {
+        is_testing: true,
+        ..Default::default()
+    };
     (sm, de)
 }
 


### PR DESCRIPTION
This PR performs minor codebase cleanup:

1. **Test Utils (`src/tests/test_utils.rs`)**: Refactors the initialization of `DiagnosticEngine` to use Rust's struct update syntax (`..Default::default()`), resolving a Clippy warning for `field_reassign_with_default`.
2. **Cranelift IR Gen (`src/codegen/clif_gen.rs`)**: Replaces instances of `unimplemented!()` with `unreachable!()` during inline assembly literal extraction. Prior semantic analysis guarantees these values are string literals, making the fallback branch mathematically unreachable, not unimplemented.

No observable functionality has been changed.

---
*PR created automatically by Jules for task [8494653889575627495](https://jules.google.com/task/8494653889575627495) started by @bungcip*