### PR TITLE
⚡ Bolt: Use FxHashMap in MirValidator to eliminate hashing overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,8 @@
 
 **Learning:** During macro expansion, Dave Prosser's hiding set algorithm repeatedly interns token sets to prevent infinite recursive macro expansion. Historically, `HideSetTable::intern` accepted a `SmallVec<[StringId; 4]>` and converted it into a heap-allocated `Vec` using `.into_vec()`, before wrapping it inside an `Arc<[StringId]>`. Because macro hide-sets are extremely small (usually containing 1 or 2 macro names), they fit entirely within `SmallVec`'s inline storage. Replacing `.into_vec()` with `Arc::from(set.as_slice())` avoids constructing the intermediate heap-allocated `Vec` entirely, eliminating a redundant heap allocation on the hot interning path.
 **Action:** Always prefer instantiating `Arc<[T]>` or `Box<[T]>` directly from a slice reference `as_slice()` instead of consuming stack-allocated `SmallVec` or `Vec` containers with `.into_vec()`, completely bypassing unnecessary heap allocation overhead on critical paths.
+
+## 2025-03-29 - FxHashMap in MirValidator Pointee Map
+
+**Learning:** `MirValidator` previously used `hashbrown::HashMap<TypeId, TypeId>` for `pointee_to_pointer`, incurring `SipHash` overhead for simple integer-like `TypeId` keys during MIR validation. Changing `pointee_to_pointer` to `rustc_hash::FxHashMap<TypeId, TypeId>` eliminates hashing overhead on this MIR validation hot path with zero functionality changes.
+**Action:** Always check validation passes and mid-level compiler IR stages for standard `hashbrown::HashMap` instances keyed by integer-like `TypeId` or `Id` types, and migrate them to `rustc_hash::FxHashMap`.

--- a/src/mir/validation.rs
+++ b/src/mir/validation.rs
@@ -99,7 +99,8 @@ impl std::fmt::Display for ValidationError {
 pub(crate) struct MirValidator<'a> {
     mir: &'a MirProgram,
     errors: Vec<ValidationError>,
-    pointee_to_pointer: hashbrown::HashMap<TypeId, TypeId>,
+    // ⚡ Bolt: Use `FxHashMap` to eliminate SipHash hashing overhead for integer-like `TypeId` keys during MIR validation.
+    pointee_to_pointer: rustc_hash::FxHashMap<TypeId, TypeId>,
     bool_type: Option<TypeId>,
     i32_type: Option<TypeId>,
 }
@@ -110,7 +111,7 @@ impl<'a> MirValidator<'a> {
         Self {
             mir: mir_program,
             errors: Vec::new(),
-            pointee_to_pointer: hashbrown::HashMap::new(),
+            pointee_to_pointer: rustc_hash::FxHashMap::default(),
             bool_type: None,
             i32_type: None,
         }


### PR DESCRIPTION
### ⚡ Bolt Optimization Summary

- **What:** Swapped `hashbrown::HashMap<TypeId, TypeId>` for `rustc_hash::FxHashMap<TypeId, TypeId>` in `MirValidator` (`src/mir/validation.rs`).
- **Why:** `TypeId` is an integer wrapper. Standard `HashMap` utilizes SipHash (for cryptographic DoS resilience), which incurs hashing overhead on integer-like keys during the MIR validation pass. `FxHashMap` uses `FxHasher`, a fast non-cryptographic hash algorithm optimized for integer keys.
- **Impact:** Eliminates SipHash overhead during MIR validation without any behavioral or correctness changes.
- **Verification:** All 1,575 unit tests pass, `cargo check` and `cargo clippy` pass cleanly.

---
*PR created automatically by Jules for task [14580118847204345471](https://jules.google.com/task/14580118847204345471) started by @bungcip*