### PR TITLE
🛡️ Guardian: Reject initializer on block-scope extern declaration

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -343,3 +343,8 @@ Action: When testing diagnostic spans for control-flow statements (like `switch`
 
 Learning: C11 requires that one of the expressions in a subscript operator `[]` has the type "pointer to complete object type" (and thus it decays to a pointer). Trying to apply the subscript operator to a non-pointer, non-array type (like `int` or `struct`) is invalid and should result in an error. We want to ensure that `SemanticError::ExpectedArrayType` correctly intercepts this with a precise diagnostic error and correct spans.
 Action: Add `guardian_expected_array_type.rs` to validate this invariant, ensuring the diagnostic triggers at `CompilePhase::Mir` with the correct error message `"subscripted value is not an array (have '...')"` and specific line/column spans.
+
+2026-08-07 - [Extern Block Scope Initializer Constraint]
+
+Learning: C11 6.7.9p5 requires that if the declaration of an identifier has block scope, and the identifier has external or internal linkage, the declaration shall have no initializer for the identifier. This means `extern int x = 10;` inside a function is a constraint violation. Cendol correctly checks this in `visit_var_declaration` during semantic analysis and emits `SemanticError::InvalidInitializer`. The diagnostic span should correctly point to the start of the declaration.
+Action: Add `guardian_invalid_initializer.rs` to explicitly validate this rejection, asserting the correct error message, phase (`CompilePhase::Mir`), and precise span.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -177,6 +177,7 @@ pub mod guardian_case_not_in_switch;
 pub mod guardian_continue_not_in_loop;
 pub mod guardian_invalid_function_specifier;
 mod guardian_invalid_number_of_arguments;
+pub mod guardian_invalid_initializer;
 pub mod guardian_invalid_storage_class_for_function;
 mod guardian_invalid_unary_operand;
 pub mod guardian_jump_into_scope_vla;

--- a/src/tests/guardian_invalid_initializer.rs
+++ b/src/tests/guardian_invalid_initializer.rs
@@ -1,0 +1,17 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail_with_diagnostic;
+
+#[test]
+fn test_extern_block_scope_initializer() {
+    run_fail_with_diagnostic(
+        r#"
+        int main() {
+            extern int x = 10;
+        }
+        "#,
+        CompilePhase::Mir,
+        "invalid initializer",
+        3,
+        13,
+    );
+}


### PR DESCRIPTION
🧪 What: Adds a test `test_extern_block_scope_initializer` to reject `extern int x = 10;` inside a block scope.

🎯 Why: Protects the compiler invariant corresponding to C11 6.7.9p5, which prohibits initializers on identifiers with block scope and external (or internal) linkage.

🛠️ Phase: `CompilePhase::Mir` (Semantic Analysis/Lowering completes and validates).

🔬 Verify: Run `cargo test guardian_invalid_initializer`.

---
*PR created automatically by Jules for task [9431985709877852330](https://jules.google.com/task/9431985709877852330) started by @bungcip*