### PR TITLE
🛡️ Guardian: Protect switch statement duplicate case scopes

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -343,3 +343,8 @@ Action: When testing diagnostic spans for control-flow statements (like `switch`
 
 Learning: C11 requires that one of the expressions in a subscript operator `[]` has the type "pointer to complete object type" (and thus it decays to a pointer). Trying to apply the subscript operator to a non-pointer, non-array type (like `int` or `struct`) is invalid and should result in an error. We want to ensure that `SemanticError::ExpectedArrayType` correctly intercepts this with a precise diagnostic error and correct spans.
 Action: Add `guardian_expected_array_type.rs` to validate this invariant, ensuring the diagnostic triggers at `CompilePhase::Mir` with the correct error message `"subscripted value is not an array (have '...')"` and specific line/column spans.
+
+2024-05-18 - [Switch case uniqueness checking]
+
+Learning: Checking for switch case duplication is done efficiently in Cendol using an `IntervalMap` via binary search (`partition_point`). Case labels must be unique *within the same switch statement scope*. Nested switch statements create separate case scopes, allowing identical case labels in inner and outer switches without conflicting.
+Action: Add explicit verification tests to confirm that nested switch scopes appropriately isolate case and default labels and do not produce false positive `DuplicateCase` semantic errors.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -193,3 +193,4 @@ pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
 pub mod test_const_eval_unary;
 pub mod test_utils;
+pub mod guardian_duplicate_case;

--- a/src/tests/guardian_duplicate_case.rs
+++ b/src/tests/guardian_duplicate_case.rs
@@ -1,0 +1,37 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_duplicate_case_rejected() {
+    run_fail_with_diagnostic(
+        r#"void f(int x) {
+    switch (x) {
+        case 1: break;
+        case 2: break;
+        case 1: break;
+    }
+}
+"#,
+        CompilePhase::Mir,
+        "duplicate case value '1'",
+        5,
+        17,
+    );
+}
+
+#[test]
+fn test_duplicate_case_nested_allowed() {
+    crate::tests::test_utils::run_pass(
+        r#"void f(int x, int y) {
+    switch (x) {
+        case 1:
+            switch (y) {
+                case 1: break;
+            }
+            break;
+    }
+}
+"#,
+        CompilePhase::Mir,
+    );
+}


### PR DESCRIPTION
🧪 What: Added C code snippets asserting proper compiler rejection of duplicate `case` values, and allowing duplicate `case` values across nested `switch` scopes.
🎯 Why: Prevents semantic ambiguity and enforces isolation of `case` scopes during `switch` statement analysis (C11 6.8.4.2p3).
🛠️ Phase: MIR
🔬 Verify: Run `cargo test guardian_duplicate_case`.

---
*PR created automatically by Jules for task [17982206798180496064](https://jules.google.com/task/17982206798180496064) started by @bungcip*