### PR TITLE
⚡ Bolt: Avoid temporary Vec allocation in HideSetTable::intern

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 
 **Learning:** During C preprocessing, file existence and ID resolution are queried repeatedly (e.g., via `__has_include` or duplicate include checks). `SourceManager`'s `path_to_id` map historically used standard `hashbrown::HashMap` which defaults to the slow, cryptographically secure `SipHash` algorithm. Swapping this map to use `rustc_hash::FxHashMap` completely removes the SipHash overhead for `PathBuf` keys, significantly accelerating path resolution and header check performance with zero functional regression.
 **Action:** Always prefer `rustc_hash::FxHashMap` over standard `hashbrown::HashMap` in core resource tables (such as `SourceManager`'s path-to-ID indices) where path string lookups are hot and denial-of-service protection is not required.
+
+## 2026-03-12 - Avoiding Temporary Heap Allocation on Arc Creation from SmallVec
+**Learning:** Instantiating `Arc<[T]>` from `SmallVec` via `Arc::from(set.into_vec())` triggers a redundant heap allocation. Even if the `SmallVec` was small and stack-allocated, `into_vec()` allocates a standard `Vec` first before shrinking it into an `Arc`. Using `Arc::from(set.as_slice())` allows the standard library to directly allocate the `Arc` header and copy the slice elements, completely bypassing the intermediate `Vec` allocation on the hot path of macro hide-set interning.
+**Action:** When creating an `Arc<[T]>` from a stack-allocated or cached collection like `SmallVec`, always use `Arc::from(set.as_slice())` rather than `into_vec()` to guarantee a single-allocation construct.

--- a/src/pp/types.rs
+++ b/src/pp/types.rs
@@ -61,7 +61,9 @@ impl HideSetTable {
             return id;
         }
 
-        let arc_set: Arc<[StringId]> = Arc::from(set.into_vec());
+        // Bolt ⚡: Use `as_slice()` instead of `into_vec()` to construct `Arc<[StringId]>`.
+        // This avoids a redundant heap-allocation of a temporary `Vec` since `StringId` is Copy/Clone.
+        let arc_set: Arc<[StringId]> = Arc::from(set.as_slice());
         let id = self.sets.len() as u32;
         self.sets.push(arc_set.clone());
         self.map.insert(arc_set, id);


### PR DESCRIPTION
This PR optimizes the macro hide-set interning process in `HideSetTable::intern` within `src/pp/types.rs`.

### 💡 What:
Replaced `Arc::from(set.into_vec())` with `Arc::from(set.as_slice())` inside `HideSetTable::intern`.

### 🎯 Why:
The previous implementation called `set.into_vec()` on `SmallVec<[StringId; 4]>`, forcing a temporary `Vec` to be allocated on the heap (even if the `SmallVec` was stack-allocated) before constructing the `Arc`. By converting directly from the slice using `Arc::from(set.as_slice())`, the standard library allocates the contiguous memory for the `Arc` header and elements in a single step, entirely bypassing the intermediate `Vec` allocation.

### 📊 Impact:
Significantly reduces redundant heap allocations on the Dave Prosser algorithm's macro hide-set interning hot path, improving preprocessing efficiency for macro-heavy C files.

---
*PR created automatically by Jules for task [12639081281093158109](https://jules.google.com/task/12639081281093158109) started by @bungcip*