### PR TITLE
⚡ Bolt: Use FxHashMap for pointee_to_pointer in MirValidator

### DIFF
--- a/src/mir/validation.rs
+++ b/src/mir/validation.rs
@@ -7,6 +7,8 @@
 //! - No illegal operations remain
 //! - MIR is Cranelift-safe
 
+use rustc_hash::FxHashMap;
+
 use crate::{
     ast::NameId,
     mir::{
@@ -99,7 +101,8 @@ impl std::fmt::Display for ValidationError {
 pub(crate) struct MirValidator<'a> {
     mir: &'a MirProgram,
     errors: Vec<ValidationError>,
-    pointee_to_pointer: hashbrown::HashMap<TypeId, TypeId>,
+    // ⚡ Bolt: Use `FxHashMap` to eliminate SipHash hashing overhead for integer-like TypeId keys.
+    pointee_to_pointer: FxHashMap<TypeId, TypeId>,
     bool_type: Option<TypeId>,
     i32_type: Option<TypeId>,
 }
@@ -110,7 +113,7 @@ impl<'a> MirValidator<'a> {
         Self {
             mir: mir_program,
             errors: Vec::new(),
-            pointee_to_pointer: hashbrown::HashMap::new(),
+            pointee_to_pointer: FxHashMap::default(),
             bool_type: None,
             i32_type: None,
         }


### PR DESCRIPTION
Replaced `hashbrown::HashMap` with `rustc_hash::FxHashMap` for `pointee_to_pointer` in `MirValidator` to avoid SipHash overhead when hashing `TypeId` keys.

---
*PR created automatically by Jules for task [7859369195566311485](https://jules.google.com/task/7859369195566311485) started by @bungcip*