### PR TITLE
🛡️ Guardian: validate return statement diagnostic constraints and spans

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -338,3 +338,8 @@ Action: Add `guardian_address_of_array_always_true.rs` to validate that `Semanti
 
 Learning: When a `switch` statement jumps into the scope of a variably modified type (VLA), the diagnostic span must correctly point to the specific `case` or `default` label that triggered the error, rather than the statement immediately following the label. This requires passing the correct AST `NodeRef` down to the error reporting function (e.g., `check_switch_vla_jump`), as relying on the body statement's node will result in inaccurate line/column numbers.
 Action: When testing diagnostic spans for control-flow statements (like `switch`), always assert the exact line and column using `run_fail_with_diagnostic` to catch subtle node resolution bugs. Ensure error reporting functions take the specific error node as a parameter rather than falling back to the current statement context.
+
+2024-08-08 - [return statement diagnostic constraints]
+
+Learning: [C11 §6.8.6.4 constraints on `return` statements have distinct semantic errors depending on if the function is void/non-void and if the return expression is missing, has a value, or is a void expression. Ensuring that the diagnostic span correctly targets the `return` expression (or the keyword itself when the expression is missing) is critical for compiler accuracy.]
+Action: [Added tests in `guardian_return_constraints.rs` to validate the specific diagnostic messages and their exact source spans for `VoidReturnWithValue`, `NonVoidReturnWithoutValue`, and `VoidReturnWithVoidExpr` during semantic lowering.]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -191,3 +191,4 @@ pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
 pub mod test_const_eval_unary;
 pub mod test_utils;
+pub mod guardian_return_constraints;

--- a/src/tests/guardian_return_constraints.rs
+++ b/src/tests/guardian_return_constraints.rs
@@ -1,0 +1,48 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_void_return_with_value_span() {
+    run_fail_with_diagnostic(
+        r#"
+        void foo(void) {
+            return 42;
+        }
+        "#,
+        CompilePhase::Mir,
+        "void function 'foo' should not return a value",
+        3,
+        20,
+    );
+}
+
+#[test]
+fn test_non_void_return_without_value_span() {
+    run_fail_with_diagnostic(
+        r#"
+        int foo(void) {
+            return;
+        }
+        "#,
+        CompilePhase::Mir,
+        "non-void function 'foo' should return a value",
+        3,
+        13,
+    );
+}
+
+#[test]
+fn test_void_return_with_void_expr_span() {
+    crate::tests::test_utils::run_pass_with_diagnostic(
+        r#"
+        void bar(void);
+        void foo(void) {
+            return bar();
+        }
+        "#,
+        CompilePhase::Mir,
+        "void function 'foo' should not return a value",
+        4,
+        20,
+    );
+}


### PR DESCRIPTION
🧪 **What:** 
Added a test snippet to evaluate invalid `return` statements based on function return type (void vs non-void) and presence of return expression.

🎯 **Why:** 
This prevents regressions in compiler diagnostics for return constraint violations, explicitly ensuring the correct error message is tied to the precise source span of the `return` expression (or keyword).

🛠️ **Phase:** 
MIR

🔬 **Verify:** 
Run `cargo test guardian_return_constraints`

---
*PR created automatically by Jules for task [11136068103733591089](https://jules.google.com/task/11136068103733591089) started by @bungcip*