### PR TITLE
Add test for floating-point short-circuit logical evaluation

### DIFF
--- a/src/tests/semantic_static_assert.rs
+++ b/src/tests/semantic_static_assert.rs
@@ -200,3 +200,13 @@ fn test_static_assert_float_unary_and_complex() {
     "#;
     run_pass(code, CompilePhase::Mir);
 }
+
+#[test]
+fn test_static_assert_float_short_circuit_eval() {
+    let code = r#"
+        extern int unresolved_var;
+        _Static_assert(!(0.0 && unresolved_var), "");
+        _Static_assert(1.0 || unresolved_var, "");
+    "#;
+    run_pass(code, CompilePhase::Mir);
+}


### PR DESCRIPTION
Adds a targeted unit test to `src/tests/semantic_static_assert.rs` using `_Static_assert` and an unresolved variable to exercise the floating-point short-circuit path in `src/semantic/const_eval.rs`. This directly increases branch/statement coverage for `eval_binary`.

---
*PR created automatically by Jules for task [16929215777061347494](https://jules.google.com/task/16929215777061347494) started by @bungcip*