### PR TITLE
🧪 Tuti: Add test for floating-point logical short-circuit evaluation

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -193,3 +193,4 @@ pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
 pub mod test_const_eval_unary;
 pub mod test_utils;
+pub mod semantic_const_eval_coverage;

--- a/src/tests/semantic_const_eval_coverage.rs
+++ b/src/tests/semantic_const_eval_coverage.rs
@@ -1,0 +1,16 @@
+use crate::tests::test_utils::run_pass;
+use crate::driver::artifact::CompilePhase;
+
+#[test]
+fn test_float_short_circuit_coverage() {
+    let source = "
+        extern int x;
+        _Static_assert(!(0.0 && x), \"\");
+        _Static_assert(1.0 || x, \"\");
+
+        // Also cover the cases where evaluation doesn't short circuit but continues.
+        _Static_assert(1.0 && 0.0 == 0.0, \"\");
+        _Static_assert(0.0 || 1.0 == 1.0, \"\");
+    ";
+    run_pass(source, CompilePhase::SemanticLowering);
+}


### PR DESCRIPTION
This adds exactly ONE test that targets an uncovered execution path in `src/semantic/const_eval.rs`. Specifically, it covers the logic where floating point constants short-circuit in logical `&&` and `||` operations, increasing line and branch coverage in the compiler.

---
*PR created automatically by Jules for task [17575652229058762550](https://jules.google.com/task/17575652229058762550) started by @bungcip*