### PR TITLE
Tuti: Increase coverage for UnaryOp::LogicNot const evaluation

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -186,5 +186,5 @@ pub mod semantic_cleanup_coverage;
 pub mod semantic_conversions_uncovered;
 pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
-pub mod test_utils;
 pub mod test_const_eval_unary;
+pub mod test_utils;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -187,3 +187,4 @@ pub mod semantic_conversions_uncovered;
 pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
 pub mod test_utils;
+pub mod test_const_eval_unary;

--- a/src/tests/test_const_eval_unary.rs
+++ b/src/tests/test_const_eval_unary.rs
@@ -1,0 +1,13 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::*;
+
+#[test]
+fn test_const_eval_unary_coverage() {
+    let source = "
+    void f() {
+        int x = 5;
+        int arr[sizeof(!x)];
+    }
+    ";
+    run_pass(source, CompilePhase::Mir);
+}


### PR DESCRIPTION
A. Coverage increased

The previously uncovered code path was the handling of the `UnaryOp::LogicNot` (`!`) operator during constant evaluation in `src/semantic/const_eval.rs`. The code was:

```rust
                    UnaryOp::LogicNot => Some(QualType::unqualified(self.registry.type_int)),
```

The added unit test uses the `sizeof` operator to trigger constant evaluation of `!x`, hitting this specific branch. The test code is:

```rust
use crate::driver::artifact::CompilePhase;
use crate::tests::test_utils::*;

#[test]
fn test_const_eval_unary_coverage() {
    let source = "
    void f() {
        int x = 5;
        int arr[sizeof(!x)];
    }
    ";
    run_pass(source, CompilePhase::Mir);
}
```

This increases coverage in `src/semantic/const_eval.rs`.

---
*PR created automatically by Jules for task [10941570066342454465](https://jules.google.com/task/10941570066342454465) started by @bungcip*