### PR TITLE
Add unit test for `__builtin_offsetof` const eval coverage

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,4 @@
+pub mod semantic_const_eval_offsetof;
 pub mod parser_lexer_coverage;
 // Preprocessor
 pub mod pp_common;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
-pub mod semantic_const_eval_offsetof;
 pub mod parser_lexer_coverage;
+pub mod semantic_const_eval_offsetof;
 // Preprocessor
 pub mod pp_common;
 pub mod pp_conditionals;

--- a/src/tests/semantic_const_eval_offsetof.rs
+++ b/src/tests/semantic_const_eval_offsetof.rs
@@ -1,0 +1,71 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::{run_pass, run_fail};
+
+#[test]
+fn test_builtin_offsetof_in_const_eval_coverage() {
+    let source = "
+    struct S {
+        int a;
+        struct {
+            int b;
+            int c;
+        };
+    };
+    int arr[__builtin_offsetof(struct S, c)];
+    ";
+    run_pass(source, CompilePhase::Mir);
+
+    let source2 = "
+    struct S { int a; };
+    int arr[__builtin_offsetof(struct S, xyz)];
+    ";
+    run_fail(source2, CompilePhase::Mir);
+
+    let source3 = "
+    int x;
+    int arr[__builtin_offsetof(int, x)];
+    ";
+    run_fail(source3, CompilePhase::Mir);
+
+    let source4 = "
+    struct S { int a[10]; };
+    int arr[__builtin_offsetof(struct S, a[2])];
+    ";
+    run_pass(source4, CompilePhase::Mir);
+
+    let source5 = "
+    struct S { int a; };
+    int arr[__builtin_offsetof(struct S, a[2])];
+    ";
+    run_fail(source5, CompilePhase::Mir);
+
+    let source6 = "
+    struct S { int a[10]; };
+    int var;
+    int arr[__builtin_offsetof(struct S, a[var])];
+    ";
+    run_fail(source6, CompilePhase::Mir);
+
+    let source7 = "
+    struct S { int a; };
+    int arr[__builtin_offsetof(struct S, a + 1)];
+    ";
+    run_fail(source7, CompilePhase::Mir);
+
+    let source8 = "
+    int x;
+    int arr[__builtin_offsetof(struct S, x)];
+    ";
+    run_fail(source8, CompilePhase::Mir);
+
+    let source9 = "
+    struct S { int a; };
+    int arr[__builtin_offsetof(struct S, 123)];
+    ";
+    run_fail(source9, CompilePhase::Mir);
+
+    let source10 = "
+    int arr[__builtin_offsetof(struct DOES_NOT_EXIST, a)];
+    ";
+    run_fail(source10, CompilePhase::Mir);
+}

--- a/src/tests/semantic_const_eval_offsetof.rs
+++ b/src/tests/semantic_const_eval_offsetof.rs
@@ -1,5 +1,5 @@
 use crate::driver::artifact::CompilePhase;
-use crate::tests::test_utils::{run_pass, run_fail};
+use crate::tests::test_utils::{run_fail, run_pass};
 
 #[test]
 fn test_builtin_offsetof_in_const_eval_coverage() {


### PR DESCRIPTION
A. Coverage increased
- **Short analysis**: The `eval_offsetof` function inside `src/semantic/const_eval.rs` handles the constant evaluation of the `__builtin_offsetof` C extension. While some basic paths were covered, many of the complex sub-paths, such as resolving members in anonymous structs and handling invalid accesses (e.g., non-struct types, out-of-bounds arrays, and unknown members), lacked coverage.
- **Test code**: Added `src/tests/semantic_const_eval_offsetof.rs` which uses valid and invalid array declarations sizing via `__builtin_offsetof` to thoroughly exercise these paths.
- **Explanation**: By adding a comprehensive unit test that leverages `run_pass` and `run_fail` across various valid and invalid `__builtin_offsetof` expressions, the coverage in `src/semantic/const_eval.rs` increased.

---
*PR created automatically by Jules for task [4155858731584096804](https://jules.google.com/task/4155858731584096804) started by @bungcip*