### PR TITLE
🛡️ Guardian: Validate expected array type on subscripting

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -338,3 +338,8 @@ Action: Add `guardian_address_of_array_always_true.rs` to validate that `Semanti
 
 Learning: When a `switch` statement jumps into the scope of a variably modified type (VLA), the diagnostic span must correctly point to the specific `case` or `default` label that triggered the error, rather than the statement immediately following the label. This requires passing the correct AST `NodeRef` down to the error reporting function (e.g., `check_switch_vla_jump`), as relying on the body statement's node will result in inaccurate line/column numbers.
 Action: When testing diagnostic spans for control-flow statements (like `switch`), always assert the exact line and column using `run_fail_with_diagnostic` to catch subtle node resolution bugs. Ensure error reporting functions take the specific error node as a parameter rather than falling back to the current statement context.
+
+2026-08-06 - [Expected Array Type on Subscripting]
+
+Learning: C11 requires that one of the expressions in a subscript operator `[]` has the type "pointer to complete object type" (and thus it decays to a pointer). Trying to apply the subscript operator to a non-pointer, non-array type (like `int` or `struct`) is invalid and should result in an error. We want to ensure that `SemanticError::ExpectedArrayType` correctly intercepts this with a precise diagnostic error and correct spans.
+Action: Add `guardian_expected_array_type.rs` to validate this invariant, ensuring the diagnostic triggers at `CompilePhase::Mir` with the correct error message `"subscripted value is not an array (have '...')"` and specific line/column spans.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+pub mod guardian_expected_array_type;
+
 pub mod parser_lexer_coverage;
 pub mod semantic_const_eval_offsetof;
 // Preprocessor

--- a/src/tests/guardian_expected_array_type.rs
+++ b/src/tests/guardian_expected_array_type.rs
@@ -1,0 +1,33 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_expected_array_type_subscript() {
+    run_fail_with_diagnostic(
+        r#"
+        void f(int a) {
+            a[0] = 1;
+        }
+        "#,
+        CompilePhase::Mir,
+        "subscripted value is not an array (have 'int')",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_expected_array_type_subscript_struct() {
+    run_fail_with_diagnostic(
+        r#"
+        struct S { int x; };
+        void f(struct S a) {
+            a[0] = 1;
+        }
+        "#,
+        CompilePhase::Mir,
+        "subscripted value is not an array (have 'struct S')",
+        4,
+        13,
+    );
+}


### PR DESCRIPTION
🧪 What: Added `guardian_expected_array_type.rs` with C code snippets validating the subscript operator on non-arrays.
🎯 Why: Protects against language miscompilation by enforcing C11 requirements for array/pointer decay in subscript expressions, explicitly checking the correct diagnostic span.
🛠️ Phase: MIR
🔬 Verify: `cargo test -p cendol guardian_expected_array_type`

---
*PR created automatically by Jules for task [14760310604977386816](https://jules.google.com/task/14760310604977386816) started by @bungcip*