### PR TITLE
🧪 Tuti: Increase test coverage for ast/parsed_types.rs

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -191,3 +191,4 @@ pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
 pub mod test_const_eval_unary;
 pub mod test_utils;
+pub mod ast_parsed_types_coverage;

--- a/src/tests/ast_parsed_types_coverage.rs
+++ b/src/tests/ast_parsed_types_coverage.rs
@@ -1,0 +1,26 @@
+use crate::ast::parsed_types::{PTypeArena, PDeclarator};
+use crate::ast::PNodeRef;
+use crate::ast::parsed::DeclSpec;
+
+#[test]
+fn test_get_declarator_scope_coverage() {
+    let mut arena = PTypeArena::default();
+
+    // Identifier declarator is the base
+    let base_decl = arena.alloc_decl(PDeclarator::Identifier(None));
+
+    // Add BitField wrapping base
+    let bitfield_decl = arena.alloc_decl(PDeclarator::BitField {
+        inner: base_decl,
+        width: PNodeRef::new(1).unwrap(),
+    });
+
+    // Add Attribute wrapping BitField
+    let attr_decl = arena.alloc_decl(PDeclarator::Attribute {
+        inner: bitfield_decl,
+        spec: DeclSpec::Attribute,
+    });
+
+    // Traverse through Attribute -> BitField -> Identifier
+    assert_eq!(arena.get_declarator_scope(attr_decl), None);
+}


### PR DESCRIPTION
Adds a targeted unit test to hit the `Attribute` and `BitField` recursive match arms within `get_declarator_scope` in `src/ast/parsed_types.rs`. This achieves 100% statement coverage on the previously unexercised lines.

---
*PR created automatically by Jules for task [6443257245493623081](https://jules.google.com/task/6443257245493623081) started by @bungcip*