### PR TITLE
🧹 Rendi: Remove unused module imports to fix clippy warnings

### DIFF
--- a/crates/cranelift/codegen/src/isa/x64/abi.rs
+++ b/crates/cranelift/codegen/src/isa/x64/abi.rs
@@ -7,7 +7,6 @@ use crate::ir::{ExternalName, types::*};
 use crate::isa;
 use crate::isa::winch;
 use crate::isa::{CallConv, unwind::UnwindInst, x64::inst::*, x64::settings as x64_settings};
-use crate::machinst::abi::*;
 use crate::machinst::*;
 use crate::settings;
 use alloc::borrow::ToOwned;

--- a/crates/cranelift/codegen/src/isa/x64/lower.rs
+++ b/crates/cranelift/codegen/src/isa/x64/lower.rs
@@ -10,7 +10,6 @@ use crate::isa::x64::abi::*;
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::isa::{CallConv, x64::X64Backend};
-use crate::machinst::lower::*;
 use crate::machinst::*;
 use crate::result::CodegenResult;
 use crate::settings::Flags;

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -3,7 +3,7 @@
 //! This module handles all expression parsing logic, including the Pratt parser
 //! implementation for operator precedence and associativity.
 
-use crate::ast::{parsed::*, *};
+use crate::ast::*;
 use crate::parser::type_builder::parse_type_name;
 use crate::parser::{ParseDiag, ParseError, Token, TokenKind};
 use crate::source_manager::{SourceLoc, SourceSpan};

--- a/src/parser/struct_parsing.rs
+++ b/src/parser/struct_parsing.rs
@@ -5,7 +5,6 @@
 
 use thin_vec::ThinVec;
 
-use crate::ast::parsed::*;
 use crate::ast::*;
 use crate::parser::declarations::parse_decl_specs;
 use crate::parser::{ParseDiag, TokenKind};


### PR DESCRIPTION
🧹 Rendi: Remove unused module imports to fix clippy warnings

This commit removes unused wildcard and module imports across the codebase that were triggering `unused_imports` warnings when building the `cendol` and `cranelift-codegen` crates with `-D warnings`.

Files updated:
- `crates/cranelift/codegen/src/isa/x64/abi.rs`: Removed `use crate::machinst::abi::*;`
- `crates/cranelift/codegen/src/isa/x64/lower.rs`: Removed `use crate::machinst::lower::*;`
- `src/parser/expressions.rs`: Removed `use crate::ast::parsed::*;`
- `src/parser/struct_parsing.rs`: Removed `use crate::ast::parsed::*;`

All compiler unit tests and checks continue to pass successfully.

---
*PR created automatically by Jules for task [15790177613582890833](https://jules.google.com/task/15790177613582890833) started by @bungcip*