### PR TITLE
🛡️ Guardian: enforces C11 6.7.9p5 constraint on extern block scope initializers

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -343,3 +343,7 @@ Action: When testing diagnostic spans for control-flow statements (like `switch`
 
 Learning: C11 requires that one of the expressions in a subscript operator `[]` has the type "pointer to complete object type" (and thus it decays to a pointer). Trying to apply the subscript operator to a non-pointer, non-array type (like `int` or `struct`) is invalid and should result in an error. We want to ensure that `SemanticError::ExpectedArrayType` correctly intercepts this with a precise diagnostic error and correct spans.
 Action: Add `guardian_expected_array_type.rs` to validate this invariant, ensuring the diagnostic triggers at `CompilePhase::Mir` with the correct error message `"subscripted value is not an array (have '...')"` and specific line/column spans.
+2024-05-24 - Enforce C11 6.7.9p5 constraints on extern block scope initializers
+
+Learning: The C11 standard explicitly states in 6.7.9p5 that "If the declaration of an identifier has block scope, and the identifier has external or internal linkage, the declaration shall have no initializer for the identifier." Thus `extern int x = 1;` inside a block scope is invalid. Previously untested specifically for the error diagnostic correctness and exact source span targeting the start of the declaration.
+Action: Added test `guardian_invalid_initializer.rs` which verifies `SemanticError::InvalidInitializer` is correctly emitted during the MIR phase, and its diagnostic points directly to the `extern` keyword.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -193,3 +193,4 @@ pub mod semantic_gnu_local_label;
 pub mod semantic_types_compatible;
 pub mod test_const_eval_unary;
 pub mod test_utils;
+pub mod guardian_invalid_initializer;

--- a/src/tests/guardian_invalid_initializer.rs
+++ b/src/tests/guardian_invalid_initializer.rs
@@ -1,0 +1,19 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_extern_with_initializer_in_block_scope() {
+    // C11 6.7.9p5: If the declaration of an identifier has block scope, and the identifier has external or
+    // internal linkage, the declaration shall have no initializer for the identifier.
+    run_fail_with_diagnostic(
+        r#"
+void f() {
+    extern int x = 1;
+}
+        "#,
+        CompilePhase::Mir,
+        "invalid initializer",
+        3,
+        5,
+    );
+}


### PR DESCRIPTION
🧪 What: Add test to check if the compiler correctly emits `SemanticError::InvalidInitializer` with the proper diagnostic span for an `extern` declaration with an initializer inside block scope.
🎯 Why: C11 6.7.9p5 explicitly dictates that block scope declarations with external or internal linkage shall have no initializer. Ensuring the diagnostic correctly catches this and points to the `extern` keyword.
🛠️ Phase: MIR
🔬 Verify: Run `cargo test test_extern_with_initializer_in_block_scope`

---
*PR created automatically by Jules for task [3742642864027806039](https://jules.google.com/task/3742642864027806039) started by @bungcip*