### PR TITLE
Tuti: Add floating-point logical short-circuit constant eval tests

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -3347,14 +3347,13 @@ impl<'a> SemanticAnalyzer<'a> {
     fn visit_ternary_op(&mut self, cond: NodeRef, then: NodeRef, else_expr: NodeRef) -> Option<QualType> {
         let cond_qt = self.visit_node(cond)?;
         self.apply_lvalue_conversion(cond);
-        if cond_qt.is_array() {
-            if let crate::ast::NodeKind::Ident(name, _) = self.ast.get_kind(cond) {
+        if cond_qt.is_array()
+            && let crate::ast::NodeKind::Ident(name, _) = self.ast.get_kind(cond) {
                 self.report_warning(
                     cond,
                     crate::semantic::errors::SemanticError::AddressOfArrayAlwaysTrue { name: *name },
                 );
             }
-        }
         let mut actual_cond_qt = cond_qt;
         if actual_cond_qt.is_array() || actual_cond_qt.is_function() {
             actual_cond_qt = self.decay(cond, actual_cond_qt);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -191,3 +191,4 @@ pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
 pub mod test_const_eval_unary;
 pub mod test_utils;
+pub mod test_const_eval_logical_float;

--- a/src/tests/test_const_eval_logical_float.rs
+++ b/src/tests/test_const_eval_logical_float.rs
@@ -1,0 +1,20 @@
+use crate::tests::test_utils::run_pass;
+use crate::driver::artifact::CompilePhase;
+
+#[test]
+pub fn test_const_eval_logical_float_coverage() {
+    let source = r#"
+        extern int x;
+        _Static_assert(!(0.0 && x), "float AND short circuit");
+        _Static_assert(1.0 || x, "float OR short circuit");
+        _Static_assert(1.0 && 1.0, "float AND true");
+        _Static_assert(!(1.0 && 0.0), "float AND false");
+        _Static_assert(!(0.0 || 0.0), "float OR false");
+        _Static_assert(0.0 || 1.0, "float OR true");
+
+        // UnaryOp::LogicNot on float
+        _Static_assert(!0.0, "not zero");
+        _Static_assert(!(!1.0), "not one");
+    "#;
+    run_pass(source, CompilePhase::SemanticLowering);
+}


### PR DESCRIPTION
Added a targeted unit test to evaluate floating-point logical short-circuiting in constant expressions, increasing coverage in `src/semantic/const_eval.rs` safely and cleanly.

---
*PR created automatically by Jules for task [11062727387262531652](https://jules.google.com/task/11062727387262531652) started by @bungcip*