### PR TITLE
🛡️ Guardian: rejects indirection on non-pointer type with correct diagnostic

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -348,3 +348,8 @@ Action: Add `guardian_expected_array_type.rs` to validate this invariant, ensuri
 
 Learning: Checking for switch case duplication is done efficiently in Cendol using an `IntervalMap` via binary search (`partition_point`). Case labels must be unique *within the same switch statement scope*. Nested switch statements create separate case scopes, allowing identical case labels in inner and outer switches without conflicting.
 Action: Add explicit verification tests to confirm that nested switch scopes appropriately isolate case and default labels and do not produce false positive `DuplicateCase` semantic errors.
+
+2024-05-18 - [Indirection Requires Pointer Operand]
+
+Learning: In C, the dereference operator (`*`) must only be applied to an operand of pointer type. Cendol checks this during semantic analysis (`SemanticLowering`/`Mir` phases). If applied to a non-pointer type like `int`, the compiler correctly rejects the code and emits `SemanticError::IndirectionRequiresPointer`. Ensuring that this is caught and the error is accurately reported at the correct source span is an important invariant for catching improper pointer arithmetics and misuse of the indirection operator early.
+Action: Add `guardian_indirection_requires_pointer.rs` to validate this invariant, ensuring that applying `*` to a primitive like `int` correctly triggers the "indirection requires pointer operand" error and points to the right position in the AST.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -196,3 +196,4 @@ pub mod semantic_types_compatible;
 pub mod test_const_eval_coverage;
 pub mod test_const_eval_unary;
 pub mod test_utils;
+pub mod guardian_indirection_requires_pointer;

--- a/src/tests/guardian_indirection_requires_pointer.rs
+++ b/src/tests/guardian_indirection_requires_pointer.rs
@@ -1,0 +1,27 @@
+use crate::driver::artifact::CompilePhase;
+use crate::tests::test_utils::run_fail;
+
+#[test]
+fn test_indirection_requires_pointer() {
+    let src = r#"
+        int main() {
+            int x = 42;
+            return *x;
+        }
+    "#;
+
+    let artifact = run_fail(src, CompilePhase::Mir);
+    let diags = &artifact.de.diagnostics;
+
+    assert_eq!(diags.len(), 1);
+
+    let diag = &diags[0];
+
+    assert_eq!(
+        diag.message,
+        "indirection requires pointer operand ('int' invalid)"
+    );
+
+    let line_col = artifact.sm.get_line_column(diag.span.start());
+    assert_eq!(line_col, Some((4, 20))); // point to `*x`
+}


### PR DESCRIPTION
🧪 What: C code snippet `int x = 42; return *x;`
🎯 Why: Protects the invariant that the indirection operator (`*`) can only be applied to pointer types, preventing downstream codegen crashes and ensuring correct language behavior.
🛠️ Phase: MIR / Semantic Lowering
🔬 Verify: Run `cargo test test_indirection_requires_pointer`

---
*PR created automatically by Jules for task [7434703454981052968](https://jules.google.com/task/7434703454981052968) started by @bungcip*