### PR TITLE
🧹 Rendi: Simplify redundant boolean equality checks

### DIFF
--- a/src/tests/semantic_bool_literals.rs
+++ b/src/tests/semantic_bool_literals.rs
@@ -7,7 +7,7 @@ fn test_c23_bool_literals_basic() {
         int main() {
             bool a = true;
             bool b = false;
-            return a == true ? 1 : 0;
+            return a ? 1 : 0;
         }
     ";
     let _ = run_pipeline(src, CompilePhase::Mir);

--- a/src/tests/semantic_types.rs
+++ b/src/tests/semantic_types.rs
@@ -262,7 +262,7 @@ fn test_typeregistry_inline_logic() {
     let p4 = reg.pointer_to(QualType::unqualified(p3));
     assert_eq!(p4.class(), TypeClass::Pointer);
     assert_eq!(p4.pointer_depth(), 0); // Registry pointer
-    assert!(p4.is_inline_pointer() == false);
+    assert!(!p4.is_inline_pointer());
     // Base of p4 is the index in registry where Type::Pointer{pointee: int***} is stored.
     // We can't easily assert the index value, but it should differ from int_ty.base().
     assert_ne!(p4.base(), int_ty.base());
@@ -290,7 +290,7 @@ fn test_typeregistry_array_logic() {
     let a2 = reg.array_of(int_ty, ArraySize::Constant(100));
     assert_eq!(a2.class(), TypeClass::Array);
     assert_eq!(a2.array_len(), None); // Registry array
-    assert!(a2.is_inline_array() == false);
+    assert!(!a2.is_inline_array());
     assert_ne!(a2.base(), int_ty.base());
 
     // int*[5] (Registry - because int* doesn't have an index)
@@ -298,7 +298,7 @@ fn test_typeregistry_array_logic() {
     let ap1 = reg.array_of(p1, ArraySize::Constant(5));
     assert_eq!(ap1.class(), TypeClass::Array);
     assert_eq!(ap1.array_len(), None); // Registry array
-    assert!(ap1.is_inline_array() == false);
+    assert!(!ap1.is_inline_array());
 
     // int[10]* (Registry Pointer)
     // int[10] is Inline Array (Base=Int, Arr=10). Not Simple.
@@ -306,7 +306,7 @@ fn test_typeregistry_array_logic() {
     let pa1 = reg.pointer_to(QualType::unqualified(a1));
     assert_eq!(pa1.class(), TypeClass::Pointer);
     assert_eq!(pa1.pointer_depth(), 0); // Registry pointer
-    assert!(pa1.is_inline_pointer() == false);
+    assert!(!pa1.is_inline_pointer());
 }
 
 #[test]


### PR DESCRIPTION
Removed redundant boolean checks `== false` and `== true` in `semantic_types.rs` and `semantic_bool_literals.rs` test files.

---
*PR created automatically by Jules for task [8957734375485907389](https://jules.google.com/task/8957734375485907389) started by @bungcip*