### PR TITLE
🛡️ Guardian: Add test for _Noreturn functions containing return statements

### DIFF
--- a/src/pp/header_search.rs
+++ b/src/pp/header_search.rs
@@ -121,7 +121,12 @@ impl HeaderSearch {
     }
 
     /// Resolve an include path for #include_next, skipping the search path valid for current_dir
-    pub(crate) fn resolve_next_path(&self, include_path: &str, is_angled: bool, current_dir: &Path) -> Option<Arc<PathBuf>> {
+    pub(crate) fn resolve_next_path(
+        &self,
+        include_path: &str,
+        is_angled: bool,
+        current_dir: &Path,
+    ) -> Option<Arc<PathBuf>> {
         let key_ref = SearchKeyRef {
             include_path,
             is_angled,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -135,6 +135,7 @@ pub mod guardian_increment_completeness;
 pub mod guardian_index_completeness;
 pub mod guardian_invalid_atomic_specifier;
 pub mod guardian_modifiable_lvalue;
+pub mod guardian_noreturn_has_return;
 pub mod guardian_noreturn_switch;
 pub mod guardian_npc_propagation;
 pub mod guardian_offsetof;

--- a/src/tests/guardian_noreturn_has_return.rs
+++ b/src/tests/guardian_noreturn_has_return.rs
@@ -1,0 +1,34 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_noreturn_function_has_return() {
+    let source = r#"
+        _Noreturn void die(void) {
+            return;
+        }
+    "#;
+    run_fail_with_diagnostic(
+        source,
+        CompilePhase::Mir,
+        "function 'die' declared '_Noreturn' contains a return statement",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_noreturn_function_has_return_with_expr() {
+    let source = r#"
+        _Noreturn int die(void) {
+            return 1;
+        }
+    "#;
+    run_fail_with_diagnostic(
+        source,
+        CompilePhase::Mir,
+        "function 'die' declared '_Noreturn' contains a return statement",
+        3,
+        13,
+    );
+}


### PR DESCRIPTION
This PR adds a high-value Guardian test case to ensure the compiler correctly emits a diagnostic when a function declared with `_Noreturn` contains a `return` statement. It verifies both the error message and the exact line/column span of the diagnostic (pointing to the `return` keyword itself).

🧪 What: Minimal C snippets with a `_Noreturn` function attempting to return a value (or void).
🎯 Why: Protects the invariant that `_Noreturn` functions should not return, guarding against miscompilations and ensuring high-quality diagnostics.
🛠️ Phase: Semantic
🔬 Verify: `cargo test -p cendol guardian_noreturn_has_return`

---
*PR created automatically by Jules for task [17229002262463393191](https://jules.google.com/task/17229002262463393191) started by @bungcip*