### PR TITLE
🧹 Rendi: Remove dead code and simplify boolean comparisons

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -172,13 +172,6 @@ impl Offset for u32 {
     }
 }
 
-impl Offset for usize {
-    #[inline]
-    fn to_u32(self) -> u32 {
-        self as u32
-    }
-}
-
 impl Offset for i32 {
     #[inline]
     fn to_u32(self) -> u32 {

--- a/src/codegen/mir_gen.rs
+++ b/src/codegen/mir_gen.rs
@@ -1260,7 +1260,7 @@ impl<'a> MirGen<'a> {
         self.visit_node(body);
 
         // If body falls through, go to merge
-        if self.current_block_has_terminator() == false {
+        if !self.current_block_has_terminator() {
             // Check if terminator is Unreachable (default) - if so, we can replace it or just leave it?
             // `current_block_has_terminator` returns false if it is Unreachable.
             // But if we are in body_entry_dummy and it's empty, we shouldn't jump to merge.

--- a/src/codegen/mir_gen_expression.rs
+++ b/src/codegen/mir_gen_expression.rs
@@ -1276,7 +1276,7 @@ impl<'a> MirGen<'a> {
             obj_qt.ty()
         };
 
-        if record_ty.is_record() == false {
+        if !record_ty.is_record() {
             panic!("ICE: Member access on non-record type");
         }
 

--- a/src/pp/preprocessor.rs
+++ b/src/pp/preprocessor.rs
@@ -590,7 +590,7 @@ impl<'src> Preprocessor<'src> {
                     self.report_pp_warning(err);
                 }
                 return Some(token);
-            } else if self.pop_lexer() == false {
+            } else if !self.pop_lexer() {
                 return None;
             }
         }

--- a/src/source_manager.rs
+++ b/src/source_manager.rs
@@ -2,7 +2,6 @@ use hashbrown::HashMap;
 use serde::Serialize;
 use std::sync::Arc;
 use std::{
-    cmp::Ordering,
     num::NonZeroU32,
     path::{Path, PathBuf},
 };
@@ -197,7 +196,7 @@ impl std::fmt::Display for SourceSpan {
 }
 
 /// Represents a single #line directive entry
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LineDirective {
     pub(crate) physical_line: u32,
     pub(crate) logical_line: u32,
@@ -211,18 +210,6 @@ impl LineDirective {
             logical_line,
             logical_file,
         }
-    }
-}
-
-impl Ord for LineDirective {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.physical_line.cmp(&other.physical_line)
-    }
-}
-
-impl PartialOrd for LineDirective {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/src/tests/driver_source_manager.rs
+++ b/src/tests/driver_source_manager.rs
@@ -277,7 +277,7 @@ fn test_line_directive_ord() {
     let entry3 = LineDirective::new(10, 150, None);
 
     assert!(entry1 < entry2);
-    assert_eq!(entry1.cmp(&entry3), std::cmp::Ordering::Equal); // Same physical line
+    assert_eq!(entry1.cmp(&entry3), std::cmp::Ordering::Less); // derived ord uses all fields
 }
 
 #[test]


### PR DESCRIPTION
This PR performs standard codebase janitorial cleanup by removing identified dead code and simplifying logic:

1. **Dead Code**: The `impl Offset for usize` in `src/ast.rs` was removed as it had 0% coverage and was unused across the codebase.
2. **Logic Bug / Boilerplate Reduction**: Replaced the manual implementation of `Ord` and `PartialOrd` for `LineDirective` with derived traits. The manual implementation compared only `physical_line`, which violates the standard Rust trait contract since `PartialEq` was already derived (checking all fields).
3. **Idiomatic Fixes**: Replaced explicit boolean equality comparisons (e.g. `x == false`) with standard negation logic (`!x`) as recommended by clippy.

---
*PR created automatically by Jules for task [12654554104439339435](https://jules.google.com/task/12654554104439339435) started by @bungcip*