### PR TITLE
⚡ Bolt: Replace SipHash with FxHashMap in MirValidator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,8 @@
 
 **Learning:** During macro expansion, Dave Prosser's hiding set algorithm repeatedly interns token sets to prevent infinite recursive macro expansion. Historically, `HideSetTable::intern` accepted a `SmallVec<[StringId; 4]>` and converted it into a heap-allocated `Vec` using `.into_vec()`, before wrapping it inside an `Arc<[StringId]>`. Because macro hide-sets are extremely small (usually containing 1 or 2 macro names), they fit entirely within `SmallVec`'s inline storage. Replacing `.into_vec()` with `Arc::from(set.as_slice())` avoids constructing the intermediate heap-allocated `Vec` entirely, eliminating a redundant heap allocation on the hot interning path.
 **Action:** Always prefer instantiating `Arc<[T]>` or `Box<[T]>` directly from a slice reference `as_slice()` instead of consuming stack-allocated `SmallVec` or `Vec` containers with `.into_vec()`, completely bypassing unnecessary heap allocation overhead on critical paths.
+
+## 2025-11-01 - FxHashMap for TypeId in MirValidator
+
+**Learning:** During MIR validation (`src/mir/validation.rs`), `MirValidator` constructs and queries `pointee_to_pointer`, mapping `TypeId` to `TypeId`. Using standard `hashbrown::HashMap` incurs SipHash overhead on integer keys. Replacing `hashbrown::HashMap` with `rustc_hash::FxHashMap` eliminates SipHash overhead during MIR validation.
+**Action:** Ensure integer-to-integer compiler maps like `TypeId` -> `TypeId` use `rustc_hash::FxHashMap` across all compiler validation passes.

--- a/src/mir/validation.rs
+++ b/src/mir/validation.rs
@@ -99,7 +99,8 @@ impl std::fmt::Display for ValidationError {
 pub(crate) struct MirValidator<'a> {
     mir: &'a MirProgram,
     errors: Vec<ValidationError>,
-    pointee_to_pointer: hashbrown::HashMap<TypeId, TypeId>,
+    // Bolt ⚡: Optimization: Use FxHashMap for TypeId keys to eliminate SipHash overhead.
+    pointee_to_pointer: rustc_hash::FxHashMap<TypeId, TypeId>,
     bool_type: Option<TypeId>,
     i32_type: Option<TypeId>,
 }
@@ -110,7 +111,7 @@ impl<'a> MirValidator<'a> {
         Self {
             mir: mir_program,
             errors: Vec::new(),
-            pointee_to_pointer: hashbrown::HashMap::new(),
+            pointee_to_pointer: rustc_hash::FxHashMap::default(),
             bool_type: None,
             i32_type: None,
         }


### PR DESCRIPTION
Replaces `hashbrown::HashMap` with `rustc_hash::FxHashMap` in `MirValidator` for mapping `TypeId` to `TypeId`. Since `TypeId` is an integer index, `FxHashMap` completely removes SipHash hashing overhead during the MIR validation pass.

---
*PR created automatically by Jules for task [17800058394577633751](https://jules.google.com/task/17800058394577633751) started by @bungcip*